### PR TITLE
had inconsistent names for the configure-autolink command

### DIFF
--- a/src/OctoshiftCLI.Tests/Commands/ConfigureAutoLinkCommand.cs
+++ b/src/OctoshiftCLI.Tests/Commands/ConfigureAutoLinkCommand.cs
@@ -11,7 +11,7 @@ namespace OctoshiftCLI.Tests.Commands
         {
             var command = new ConfigureAutoLinkCommand();
             Assert.NotNull(command);
-            Assert.Equal("configure-auto-link", command.Name);
+            Assert.Equal("configure-autolink", command.Name);
             Assert.Equal(4, command.Options.Count);
 
             Helpers.VerifyCommandOption(command.Options, "github-org", true);

--- a/src/OctoshiftCLI/Commands/ConfigureAutoLinkCommand.cs
+++ b/src/OctoshiftCLI/Commands/ConfigureAutoLinkCommand.cs
@@ -9,7 +9,7 @@ namespace OctoshiftCLI
     {
         private GithubApi _github;
 
-        public ConfigureAutoLinkCommand() : base("configure-auto-link")
+        public ConfigureAutoLinkCommand() : base("configure-autolink")
         {
             var githubOrg = new Option<string>("--github-org")
             {


### PR DESCRIPTION
in one place it was configure-autolink in another it was configure-auto-link.

Changed it to be configure-autolink everywhere