### PR TITLE
fixed configure-auto-link

### DIFF
--- a/src/OctoshiftCLI/Commands/ConfigureAutoLinkCommand.cs
+++ b/src/OctoshiftCLI/Commands/ConfigureAutoLinkCommand.cs
@@ -48,13 +48,20 @@ namespace OctoshiftCLI
 
             if (string.IsNullOrWhiteSpace(githubToken))
             {
+                Console.ForegroundColor = ConsoleColor.Red;
                 Console.WriteLine("ERROR: NO GH_PAT FOUND IN ENV VARS, exiting...");
+                Console.ResetColor();
                 return;
             }
 
             _github = new GithubApi(githubToken);
 
+            // TODO: This crashes if autolink is already configured
             await _github.AddAutoLink(githubOrg, githubRepo, adoOrg, adoTeamProject);
+
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine("Successfully configured autolink references");
+            Console.ResetColor();
         }
     }
 }

--- a/src/OctoshiftCLI/GithubApi.cs
+++ b/src/OctoshiftCLI/GithubApi.cs
@@ -20,7 +20,7 @@ namespace OctoshiftCLI
         {
             var url = $"https://api.github.com/repos/{org}/{repo}/autolinks";
 
-            var payload = $"{{ 'key_prefix': 'AB#', 'url_template': 'https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/' }}";
+            var payload = $"{{ \"key_prefix\": \"AB#\", \"url_template\": \"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/\" }}";
             using var body = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
 
             await _client.PostAsync(url, body);


### PR DESCRIPTION
had the quotes wrong in the api call. also added a bit of console output