### PR TITLE
unit tests for GenerateScriptCommand

### DIFF
--- a/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
@@ -1,3 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
 using OctoshiftCLI.Commands;
 using Xunit;
 
@@ -19,6 +25,67 @@ namespace OctoshiftCLI.Tests.Commands
             TestHelpers.VerifyCommandOption(command.Options, "repos-only", false);
             TestHelpers.VerifyCommandOption(command.Options, "skip-idp", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+        }
+
+        [Fact]
+        public async Task NoData()
+        {
+            var githubOrg = "foo-gh-org";
+
+            var command = new GenerateScriptCommand(null, null);
+            var script = command.GenerateScript(null, null, null, githubOrg, false);
+
+            Assert.True(string.IsNullOrWhiteSpace(script));
+        }
+
+        [Fact]
+        public void SingleRepo()
+        {
+            var githubOrg = "foo-gh-org";
+            var adoOrg = "foo-ado-org";
+            var adoTeamProject = "foo-team-project";
+            var repo = "foo-repo";
+
+            var repos = new Dictionary<string, Dictionary<string, IEnumerable<string>>>
+            {
+                { adoOrg, new Dictionary<string, IEnumerable<string>>() }
+            };
+
+            repos[adoOrg].Add(adoTeamProject, new List<string>() { repo });
+
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
+            var script = command.GenerateScript(repos, null, null, githubOrg, false);
+
+            script = TrimNonExecutableLines(script);
+
+            var expected = $"./octoshift create-team --github-org \"{githubOrg}\" --team-name \"{adoTeamProject}-Maintainers\" --idp-group \"{adoTeamProject}-Maintainers\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift create-team --github-org \"{githubOrg}\" --team-name \"{adoTeamProject}-Admins\" --idp-group \"{adoTeamProject}-Admins\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift lock-ado-repo --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{repo}\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift migrate-repo --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{repo}\" --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift disable-ado-repo --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{repo}\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift configure-autolink --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\" --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift add-team-to-repo --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\" --team \"{adoTeamProject}-Maintainers\" --role \"maintain\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift add-team-to-repo --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\" --team \"{adoTeamProject}-Admins\" --role \"admin\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift integrate-boards --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\"";
+
+            Assert.Equal(expected, script);
+        }
+
+        private string TrimNonExecutableLines(string script)
+        {
+            var lines = script.Split(new string[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries).AsEnumerable();
+
+            lines = lines.Where(x => !string.IsNullOrWhiteSpace(x)).Where(x => !x.Trim().StartsWith("#"));
+
+            return string.Join(Environment.NewLine, lines);
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
@@ -79,6 +79,69 @@ namespace OctoshiftCLI.Tests.Commands
             Assert.Equal(expected, script);
         }
 
+        [Fact]
+        public void SingleRepoTwoPipelines()
+        {
+            var githubOrg = "foo-gh-org";
+            var adoOrg = "foo-ado-org";
+            var adoTeamProject = "foo-team-project";
+            var repo = "foo-repo";
+            var pipelineOne = "CICD";
+            var pipelineTwo = "Publish";
+            var appId = Guid.NewGuid().ToString();
+
+            var repos = new Dictionary<string, Dictionary<string, IEnumerable<string>>>
+            {
+                { adoOrg, new Dictionary<string, IEnumerable<string>>() }
+            };
+
+            repos[adoOrg].Add(adoTeamProject, new List<string>() { repo });
+
+            var pipelines = new Dictionary<string, Dictionary<string, Dictionary<string, IEnumerable<string>>>>
+            {
+                { adoOrg, new Dictionary<string, Dictionary<string, IEnumerable<string>>>() }
+            };
+
+            pipelines[adoOrg].Add(adoTeamProject, new Dictionary<string, IEnumerable<string>>());
+            pipelines[adoOrg][adoTeamProject].Add(repo, new List<string>() { pipelineOne, pipelineTwo });
+
+            var appIds = new Dictionary<string, string>
+            {
+                { adoOrg, appId }
+            };
+
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
+            var script = command.GenerateScript(repos, pipelines, appIds, githubOrg, false);
+
+            script = TrimNonExecutableLines(script);
+
+            var expected = $"./octoshift create-team --github-org \"{githubOrg}\" --team-name \"{adoTeamProject}-Maintainers\" --idp-group \"{adoTeamProject}-Maintainers\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift create-team --github-org \"{githubOrg}\" --team-name \"{adoTeamProject}-Admins\" --idp-group \"{adoTeamProject}-Admins\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift share-service-connection --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --service-connection-id \"{appId}\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift lock-ado-repo --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{repo}\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift migrate-repo --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{repo}\" --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift disable-ado-repo --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{repo}\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift configure-autolink --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\" --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift add-team-to-repo --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\" --team \"{adoTeamProject}-Maintainers\" --role \"maintain\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift add-team-to-repo --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\" --team \"{adoTeamProject}-Admins\" --role \"admin\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift integrate-boards --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift rewire-pipeline --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-pipeline \"{pipelineOne}\" --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\" --service-connection-id \"{appId}\"";
+            expected += Environment.NewLine;
+            expected += $"./octoshift rewire-pipeline --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-pipeline \"{pipelineTwo}\" --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\" --service-connection-id \"{appId}\"";
+
+            Assert.Equal(expected, script);
+        }
+
         private string TrimNonExecutableLines(string script)
         {
             var lines = script.Split(new string[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries).AsEnumerable();

--- a/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
@@ -352,7 +352,6 @@ namespace OctoshiftCLI.Tests.Commands
         {
             var org = "foo-org";
             var teamProject = "foo-tp";
-            var teamProjects = new List<string>() { teamProject };
             var repo = "foo-repo";
             var repoId = Guid.NewGuid().ToString();
             var repos = new Dictionary<string, IDictionary<string, IEnumerable<string>>>();

--- a/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
@@ -313,7 +313,6 @@ namespace OctoshiftCLI.Tests.Commands
         public async Task GetOrgsOrgProvided()
         {
             var org1 = "foo-1";
-            var orgs = new List<string>() { org1 };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
             var result = await command.GetOrgs(null, org1);

--- a/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using Moq;
 using OctoshiftCLI.Commands;
 using Xunit;
@@ -28,7 +26,7 @@ namespace OctoshiftCLI.Tests.Commands
         }
 
         [Fact]
-        public async Task NoData()
+        public void NoData()
         {
             var githubOrg = "foo-gh-org";
 

--- a/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
@@ -376,6 +376,28 @@ namespace OctoshiftCLI.Tests.Commands
             Assert.Contains(result[org][teamProject][repo], x => x == pipeline2);
         }
 
+        [Fact]
+        public async Task GetAppIdsServiceConnectExists()
+        {
+            var org = "foo-org";
+            var orgs = new List<string>() { org };
+            var githubOrg = "foo-gh-org";
+            var teamProject1 = "foo-tp1";
+            var teamProject2 = "foo-tp2";
+            var teamProjects = new List<string>() { teamProject1, teamProject2 };
+            var appId = Guid.NewGuid().ToString();
+
+            var mockAdo = new Mock<AdoApi>(null);
+
+            mockAdo.Setup(x => x.GetTeamProjects(org).Result).Returns(teamProjects);
+            mockAdo.Setup(x => x.GetGithubAppId(org, githubOrg, teamProjects).Result).Returns(appId);
+
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
+            var result = await command.GetAppIds(mockAdo.Object, orgs, githubOrg);
+
+            Assert.Equal(appId, result[org]);
+        }
+
         private string TrimNonExecutableLines(string script)
         {
             var lines = script.Split(new string[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries).AsEnumerable();

--- a/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
@@ -289,7 +289,7 @@ namespace OctoshiftCLI.Tests.Commands
         }
 
         [Fact]
-        public async Task GetOrgs_AllOrgs()
+        public async Task GetOrgsAllOrgs()
         {
             var userId = "foo-user";
             var org1 = "foo-1";
@@ -310,7 +310,7 @@ namespace OctoshiftCLI.Tests.Commands
         }
 
         [Fact]
-        public async Task GetOrgs_OrgProvided()
+        public async Task GetOrgsOrgProvided()
         {
             var org1 = "foo-1";
             var orgs = new List<string>() { org1 };

--- a/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
@@ -351,7 +351,6 @@ namespace OctoshiftCLI.Tests.Commands
         public async Task GetPipelinesOneRepoTwoPipelines()
         {
             var org = "foo-org";
-            var orgs = new List<string>() { org };
             var teamProject = "foo-tp";
             var teamProjects = new List<string>() { teamProject };
             var repo = "foo-repo";

--- a/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/Commands/GenerateScriptCommandTests.cs
@@ -79,6 +79,28 @@ namespace OctoshiftCLI.Tests.Commands
         }
 
         [Fact]
+        public void SkipTeamProjectWithNoRepos()
+        {
+            var githubOrg = "foo-gh-org";
+            var adoOrg = "foo-ado-org";
+            var adoTeamProject = "foo-team-project";
+
+            var repos = new Dictionary<string, Dictionary<string, IEnumerable<string>>>
+            {
+                { adoOrg, new Dictionary<string, IEnumerable<string>>() }
+            };
+
+            repos[adoOrg].Add(adoTeamProject, new List<string>());
+
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
+            var script = command.GenerateScript(repos, null, null, githubOrg, false);
+
+            script = TrimNonExecutableLines(script);
+
+            Assert.Equal(string.Empty, script);
+        }
+
+        [Fact]
         public void SingleRepoTwoPipelines()
         {
             var githubOrg = "foo-gh-org";

--- a/src/OctoshiftCLI/Commands/GenerateScriptCommand.cs
+++ b/src/OctoshiftCLI/Commands/GenerateScriptCommand.cs
@@ -175,14 +175,14 @@ namespace OctoshiftCLI.Commands
         {
             var orgs = new List<string>();
 
-            if (ado != null)
+            if (!string.IsNullOrWhiteSpace(adoOrg))
             {
-                if (!string.IsNullOrWhiteSpace(adoOrg))
-                {
-                    _log.LogInformation($"ADO Org provided, only processing repos for {adoOrg}");
-                    orgs.Add(adoOrg);
-                }
-                else
+                _log.LogInformation($"ADO Org provided, only processing repos for {adoOrg}");
+                orgs.Add(adoOrg);
+            }
+            else
+            {
+                if (ado != null)
                 {
                     _log.LogInformation($"No ADO Org provided, retrieving list of all Orgs PAT has access to...");
                     // TODO: Check if the PAT has the proper permissions to retrieve list of ADO orgs, needs the All Orgs scope


### PR DESCRIPTION
Closes #159

Could probably write a couple more, but this gets most of the logic in that command covered. Had to make some minor refactorings to GenerateScriptCommand to make it more testable.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked