### PR TITLE
Use interpolated string

### DIFF
--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -23,7 +23,7 @@ namespace OctoshiftCLI.Tests
             var payload = new
             {
                 key_prefix = "AB#",
-                url_template = "https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/"
+                url_template = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/"
             };
 
             var githubClientMock = new Mock<GithubClient>(null, "");

--- a/src/OctoshiftCLI/GithubApi.cs
+++ b/src/OctoshiftCLI/GithubApi.cs
@@ -21,7 +21,7 @@ namespace OctoshiftCLI
             var payload = new
             {
                 key_prefix = "AB#",
-                url_template = "https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/"
+                url_template = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/"
             };
 
             await _client.PostAsync(url, payload);


### PR DESCRIPTION
I noticed a small bug (thanks to `Rider`) which was introduced in the previous PR. Here is a quick fix.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked