### PR TITLE
Lock the repo before migrating it

### DIFF
--- a/src/OctoshiftCLI/Commands/GenerateScriptCommand.cs
+++ b/src/OctoshiftCLI/Commands/GenerateScriptCommand.cs
@@ -196,6 +196,7 @@ namespace OctoshiftCLI.Commands
 
                             var githubRepo = GetGithubRepoName(adoTeamProject, adoRepo);
 
+                            content.AppendLine(LockAdoRepoScript(adoOrg, adoTeamProject, adoRepo));
                             content.AppendLine(MigrateRepoScript(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo));
                             content.AppendLine(DisableAdoRepoScript(adoOrg, adoTeamProject, adoRepo));
                             content.AppendLine(AutolinkScript(githubOrg, githubRepo, adoOrg, adoTeamProject));
@@ -227,6 +228,13 @@ namespace OctoshiftCLI.Commands
             if (_reposOnly) return string.Empty;
 
             return $"./octoshift disable-ado-repo --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{adoRepo}\"";
+        }
+
+        private string LockAdoRepoScript(string adoOrg, string adoTeamProject, string adoRepo)
+        {
+            if (_reposOnly) return string.Empty;
+
+            return $"./octoshift lock-ado-repo --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{adoRepo}\"";
         }
 
         private string ShareServiceConnectionScript(string adoOrg, string adoTeamProject, string appId)


### PR DESCRIPTION
We were migrating the repo then disabling it, this also has the generate-script include a call to "lock" the repo before migrating it.

Locking a repo makes it read-only. Disabling it makes non-readable.