### PR TITLE
add a note about migrate-repo using GH_PAT

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
 - Added descriptions to all commands in the built-in CLI help
 - add-team-to-repo now includes built-in help listing the valid values for the --role argument (octoshift add-team-to-repo --help), the CLI also validates the value of --role before attempting to run.
 - integrate-boards command now expects a single call per repo (instead of single call per team project with a list of repos). This will enable splitting a single team project into multiple batches for migration purposes. If no Boards-GitHub connection exists it will create it, otherwise it will add the repo to the existing connection. It assumes either 0 or 1 boards connection exists per team project (multiple connections in a single team project has not been tested).
+- migrate-repo now uses the GH_PAT for git push. The GH_PAT needs to have the repo scope in order for the git push to work.   


### PR DESCRIPTION
Added a release note to specify that from now on `migrate-repo` is going to use the `GH_PAT` for git push operations. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked