### PR TITLE
Bad arg when calling create-team

### DIFF
--- a/src/OctoshiftCLI/Commands/GenerateScriptCommand.cs
+++ b/src/OctoshiftCLI/Commands/GenerateScriptCommand.cs
@@ -264,7 +264,7 @@ namespace OctoshiftCLI.Commands
 
             if (!skipIdp)
             {
-                result += " --idp-group \"{adoTeamProject}-Maintainers\"";
+                result += $" --idp-group \"{adoTeamProject}-Maintainers\"";
             }
             result += Environment.NewLine;
 
@@ -272,7 +272,7 @@ namespace OctoshiftCLI.Commands
 
             if (!skipIdp)
             {
-                result += " --idp-group \"{adoTeamProject}-Admins\"";
+                result += $" --idp-group \"{adoTeamProject}-Admins\"";
             }
 
             return result;


### PR DESCRIPTION
Missed the $ for string interpolation, so the string was being generated with the token instead of the real value in it