### PR TITLE
AdoApi improvements

### DIFF
--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -302,7 +302,7 @@ namespace OctoshiftCLI
             await _client.PatchAsync(url, payload);
         }
 
-        public virtual async Task<(string defaultBranch, string clean, string checkoutSubmodules)> GetPipeline(string org, string teamProject, int pipelineId)
+        public virtual async Task<(string DefaultBranch, string Clean, string CheckoutSubmodules)> GetPipeline(string org, string teamProject, int pipelineId)
         {
             var url = $"https://dev.azure.com/{org}/{teamProject}/_apis/build/definitions/{pipelineId}?api-version=6.0";
 
@@ -325,7 +325,6 @@ namespace OctoshiftCLI
             return (defaultBranch, clean, checkoutSubmodules);
         }
 
-        //public virtual async Task ChangePipelineRepo(AdoPipeline pipeline, string githubOrg, string githubRepo, string connectedServiceId)
         public virtual async Task ChangePipelineRepo(string adoOrg, string teamProject, int pipelineId, string defaultBranch, string clean, string checkoutSubmodules, string githubOrg, string githubRepo, string connectedServiceId)
         {
             var url = $"https://dev.azure.com/{adoOrg}/{teamProject}/_apis/build/definitions/{pipelineId}?api-version=6.0";
@@ -514,14 +513,4 @@ namespace OctoshiftCLI
             await _client.PostAsync(url, payload);
         }
     }
-
-    //public class AdoPipeline
-    //{
-    //    public int Id { get; set; }
-    //    public string Org { get; set; }
-    //    public string TeamProject { get; set; }
-    //    public string DefaultBranch { get; set; }
-    //    public string Clean { get; set; }
-    //    public string CheckoutSubmodules { get; set; }
-    //}
 }

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -126,7 +126,7 @@ namespace OctoshiftCLI
                 }
             };
 
-            var response = await _client.PostAsync(url, payload.ToJson());
+            var response = await _client.PostAsync(url, payload);
             var data = JObject.Parse(response);
 
             return (string)data["dataProviders"]["ms.vss-work-web.github-user-data-provider"]["login"];
@@ -136,29 +136,33 @@ namespace OctoshiftCLI
         {
             var url = $"https://dev.azure.com/{org}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
-            var payload = @"
-{
-	""contributionIds"": [""ms.vss-work-web.azure-boards-external-connection-data-provider""],
-	""dataProviderContext"": {
-		""properties"": {
-			""includeInvalidConnections"": false,
-			""sourcePage"": {
-				""url"": ""https://dev.azure.com/ADO_ORGANIZATION/ADO_TEAMPROJECT/_settings/work-team"",
-				""routeId"": ""ms.vss-admin-web.project-admin-hub-route"",
-				""routeValues"": {
-					""project"": ""ADO_TEAMPROJECT"",
-					""adminPivot"": ""work-team"",
-					""controller"": ""ContributedPage"",
-					""action"": ""Execute"",
-					""serviceHost"": ""ADO_ORGID (ADO_ORGANIZATION)""
-				}
-			}
-		}
-	}
-}";
-            payload = payload.Replace("ADO_ORGANIZATION", org);
-            payload = payload.Replace("ADO_TEAMPROJECT", teamProject);
-            payload = payload.Replace("ADO_ORGID", orgId);
+            var payload = new
+            {
+                contributionIds = new[]
+                {
+                    "ms.vss-work-web.azure-boards-external-connection-data-provider"
+                },
+                dataProviderContext = new
+                {
+                    properties = new
+                    {
+                        includeInvalidConnections = false,
+                        sourcePage = new
+                        {
+                            url = $"https://dev.azure.com/{org}/{teamProject}/_settings/work-team",
+                            routeId = "ms.vss-admin-web.project-admin-hub-route",
+                            routeValues = new
+                            {
+                                project = teamProject,
+                                adminPivot = "work-team",
+                                controller = "ContributedPage",
+                                action = "Execute",
+                                serviceHost = $"{orgId} ({org})"
+                            }
+                        }
+                    }
+                }
+            };
 
             var response = await _client.PostAsync(url, payload);
             var data = JObject.Parse(response);
@@ -179,25 +183,24 @@ namespace OctoshiftCLI
         {
             var url = $"https://dev.azure.com/{org}/{teamProjectId}/_apis/serviceendpoint/endpoints?api-version=5.0-preview.1";
 
-            var payload = @"
-{
-    ""type"": ""githubboards"",
-    ""url"": ""http://github.com"",
-    ""authorization"": {
-        ""scheme"": ""PersonalAccessToken"",
-        ""parameters"": {
-            ""accessToken"": ""GITHUB_TOKEN""
-        }
-    },
-    ""data"": {
-        ""GitHubHandle"": ""GITHUB_HANDLE""
-    },
-    ""name"": ""ENDPOINT_NAME""
-}";
-
-            payload = payload.Replace("GITHUB_TOKEN", githubToken);
-            payload = payload.Replace("GITHUB_HANDLE", githubHandle);
-            payload = payload.Replace("ENDPOINT_NAME", endpointName);
+            var payload = new
+            {
+                type = "githubboards",
+                url = "http://github.com",
+                authorization = new
+                {
+                    scheme = "PersonalAccessToken",
+                    parameters = new
+                    {
+                        accessToken = githubToken
+                    }
+                },
+                data = new
+                {
+                    GitHubHandle = githubHandle
+                },
+                name = endpointName
+            };
 
             var response = await _client.PostAsync(url, payload);
             var data = JObject.Parse(response);
@@ -209,44 +212,42 @@ namespace OctoshiftCLI
         {
             var url = $"https://dev.azure.com/{org}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
-            var payload = @"
-{
-	""contributionIds"": [""ms.vss-work-web.azure-boards-save-external-connection-data-provider""],
-	""dataProviderContext"": {
-		""properties"": {
-			""externalConnection"": {
-				""serviceEndpointId"": ""ENDPOINT_ID"",
-				""connectionName"": ""CONNECTION_NAME"",
-				""connectionId"": ""CONNECTION_ID"",
-				""operation"": 1,
-                ""externalRepositoryExternalIds"": [
-                    REPO_IDS
-                ],
-				""providerKey"": ""github.com"",
-				""isGitHubApp"": false
-			},
-			""sourcePage"": {
-				""url"": ""https://dev.azure.com/ADO_ORGANIZATION/ADO_TEAMPROJECT/_settings/boards-external-integration"",
-				""routeId"": ""ms.vss-admin-web.project-admin-hub-route"",
-				""routeValues"": {
-					""project"": ""ADO_TEAMPROJECT"",
-					""adminPivot"": ""boards-external-integration"",
-					""controller"": ""ContributedPage"",
-					""action"": ""Execute"",
-					""serviceHost"": ""ADO_ORGID (ADO_ORGANIZATION)""
-				}
-			}
-		}
-	}
-}";
-
-            payload = payload.Replace("ENDPOINT_ID", endpointId);
-            payload = payload.Replace("CONNECTION_NAME", connectionName);
-            payload = payload.Replace("CONNECTION_ID", connectionId);
-            payload = payload.Replace("ADO_ORGANIZATION", org);
-            payload = payload.Replace("ADO_TEAMPROJECT", teamProject);
-            payload = payload.Replace("ADO_ORGID", orgId);
-            payload = payload.Replace("REPO_IDS", BuildRepoString(repoIds));
+            var payload = new
+            {
+                contributionIds = new[]
+                {
+                    "ms.vss-work-web.azure-boards-save-external-connection-data-provider"
+                },
+                dataProviderContext = new
+                {
+                    properties = new
+                    {
+                        externalConnection = new
+                        {
+                            serviceEndpointId = endpointId,
+                            connectionName,
+                            connectionId,
+                            operation = 1,
+                            externalRepositoryExternalIds = repoIds.ToArray(),
+                            providerKey = "github.com",
+                            isGitHubApp = false
+                        },
+                        sourcePage = new
+                        {
+                            url = $"https://dev.azure.com/{org}/{teamProject}/_settings/boards-external-integration",
+                            routeId = "ms.vss-admin-web.project-admin-hub-route",
+                            routeValues = new
+                            {
+                                project = teamProject,
+                                adminPivot = "boards-external-integration",
+                                controller = "ContributedPage",
+                                action = "Execute",
+                                serviceHost = $"{orgId} ({org})"
+                            }
+                        }
+                    }
+                }
+            };
 
             await _client.PostAsync(url, payload);
         }
@@ -285,87 +286,78 @@ namespace OctoshiftCLI
         {
             var url = $"https://dev.azure.com/{adoOrg}/_apis/serviceendpoint/endpoints/{serviceConnectionId}?api-version=6.0-preview.4";
 
-            var payload = @"
-[{
-    ""name"": ""ADO_ORGANIZATION-ADO_TEAM_PROJECT"",
-	""projectReference"": {
-        ""id"": ""ADO_PROJECT_ID"",
-		""name"": ""ADO_TEAM_PROJECT""
-    }
-}]";
-
-            payload = payload.Replace("ADO_ORGANIZATION", adoOrg);
-            payload = payload.Replace("ADO_TEAM_PROJECT", adoTeamProject);
-            payload = payload.Replace("ADO_PROJECT_ID", adoTeamProjectId);
+            var payload = new[]
+            {
+                new
+                {
+                    name = $"{adoOrg}-{adoTeamProject}",
+                    projectReference = new
+                    {
+                        id = adoTeamProjectId,
+                        name = adoTeamProject
+                    }
+                }
+            };
 
             await _client.PatchAsync(url, payload);
         }
 
-        public virtual async Task<AdoPipeline> GetPipeline(string org, string teamProject, int pipelineId)
+        public virtual async Task<(string defaultBranch, string clean, string checkoutSubmodules)> GetPipeline(string org, string teamProject, int pipelineId)
         {
             var url = $"https://dev.azure.com/{org}/{teamProject}/_apis/build/definitions/{pipelineId}?api-version=6.0";
 
             var response = await _client.GetAsync(url);
             var data = JObject.Parse(response);
 
-            var result = new AdoPipeline
-            {
-                Id = pipelineId,
-                Org = org,
-                TeamProject = teamProject
-            };
+            var defaultBranch = (string)data["repository"]["defaultBranch"];
 
-            result.DefaultBranch = (string)data["repository"]["defaultBranch"];
-            if (result.DefaultBranch.ToLower().StartsWith("refs/heads/"))
+            if (defaultBranch.ToLower().StartsWith("refs/heads/"))
             {
-                result.DefaultBranch = result.DefaultBranch["refs/heads/".Length..];
+                defaultBranch = defaultBranch["refs/heads/".Length..];
             }
-            result.Clean = (string)data["repository"]["clean"];
-            result.Clean = result.Clean == null ? "null" : result.Clean.ToLower();
-            result.CheckoutSubmodules = (string)data["repository"]["checkoutSubmodules"];
-            result.CheckoutSubmodules = result.CheckoutSubmodules == null ? "null" : result.CheckoutSubmodules.ToLower();
 
-            return result;
+            var clean = (string)data["repository"]["clean"];
+            clean = clean == null ? "null" : clean.ToLower();
+
+            var checkoutSubmodules = (string)data["repository"]["checkoutSubmodules"];
+            checkoutSubmodules = checkoutSubmodules == null ? "null" : checkoutSubmodules.ToLower();
+
+            return (defaultBranch, clean, checkoutSubmodules);
         }
 
-        public virtual async Task ChangePipelineRepo(AdoPipeline pipeline, string githubOrg, string githubRepo, string serviceConnectionId)
+        //public virtual async Task ChangePipelineRepo(AdoPipeline pipeline, string githubOrg, string githubRepo, string connectedServiceId)
+        public virtual async Task ChangePipelineRepo(string adoOrg, string teamProject, int pipelineId, string defaultBranch, string clean, string checkoutSubmodules, string githubOrg, string githubRepo, string connectedServiceId)
         {
-            var url = $"https://dev.azure.com/{pipeline?.Org}/{pipeline?.TeamProject}/_apis/build/definitions/{pipeline?.Id}?api-version=6.0";
+            var url = $"https://dev.azure.com/{adoOrg}/{teamProject}/_apis/build/definitions/{pipelineId}?api-version=6.0";
 
             var response = await _client.GetAsync(url);
             var data = JObject.Parse(response);
 
-            var newRepo = @"
-{
-    ""properties"": {
-        ""apiUrl"": ""https://api.github.com/repos/GITHUB_ORG/GITHUB_REPO"",
-        ""branchesUrl"": ""https://api.github.com/repos/GITHUB_ORG/GITHUB_REPO/branches"",
-        ""cloneUrl"": ""https://github.com/GITHUB_ORG/GITHUB_REPO.git"",
-        ""connectedServiceId"": ""CONNECTED_SERVICE_ID"",
-        ""defaultBranch"": ""DEFAULT_BRANCH"",
-        ""fullName"": ""GITHUB_ORG/GITHUB_REPO"",
-        ""manageUrl"": ""https://github.com/GITHUB_ORG/GITHUB_REPO"",
-        ""orgName"": ""GITHUB_ORG"",
-        ""refsUrl"": ""https://api.github.com/repos/GITHUB_ORG/GITHUB_REPO/git/refs"",
-        ""safeRepository"": ""GITHUB_ORG/GITHUB_REPO"",
-        ""shortName"": ""GITHUB_REPO"",
-        ""reportBuildStatus"": ""true""
-    },
-    ""id"": ""GITHUB_ORG/GITHUB_REPO"",
-    ""type"": ""GitHub"",
-    ""name"": ""GITHUB_ORG/GITHUB_REPO"",
-    ""url"": ""https://github.com/GITHUB_ORG/GITHUB_REPO.git"",
-    ""defaultBranch"": ""DEFAULT_BRANCH"",
-    ""clean"": CLEAN_FLAG,
-    ""checkoutSubmodules"": CHECKOUT_SUBMODULES_FLAG
-}";
-
-            newRepo = newRepo.Replace("GITHUB_ORG", githubOrg);
-            newRepo = newRepo.Replace("GITHUB_REPO", githubRepo);
-            newRepo = newRepo.Replace("DEFAULT_BRANCH", pipeline?.DefaultBranch);
-            newRepo = newRepo.Replace("CLEAN_FLAG", pipeline?.Clean);
-            newRepo = newRepo.Replace("CHECKOUT_SUBMODULES_FLAG", pipeline?.CheckoutSubmodules);
-            newRepo = newRepo.Replace("CONNECTED_SERVICE_ID", serviceConnectionId);
+            var newRepo = new
+            {
+                properties = new
+                {
+                    apiUrl = $"https://api.github.com/repos/{githubOrg}/{githubRepo}",
+                    branchesUrl = $"https://api.github.com/repos/{githubOrg}/{githubRepo}/branches",
+                    cloneUrl = $"https://github.com/{githubOrg}/{githubRepo}.git",
+                    connectedServiceId,
+                    defaultBranch,
+                    fullName = $"{githubOrg}/{githubRepo}",
+                    manageUrl = $"https://github.com/{githubOrg}/{githubRepo}",
+                    orgName = githubOrg,
+                    refsUrl = $"https://api.github.com/repos/{githubOrg}/{githubRepo}/git/refs",
+                    safeRepository = $"{githubOrg}/{githubRepo}",
+                    shortName = githubRepo,
+                    reportBuildStatus = true
+                },
+                id = $"{githubOrg}/{githubRepo}",
+                type = "GitHub",
+                name = $"{githubOrg}/{githubRepo}",
+                url = $"https://github.com/{githubOrg}/{githubRepo}.git",
+                defaultBranch,
+                clean,
+                checkoutSubmodules
+            };
 
             var payload = new JObject();
 
@@ -373,51 +365,48 @@ namespace OctoshiftCLI
             {
                 if (prop.Name == "repository")
                 {
-                    prop.Value = JObject.Parse(newRepo);
+                    prop.Value = JObject.Parse(newRepo.ToJson());
                 }
 
                 payload.Add(prop.Name, prop.Value);
             }
 
-            await _client.PutAsync(url, payload.ToString());
+            await _client.PutAsync(url, payload.ToObject(typeof(object)));
         }
 
         public virtual async Task<string> GetBoardsGithubRepoId(string org, string orgId, string teamProject, string teamProjectId, string endpointId, string githubOrg, string githubRepo)
         {
             var url = $"https://dev.azure.com/{org}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
-            var payload = @"
-{
-    ""contributionIds"": [
-        ""ms.vss-work-web.github-user-repository-data-provider""
-    ],
-    ""dataProviderContext"": {
-        ""properties"": {
-            ""projectId"": ""ADO_TEAMPROJECTID"",
-            ""repoWithOwnerName"": ""GITHUB_ORG/GITHUB_REPO"",
-            ""serviceEndpointId"": ""ENDPOINT_ID"",
-            ""sourcePage"": {
-                ""url"": ""https://dev.azure.com/ADO_ORGANIZATION/ADO_TEAMPROJECT/_settings/boards-external-integration#"",
-                ""routeId"": ""ms.vss-admin-web.project-admin-hub-route"",
-                ""routeValues"": {
-                    ""project"": ""ADO_TEAMPROJECT"",
-                    ""adminPivot"": ""boards-external-integration"",
-                    ""controller"": ""ContributedPage"",
-                    ""action"": ""Execute"",
-                    ""serviceHost"": ""ADO_ORGID (ADO_ORGANIZATION)""
+            var payload = new
+            {
+                contributionIds = new[]
+                {
+                    "ms.vss-work-web.github-user-repository-data-provider"
+                },
+                dataProviderContext = new
+                {
+                    properties = new
+                    {
+                        projectId = teamProjectId,
+                        repoWithOwnerName = $"{githubOrg}/{githubRepo}",
+                        serviceEndpointId = endpointId,
+                        sourcePage = new
+                        {
+                            url = $"https://dev.azure.com/{org}/{teamProject}/_settings/boards-external-integration#",
+                            routeId = "ms.vss-admin-web.project-admin-hub-route",
+                            routeValues = new
+                            {
+                                project = teamProject,
+                                adminPivot = "boards-external-integration",
+                                controller = "ContributedPage",
+                                action = "Execute",
+                                serviceHost = $"{orgId} ({org})"
+                            }
+                        }
+                    }
                 }
-            }
-        }
-    }
-}";
-
-            payload = payload.Replace("ADO_TEAMPROJECTID", teamProjectId);
-            payload = payload.Replace("GITHUB_ORG", githubOrg);
-            payload = payload.Replace("ENDPOINT_ID", endpointId);
-            payload = payload.Replace("ADO_ORGANIZATION", org);
-            payload = payload.Replace("ADO_TEAMPROJECT", teamProject);
-            payload = payload.Replace("ADO_ORGID", orgId);
-            payload = payload.Replace("GITHUB_REPO", githubRepo);
+            };
 
             var response = await _client.PostAsync(url, payload);
             var data = JObject.Parse(response);
@@ -429,42 +418,43 @@ namespace OctoshiftCLI
         {
             var url = $"https://dev.azure.com/{org}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
-            var payload = @"
-{
-    ""contributionIds"": [
-        ""ms.vss-work-web.azure-boards-save-external-connection-data-provider""
-    ],
-    ""dataProviderContext"": {
-        ""properties"": {
-            ""externalConnection"": {
-                ""serviceEndpointId"": ""ENDPOINT_ID"",
-                ""operation"": 0,
-                ""externalRepositoryExternalIds"": [
-                    ""REPO_ID""
-                ],
-                ""providerKey"": ""github.com"",
-                ""isGitHubApp"": false
-            },
-            ""sourcePage"": {
-                ""url"": ""https://dev.azure.com/ADO_ORGANIZATION/ADO_TEAMPROJECT/_settings/boards-external-integration#"",
-                ""routeId"": ""ms.vss-admin-web.project-admin-hub-route"",
-                ""routeValues"": {
-                    ""project"": ""ADO_TEAMPROJECT"",
-                    ""adminPivot"": ""boards-external-integration"",
-                    ""controller"": ""ContributedPage"",
-                    ""action"": ""Execute"",
-                    ""serviceHost"": ""ADO_ORGID (ADO_ORGANIZATION)""
+            var payload = new
+            {
+                contributionIds = new[]
+                {
+                    "ms.vss-work-web.azure-boards-save-external-connection-data-provider"
+                },
+                dataProviderContext = new
+                {
+                    properties = new
+                    {
+                        externalConnection = new
+                        {
+                            serviceEndpointId = endpointId,
+                            operation = 0,
+                            externalRepositoryExternalIds = new[]
+                            {
+                                repoId
+                            },
+                            providerKey = "github.com",
+                            isGitHubApp = false
+                        },
+                        sourcePage = new
+                        {
+                            url = $"https://dev.azure.com/{org}/{teamProject}/_settings/boards-external-integration#",
+                            routeId = "ms.vss-admin-web.project-admin-hub-route",
+                            routeValues = new
+                            {
+                                project = teamProject,
+                                adminPivot = "boards-external-integration",
+                                controller = "ContributedPage",
+                                action = "Execute",
+                                serviceHost = $"{orgId} ({org})"
+                            }
+                        }
+                    }
                 }
-            }
-        }
-    }
-}";
-
-            payload = payload.Replace("ENDPOINT_ID", endpointId);
-            payload = payload.Replace("ADO_ORGANIZATION", org);
-            payload = payload.Replace("ADO_TEAMPROJECT", teamProject);
-            payload = payload.Replace("ADO_ORGID", orgId);
-            payload = payload.Replace("REPO_ID", repoId);
+            };
 
             await _client.PostAsync(url, payload);
         }
@@ -479,7 +469,7 @@ namespace OctoshiftCLI
         {
             var url = $"https://dev.azure.com/{org}/{teamProject}/_apis/git/repositories/{repoId}?api-version=6.1-preview.1";
 
-            var payload = "{ \"isDisabled\": true }";
+            var payload = new { isDisabled = true };
             await _client.PatchAsync(url, payload);
         }
 
@@ -499,41 +489,39 @@ namespace OctoshiftCLI
 
             var url = $"https://dev.azure.com/{org}/_apis/accesscontrolentries/{gitReposNamespace}?api-version=6.1-preview.1";
 
-            var payload = @"
-{
-  ""token"": ""repoV2/TEAM_PROJECT_ID/REPO_ID"",
-  ""merge"": true,
-  ""accessControlEntries"": [
-    {
-      ""descriptor"": ""IDENTITY_DESCRIPTOR"",
-      ""allow"": 0,
-      ""deny"": 56828,
-      ""extendedInfo"": {
-        ""effectiveAllow"": 0,
-        ""effectiveDeny"": 56828,
-        ""inheritedAllow"": 0,
-        ""inheritedDeny"": 56828
-      }
-    }
-  ]
-}
-";
-
-            payload = payload.Replace("TEAM_PROJECT_ID", teamProjectId);
-            payload = payload.Replace("REPO_ID", repoId);
-            payload = payload.Replace("IDENTITY_DESCRIPTOR", identityDescriptor);
+            var payload = new
+            {
+                token = $"repoV2/{teamProjectId}/{repoId}",
+                merge = true,
+                accessControlEntries = new[]
+                {
+                    new
+                    {
+                        descriptor = identityDescriptor,
+                        allow = 0,
+                        deny = 56828,
+                        extendedInfo = new
+                        {
+                            effectiveAllow = 0,
+                            effectiveDeny = 56828,
+                            inheritedAllow = 0,
+                            inheritedDeny = 56828
+                        }
+                    }
+                }
+            };
 
             await _client.PostAsync(url, payload);
         }
     }
 
-    public class AdoPipeline
-    {
-        public int Id { get; set; }
-        public string Org { get; set; }
-        public string TeamProject { get; set; }
-        public string DefaultBranch { get; set; }
-        public string Clean { get; set; }
-        public string CheckoutSubmodules { get; set; }
-    }
+    //public class AdoPipeline
+    //{
+    //    public int Id { get; set; }
+    //    public string Org { get; set; }
+    //    public string TeamProject { get; set; }
+    //    public string DefaultBranch { get; set; }
+    //    public string Clean { get; set; }
+    //    public string CheckoutSubmodules { get; set; }
+    //}
 }

--- a/src/OctoshiftCLI.Tests/AdoApiTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoApiTests.cs
@@ -200,11 +200,12 @@ namespace OctoshiftCLI.Tests
         }
     }
 }";
+            payload = JObject.Parse(payload).ToString();
             var json = $"{{ \"dataProviders\": {{ \"ms.vss-work-web.github-user-data-provider\": {{ \"login\": '{handle}' }} }} }}";
 
             var mockClient = new Mock<AdoClient>(null, null);
 
-            mockClient.Setup(x => x.PostAsync(endpoint, payload).Result).Returns(json);
+            mockClient.Setup(x => x.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result).Returns(json);
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.GetGithubHandle("FOO-ORG", "FOO-ORGID", "FOO-TEAMPROJECT", "FOO-TOKEN");
@@ -240,6 +241,8 @@ namespace OctoshiftCLI.Tests
 		}}
 	}}
 }}";
+            payload = JObject.Parse(payload).ToString();
+
             var connectionId = "foo-id";
             var endpointId = "foo-endpoint-id";
             var connectionName = "foo-name";
@@ -250,7 +253,7 @@ namespace OctoshiftCLI.Tests
 
             var mockClient = new Mock<AdoClient>(null, null);
 
-            mockClient.Setup(x => x.PostAsync(endpoint, payload).Result).Returns(json);
+            mockClient.Setup(x => x.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result).Returns(json);
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.GetBoardsGithubConnection("FOO-ORG", "FOO-ORGID", "FOO-TEAMPROJECT");
@@ -289,11 +292,12 @@ namespace OctoshiftCLI.Tests
     ""name"": ""{endpointName}""
 }}";
 
+            payload = JObject.Parse(payload).ToString();
             var endpointId = "foo-id";
             var json = $"{{id: '{endpointId}', name: 'something'}}";
 
             var mockClient = new Mock<AdoClient>(null, null);
-            mockClient.Setup(x => x.PostAsync(endpoint, payload).Result).Returns(json);
+            mockClient.Setup(x => x.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result).Returns(json);
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.CreateBoardsGithubEndpoint(orgName, teamProjectId, githubToken, githubHandle, endpointName);
@@ -346,11 +350,12 @@ namespace OctoshiftCLI.Tests
 	}}
 }}";
 
+            payload = JObject.Parse(payload).ToString();
             var mockClient = new Mock<AdoClient>(null, null);
             var sut = new AdoApi(mockClient.Object);
             await sut.AddRepoToBoardsGithubConnection(orgName, orgId, teamProject, connectionId, connectionName, endpointId, new List<string>() { repo1, repo2 });
 
-            mockClient.Verify(m => m.PostAsync(endpoint, payload).Result);
+            mockClient.Verify(m => m.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result);
         }
 
         [Fact]
@@ -453,11 +458,12 @@ namespace OctoshiftCLI.Tests
     }}
 }}]";
 
+            payload = JArray.Parse(payload).ToString();
             var mockClient = new Mock<AdoClient>(null, null);
             var sut = new AdoApi(mockClient.Object);
             await sut.ShareServiceConnection(org, teamProject, teamProjectId, serviceConnectionId);
 
-            mockClient.Verify(m => m.PatchAsync(endpoint, payload));
+            mockClient.Verify(m => m.PatchAsync(endpoint, It.Is<string>(y => JArray.Parse(y).ToString() == payload)));
         }
 
         [Fact]
@@ -598,11 +604,12 @@ namespace OctoshiftCLI.Tests
     }}
 }}";
 
+            payload = JObject.Parse(payload).ToString();
             var repoId = Guid.NewGuid().ToString();
             var json = $@"{{dataProviders: {{ ""ms.vss-work-web.github-user-repository-data-provider"": {{ additionalProperties: {{ nodeId: '{repoId}' }} }} }} }}";
 
             var mockClient = new Mock<AdoClient>(null, null);
-            mockClient.Setup(x => x.PostAsync(endpoint, payload).Result).Returns(json);
+            mockClient.Setup(x => x.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result).Returns(json);
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.GetBoardsGithubRepoId(orgName, orgId, teamProject, teamProjectId, endpointId, githubOrg, githubRepo);
@@ -652,12 +659,13 @@ namespace OctoshiftCLI.Tests
     }}
 }}";
 
+            payload = JObject.Parse(payload).ToString();
             var mockClient = new Mock<AdoClient>(null, null);
 
             var sut = new AdoApi(mockClient.Object);
             await sut.CreateBoardsGithubConnection(orgName, orgId, teamProject, endpointId, repoId);
 
-            mockClient.Verify(m => m.PostAsync(endpoint, payload).Result);
+            mockClient.Verify(m => m.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result);
         }
 
         [Fact]
@@ -673,9 +681,10 @@ namespace OctoshiftCLI.Tests
             var sut = new AdoApi(mockClient.Object);
             await sut.DisableRepo(orgName, teamProject, repoId);
 
-            var expectedPayload = @"{ ""isDisabled"": true }";
+            var payload = @"{ ""isDisabled"": true }";
+            payload = JObject.Parse(payload).ToString();
 
-            mockClient.Verify(m => m.PatchAsync(endpoint, expectedPayload).Result);
+            mockClient.Verify(m => m.PatchAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result);
         }
 
         [Fact]
@@ -730,11 +739,12 @@ namespace OctoshiftCLI.Tests
 }}
 ";
 
+            payload = JObject.Parse(payload).ToString();
             var mockClient = new Mock<AdoClient>(null, null);
             var sut = new AdoApi(mockClient.Object);
             await sut.LockRepo(orgName, teamProjectId, repoId, identityDescriptor);
 
-            mockClient.Verify(m => m.PostAsync(endpoint, payload).Result);
+            mockClient.Verify(m => m.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result);
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/AdoApiTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoApiTests.cs
@@ -18,11 +18,20 @@ namespace OctoshiftCLI.Tests
         {
             var endpoint = "https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=5.0-preview.1";
             var userId = "foo";
-            var userJson = "{ coreAttributes: { PublicAlias: { value: \"" + userId + "\" }}}";
+            var userJson = new
+            {
+                coreAttributes = new
+                {
+                    PublicAlias = new
+                    {
+                        value = userId
+                    }
+                }
+            };
 
             var mockClient = new Mock<AdoClient>(null, null);
 
-            mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(userJson);
+            mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(userJson.ToJson());
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.GetUserId();
@@ -35,11 +44,20 @@ namespace OctoshiftCLI.Tests
         {
             var endpoint = "https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=5.0-preview.1";
             var userId = "foo";
-            var userJson = "{ invalid: { PublicAlias: { value: \"" + userId + "\" }}}";
+            var userJson = new
+            {
+                invalid = new
+                {
+                    PublicAlias = new
+                    {
+                        value = userId
+                    }
+                }
+            };
 
             var mockClient = new Mock<AdoClient>(null, null);
 
-            mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(userJson);
+            mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(userJson.ToJson());
 
             var sut = new AdoApi(mockClient.Object);
             await Assert.ThrowsAsync<InvalidDataException>(async () => await sut.GetUserId());
@@ -50,11 +68,22 @@ namespace OctoshiftCLI.Tests
         {
             var userId = "foo";
             var endpoint = $"https://app.vssps.visualstudio.com/_apis/accounts?memberId={userId}?api-version=5.0-preview.1";
-            var accountsJson = "[{accountId: 'blah', AccountName: 'foo'}, {AccountName: 'foo2'}]";
+            var accountsJson = new object[]
+            {
+                new
+                {
+                    accountId = "blah",
+                    AccountName = "foo"
+                },
+                new
+                {
+                    AccountName = "foo2"
+                }
+            };
 
             var mockClient = new Mock<AdoClient>(null, null);
 
-            mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(accountsJson);
+            mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(accountsJson.ToJson());
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.GetOrganizations(userId);
@@ -70,8 +99,21 @@ namespace OctoshiftCLI.Tests
             var adoOrg = "foo-org";
             var orgId = "blah";
             var endpoint = $"https://app.vssps.visualstudio.com/_apis/accounts?memberId={userId}&api-version=5.0-preview.1";
-            var accountsJson = "[{accountId: '" + orgId + "', accountName: '" + adoOrg + "'}, {accountName: 'foo2', accountId: 'asdf'}]";
-            var response = JArray.Parse(accountsJson);
+            var accountsJson = new object[]
+            {
+                new
+                {
+                    accountId = orgId,
+                    accountName = adoOrg
+                },
+                new
+                {
+                    accountName = "foo2",
+                    accountId = "asdf"
+                }
+            };
+
+            var response = JArray.Parse(accountsJson.ToJson());
 
             var mockClient = new Mock<AdoClient>(null, null);
 
@@ -90,8 +132,20 @@ namespace OctoshiftCLI.Tests
             var teamProject1 = "foo-tp";
             var teamProject2 = "foo-tp2";
             var endpoint = $"https://dev.azure.com/{adoOrg}/_apis/projects?api-version=6.1-preview";
-            var json = "[{somethingElse: false, name: '" + teamProject1 + "'}, {id: 'sfasfasdf', name: '" + teamProject2 + "'}]";
-            var response = JArray.Parse(json);
+            var json = new object[]
+            {
+                new
+                {
+                    somethingElse = false,
+                    name = teamProject1
+                },
+                new
+                {
+                    id = "sfasfasdf",
+                    name = teamProject2
+                }
+            };
+            var response = JArray.Parse(json.ToJson());
 
             var mockClient = new Mock<AdoClient>(null, null);
 
@@ -112,8 +166,25 @@ namespace OctoshiftCLI.Tests
             var repo1 = "foo-repo";
             var repo2 = "foo-repo2";
             var endpoint = $"https://dev.azure.com/{adoOrg}/{teamProject}/_apis/git/repositories?api-version=6.1-preview.1";
-            var json = "[{isDisabled: 'true', name: 'testing'}, {isDisabled: false, name: '" + repo1 + "'}, {isDisabled: 'FALSE', name: '" + repo2 + "'}]";
-            var response = JArray.Parse(json);
+            var json = new object[]
+            {
+                new
+                {
+                    isDisabled = true,
+                    name = "testing"
+                },
+                new
+                {
+                    isDisabled = false,
+                    name = repo1
+                },
+                new
+                {
+                    isDisabled = "FALSE",
+                    name = repo2
+                }
+            };
+            var response = JArray.Parse(json.ToJson());
 
             var mockClient = new Mock<AdoClient>(null, null);
 
@@ -136,8 +207,16 @@ namespace OctoshiftCLI.Tests
             var teamProjects = new List<string>() { teamProject1, teamProject2 };
             var appId = Guid.NewGuid().ToString();
 
-            var json = "[{type: 'GitHub', name: '" + githubOrg + "', id: '" + appId + "'}]";
-            var response = JArray.Parse(json);
+            var json = new object[]
+            {
+                new
+                {
+                    type = "GitHub",
+                    name = githubOrg,
+                    id = appId
+                }
+            };
+            var response = JArray.Parse(json.ToJson());
 
             var mockClient = new Mock<AdoClient>(null, null);
 
@@ -160,8 +239,16 @@ namespace OctoshiftCLI.Tests
             var teamProjects = new List<string>() { teamProject1, teamProject2 };
             var appId = Guid.NewGuid().ToString();
 
-            var json = "[{type: 'GitHub', name: 'wrongOrg', id: '" + appId + "'}]";
-            var response = JArray.Parse(json);
+            var json = new object[]
+            {
+                new
+                {
+                    type = "GitHub",
+                    name = "wrongOrg",
+                    id = appId
+                }
+            };
+            var response = JArray.Parse(json.ToJson());
 
             var mockClient = new Mock<AdoClient>(null, null);
 
@@ -210,13 +297,13 @@ namespace OctoshiftCLI.Tests
                         }
                     }
                 }
-            }.ToJson();
+            };
 
             var json = $"{{ \"dataProviders\": {{ \"ms.vss-work-web.github-user-data-provider\": {{ \"login\": '{handle}' }} }} }}";
 
             var mockClient = new Mock<AdoClient>(null, null);
 
-            mockClient.Setup(x => x.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == JObject.Parse(payload).ToString())).Result).Returns(json);
+            mockClient.Setup(x => x.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result).Returns(json);
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.GetGithubHandle(adoOrg, adoOrgId, teamProject, githubToken);
@@ -232,27 +319,33 @@ namespace OctoshiftCLI.Tests
             var orgName = "FOO-ORG";
             var endpoint = $"https://dev.azure.com/{orgName}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
-            var payload = $@"
-{{
-	""contributionIds"": [""ms.vss-work-web.azure-boards-external-connection-data-provider""],
-	""dataProviderContext"": {{
-		""properties"": {{
-			""includeInvalidConnections"": false,
-			""sourcePage"": {{
-				""url"": ""https://dev.azure.com/FOO-ORG/FOO-TEAMPROJECT/_settings/work-team"",
-				""routeId"": ""ms.vss-admin-web.project-admin-hub-route"",
-				""routeValues"": {{
-					""project"": ""{teamProject}"",
-					""adminPivot"": ""work-team"",
-					""controller"": ""ContributedPage"",
-					""action"": ""Execute"",
-					""serviceHost"": ""{orgId} ({orgName})""
-				}}
-			}}
-		}}
-	}}
-}}";
-            payload = JObject.Parse(payload).ToString();
+            var payload = new
+            {
+                contributionIds = new[]
+                {
+                    "ms.vss-work-web.azure-boards-external-connection-data-provider"
+                },
+                dataProviderContext = new
+                {
+                    properties = new
+                    {
+                        includeInvalidConnections = false,
+                        sourcePage = new
+                        {
+                            url = $"https://dev.azure.com/{orgName}/{teamProject}/_settings/work-team",
+                            routeId = "ms.vss-admin-web.project-admin-hub-route",
+                            routeValues = new
+                            {
+                                project = teamProject,
+                                adminPivot = "work-team",
+                                controller = "ContributedPage",
+                                action = "Execute",
+                                serviceHost = $"{orgId} ({orgName})"
+                            }
+                        }
+                    }
+                }
+            };
 
             var connectionId = "foo-id";
             var endpointId = "foo-endpoint-id";
@@ -264,7 +357,7 @@ namespace OctoshiftCLI.Tests
 
             var mockClient = new Mock<AdoClient>(null, null);
 
-            mockClient.Setup(x => x.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result).Returns(json);
+            mockClient.Setup(x => x.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result).Returns(json);
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.GetBoardsGithubConnection("FOO-ORG", "FOO-ORGID", "FOO-TEAMPROJECT");
@@ -287,28 +380,34 @@ namespace OctoshiftCLI.Tests
 
             var endpoint = $"https://dev.azure.com/{orgName}/{teamProjectId}/_apis/serviceendpoint/endpoints?api-version=5.0-preview.1";
 
-            var payload = $@"
-{{
-    ""type"": ""githubboards"",
-    ""url"": ""http://github.com"",
-    ""authorization"": {{
-        ""scheme"": ""PersonalAccessToken"",
-        ""parameters"": {{
-            ""accessToken"": ""{githubToken}""
-        }}
-    }},
-    ""data"": {{
-        ""GitHubHandle"": ""{githubHandle}""
-    }},
-    ""name"": ""{endpointName}""
-}}";
+            var payload = new
+            {
+                type = "githubboards",
+                url = "http://github.com",
+                authorization = new
+                {
+                    scheme = "PersonalAccessToken",
+                    parameters = new
+                    {
+                        accessToken = githubToken
+                    }
+                },
+                data = new
+                {
+                    GitHubHandle = githubHandle
+                },
+                name = endpointName
+            };
 
-            payload = JObject.Parse(payload).ToString();
             var endpointId = "foo-id";
-            var json = $"{{id: '{endpointId}', name: 'something'}}";
+            var json = new
+            {
+                id = endpointId,
+                name = "something"
+            };
 
             var mockClient = new Mock<AdoClient>(null, null);
-            mockClient.Setup(x => x.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result).Returns(json);
+            mockClient.Setup(x => x.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result).Returns(json.ToJson());
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.CreateBoardsGithubEndpoint(orgName, teamProjectId, githubToken, githubHandle, endpointName);
@@ -330,43 +429,52 @@ namespace OctoshiftCLI.Tests
 
             var endpoint = $"https://dev.azure.com/{orgName}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
-            var payload = $@"
-{{
-	""contributionIds"": [""ms.vss-work-web.azure-boards-save-external-connection-data-provider""],
-	""dataProviderContext"": {{
-		""properties"": {{
-			""externalConnection"": {{
-				""serviceEndpointId"": ""{endpointId}"",
-				""connectionName"": ""{connectionName}"",
-				""connectionId"": ""{connectionId}"",
-				""operation"": 1,
-                ""externalRepositoryExternalIds"": [
-                    ""{repo1}"",""{repo2}""
-                ],
-				""providerKey"": ""github.com"",
-				""isGitHubApp"": false
-			}},
-			""sourcePage"": {{
-				""url"": ""https://dev.azure.com/{orgName}/{teamProject}/_settings/boards-external-integration"",
-				""routeId"": ""ms.vss-admin-web.project-admin-hub-route"",
-				""routeValues"": {{
-					""project"": ""{teamProject}"",
-					""adminPivot"": ""boards-external-integration"",
-					""controller"": ""ContributedPage"",
-					""action"": ""Execute"",
-					""serviceHost"": ""{orgId} ({orgName})""
-				}}
-			}}
-		}}
-	}}
-}}";
+            var payload = new
+            {
+                contributionIds = new[]
+                {
+                    "ms.vss-work-web.azure-boards-save-external-connection-data-provider"
+                },
+                dataProviderContext = new
+                {
+                    properties = new
+                    {
+                        externalConnection = new
+                        {
+                            serviceEndpointId = endpointId,
+                            connectionName,
+                            connectionId,
+                            operation = 1,
+                            externalRepositoryExternalIds = new[]
+                            {
+                                repo1,
+                                repo2
+                            },
+                            providerKey = "github.com",
+                            isGitHubApp = false
+                        },
+                        sourcePage = new
+                        {
+                            url = $"https://dev.azure.com/{orgName}/{teamProject}/_settings/boards-external-integration",
+                            routeId = "ms.vss-admin-web.project-admin-hub-route",
+                            routeValues = new
+                            {
+                                project = teamProject,
+                                adminPivot = "boards-external-integration",
+                                controller = "ContributedPage",
+                                action = "Execute",
+                                serviceHost = $"{orgId} ({orgName})"
+                            }
+                        }
+                    }
+                }
+            };
 
-            payload = JObject.Parse(payload).ToString();
             var mockClient = new Mock<AdoClient>(null, null);
             var sut = new AdoApi(mockClient.Object);
             await sut.AddRepoToBoardsGithubConnection(orgName, orgId, teamProject, connectionId, connectionName, endpointId, new List<string>() { repo1, repo2 });
 
-            mockClient.Verify(m => m.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result);
+            mockClient.Verify(m => m.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result);
         }
 
         [Fact]
@@ -377,10 +485,10 @@ namespace OctoshiftCLI.Tests
             var teamProjectId = Guid.NewGuid().ToString();
 
             var endpoint = $"https://dev.azure.com/{org}/_apis/projects/{teamProject}?api-version=5.0-preview.1";
-            var response = $"{{id: '{teamProjectId}'}}";
+            var response = new { id = teamProjectId };
 
             var mockClient = new Mock<AdoClient>(null, null);
-            mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(response);
+            mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(response.ToJson());
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.GetTeamProjectId(org, teamProject);
@@ -397,10 +505,10 @@ namespace OctoshiftCLI.Tests
             var repoId = Guid.NewGuid().ToString();
 
             var endpoint = $"https://dev.azure.com/{org}/{teamProject}/_apis/git/repositories/{repo}?api-version=4.1";
-            var response = $"{{id: '{repoId}'}}";
+            var response = new { id = repoId };
 
             var mockClient = new Mock<AdoClient>(null, null);
-            mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(response);
+            mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(response.ToJson());
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.GetRepoId(org, teamProject, repo);
@@ -418,10 +526,21 @@ namespace OctoshiftCLI.Tests
             var pipeline2 = "foo-pipe-2";
 
             var endpoint = $"https://dev.azure.com/{org}/{teamProject}/_apis/build/definitions?repositoryId={repoId}&repositoryType=TfsGit";
-            var response = $"[{{id: 'whatever', name: '{pipeline1}'}}, {{name: '{pipeline2}'}}]";
+            var response = new object[]
+            {
+                new
+                {
+                    id = "whatever",
+                    name = pipeline1
+                },
+                new
+                {
+                    name = pipeline2
+                }
+            };
 
             var mockClient = new Mock<AdoClient>(null, null);
-            mockClient.Setup(x => x.GetWithPagingAsync(endpoint).Result).Returns(JArray.Parse(response));
+            mockClient.Setup(x => x.GetWithPagingAsync(endpoint).Result).Returns(JArray.Parse(response.ToJson()));
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.GetPipelines(org, teamProject, repoId);
@@ -439,10 +558,22 @@ namespace OctoshiftCLI.Tests
             var pipelineId = 36383;
 
             var endpoint = $"https://dev.azure.com/{org}/{teamProject}/_apis/build/definitions";
-            var response = $"[ {{id: '123', name: 'wrong'}}, {{ id: '{pipelineId}', name: '{pipeline.ToUpper()}'}} ]";
+            var response = new object[]
+            {
+                new
+                {
+                    id = 123,
+                    name = "wrong"
+                },
+                new
+                {
+                    id = pipelineId,
+                    name = pipeline.ToUpper()
+                }
+            };
 
             var mockClient = new Mock<AdoClient>(null, null);
-            mockClient.Setup(x => x.GetWithPagingAsync(endpoint).Result).Returns(JArray.Parse(response));
+            mockClient.Setup(x => x.GetWithPagingAsync(endpoint).Result).Returns(JArray.Parse(response.ToJson()));
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.GetPipelineId(org, teamProject, pipeline);
@@ -460,21 +591,24 @@ namespace OctoshiftCLI.Tests
 
             var endpoint = $"https://dev.azure.com/{org}/_apis/serviceendpoint/endpoints/{serviceConnectionId}?api-version=6.0-preview.4";
 
-            var payload = $@"
-[{{
-    ""name"": ""{org}-{teamProject}"",
-	""projectReference"": {{
-        ""id"": ""{teamProjectId}"",
-		""name"": ""{teamProject}""
-    }}
-}}]";
+            var payload = new[]
+            {
+                new
+                {
+                    name = $"{org}-{teamProject}",
+                    projectReference = new
+                    {
+                        id = teamProjectId,
+                        name = teamProject
+                    }
+                }
+            };
 
-            payload = JArray.Parse(payload).ToString();
             var mockClient = new Mock<AdoClient>(null, null);
             var sut = new AdoApi(mockClient.Object);
             await sut.ShareServiceConnection(org, teamProject, teamProjectId, serviceConnectionId);
 
-            mockClient.Verify(m => m.PatchAsync(endpoint, It.Is<string>(y => JArray.Parse(y).ToString() == payload)));
+            mockClient.Verify(m => m.PatchAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())));
         }
 
         [Fact]
@@ -488,17 +622,25 @@ namespace OctoshiftCLI.Tests
             var clean = "True";
 
             var endpoint = $"https://dev.azure.com/{org}/{teamProject}/_apis/build/definitions/{pipelineId}?api-version=6.0";
-            var response = $"{{ repository: {{ defaultBranch: '{defaultBranch}', clean: '{clean}', checkoutSubmodules: null }} }}";
+            var response = new
+            {
+                repository = new
+                {
+                    defaultBranch,
+                    clean,
+                    checkoutSubmodules = default(object)
+                }
+            };
 
             var mockClient = new Mock<AdoClient>(null, null);
-            mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(response);
+            mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(response.ToJson());
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.GetPipeline(org, teamProject, pipelineId);
 
-            result.DefaultBranch.Should().Be(branchName);
-            result.Clean.Should().Be("true");
-            result.CheckoutSubmodules.Should().Be("null");
+            result.defaultBranch.Should().Be(branchName);
+            result.clean.Should().Be("true");
+            result.checkoutSubmodules.Should().Be("null");
         }
 
         [Fact]
@@ -510,71 +652,70 @@ namespace OctoshiftCLI.Tests
             var teamProject = "foo-tp";
             var serviceConnectionId = Guid.NewGuid().ToString();
             var defaultBranch = "foo-branch";
+            var pipelineId = 123;
+            var clean = "true";
+            var checkoutSubmodules = "false";
 
-            var pipeline = new AdoPipeline
+            var oldJson = new
             {
-                Id = 123,
-                Org = org,
-                TeamProject = teamProject,
-                DefaultBranch = defaultBranch,
-                Clean = "true",
-                CheckoutSubmodules = "false",
+                something = "foo",
+                somethingElse = new
+                {
+                    blah = "foo",
+                    repository = "blah"
+                },
+                repository = new
+                {
+                    testing = true,
+                    moreTesting = default(string)
+                },
+                oneLastThing = false
             };
 
-            var oldJson = $@"
-{{
-    ""something"": ""foo"",
-    ""somethingElse"": {{
-        ""blah"": ""foo"",
-        ""repository"": ""blah""
-    }},
-    ""repository"": {{
-        ""testing"": true,
-        ""moreTesting"": null
-    }},
-    ""oneLastThing"": false
-}}";
+            var endpoint = $"https://dev.azure.com/{org}/{teamProject}/_apis/build/definitions/{pipelineId}?api-version=6.0";
 
-            var endpoint = $"https://dev.azure.com/{org}/{teamProject}/_apis/build/definitions/{pipeline.Id}?api-version=6.0";
-
-            var newJson = $@"{{
-  ""something"": ""foo"",
-  ""somethingElse"": {{
-    ""blah"": ""foo"",
-    ""repository"": ""blah""
-  }},
-  ""repository"": {{
-    ""properties"": {{
-      ""apiUrl"": ""https://api.github.com/repos/{githubOrg}/{githubRepo}"",
-      ""branchesUrl"": ""https://api.github.com/repos/{githubOrg}/{githubRepo}/branches"",
-      ""cloneUrl"": ""https://github.com/{githubOrg}/{githubRepo}.git"",
-      ""connectedServiceId"": ""{serviceConnectionId}"",
-      ""defaultBranch"": ""{defaultBranch}"",
-      ""fullName"": ""{githubOrg}/{githubRepo}"",
-      ""manageUrl"": ""https://github.com/{githubOrg}/{githubRepo}"",
-      ""orgName"": ""{githubOrg}"",
-      ""refsUrl"": ""https://api.github.com/repos/{githubOrg}/{githubRepo}/git/refs"",
-      ""safeRepository"": ""{githubOrg}/{githubRepo}"",
-      ""shortName"": ""{githubRepo}"",
-      ""reportBuildStatus"": ""true""
-    }},
-    ""id"": ""{githubOrg}/{githubRepo}"",
-    ""type"": ""GitHub"",
-    ""name"": ""{githubOrg}/{githubRepo}"",
-    ""url"": ""https://github.com/{githubOrg}/{githubRepo}.git"",
-    ""defaultBranch"": ""{defaultBranch}"",
-    ""clean"": true,
-    ""checkoutSubmodules"": false
-  }},
-  ""oneLastThing"": false
-}}";
+            var newJson = new
+            {
+                something = "foo",
+                somethingElse = new
+                {
+                    blah = "foo",
+                    repository = "blah"
+                },
+                repository = new
+                {
+                    properties = new
+                    {
+                        apiUrl = $"https://api.github.com/repos/{githubOrg}/{githubRepo}",
+                        branchesUrl = $"https://api.github.com/repos/{githubOrg}/{githubRepo}/branches",
+                        cloneUrl = $"https://github.com/{githubOrg}/{githubRepo}.git",
+                        connectedServiceId = serviceConnectionId,
+                        defaultBranch,
+                        fullName = $"{githubOrg}/{githubRepo}",
+                        manageUrl = $"https://github.com/{githubOrg}/{githubRepo}",
+                        orgName = githubOrg,
+                        refsUrl = $"https://api.github.com/repos/{githubOrg}/{githubRepo}/git/refs",
+                        safeRepository = $"{githubOrg}/{githubRepo}",
+                        shortName = githubRepo,
+                        reportBuildStatus = true
+                    },
+                    id = $"{githubOrg}/{githubRepo}",
+                    type = "GitHub",
+                    name = $"{githubOrg}/{githubRepo}",
+                    url = $"https://github.com/{githubOrg}/{githubRepo}.git",
+                    defaultBranch,
+                    clean,
+                    checkoutSubmodules
+                },
+                oneLastThing = false
+            };
 
             var mockClient = new Mock<AdoClient>(null, null);
-            mockClient.Setup(m => m.GetAsync(endpoint).Result).Returns(oldJson);
+            mockClient.Setup(m => m.GetAsync(endpoint).Result).Returns(oldJson.ToJson());
             var sut = new AdoApi(mockClient.Object);
-            await sut.ChangePipelineRepo(pipeline, githubOrg, githubRepo, serviceConnectionId);
+            await sut.ChangePipelineRepo(org, teamProject, pipelineId, defaultBranch, clean, checkoutSubmodules, githubOrg, githubRepo, serviceConnectionId);
 
-            mockClient.Verify(m => m.PutAsync(endpoint, JObject.Parse(newJson).ToString()));
+            mockClient.Verify(m => m.PutAsync(endpoint, It.Is<object>(y => y.ToJson() == newJson.ToJson())));
         }
 
         [Fact]
@@ -590,37 +731,41 @@ namespace OctoshiftCLI.Tests
 
             var endpoint = $"https://dev.azure.com/{orgName}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
-            var payload = $@"
-{{
-    ""contributionIds"": [
-        ""ms.vss-work-web.github-user-repository-data-provider""
-    ],
-    ""dataProviderContext"": {{
-        ""properties"": {{
-            ""projectId"": ""{teamProjectId}"",
-            ""repoWithOwnerName"": ""{githubOrg}/{githubRepo}"",
-            ""serviceEndpointId"": ""{endpointId}"",
-            ""sourcePage"": {{
-                ""url"": ""https://dev.azure.com/{orgName}/{teamProject}/_settings/boards-external-integration#"",
-                ""routeId"": ""ms.vss-admin-web.project-admin-hub-route"",
-                ""routeValues"": {{
-                    ""project"": ""{teamProject}"",
-                    ""adminPivot"": ""boards-external-integration"",
-                    ""controller"": ""ContributedPage"",
-                    ""action"": ""Execute"",
-                    ""serviceHost"": ""{orgId} ({orgName})""
-                }}
-            }}
-        }}
-    }}
-}}";
+            var payload = new
+            {
+                contributionIds = new[]
+                {
+                    "ms.vss-work-web.github-user-repository-data-provider"
+                },
+                dataProviderContext = new
+                {
+                    properties = new
+                    {
+                        projectId = teamProjectId,
+                        repoWithOwnerName = $"{githubOrg}/{githubRepo}",
+                        serviceEndpointId = endpointId,
+                        sourcePage = new
+                        {
+                            url = $"https://dev.azure.com/{orgName}/{teamProject}/_settings/boards-external-integration#",
+                            routeId = "ms.vss-admin-web.project-admin-hub-route",
+                            routeValues = new
+                            {
+                                project = teamProject,
+                                adminPivot = "boards-external-integration",
+                                controller = "ContributedPage",
+                                action = "Execute",
+                                serviceHost = $"{orgId} ({orgName})"
+                            }
+                        }
+                    }
+                }
+            };
 
-            payload = JObject.Parse(payload).ToString();
             var repoId = Guid.NewGuid().ToString();
             var json = $@"{{dataProviders: {{ ""ms.vss-work-web.github-user-repository-data-provider"": {{ additionalProperties: {{ nodeId: '{repoId}' }} }} }} }}";
 
             var mockClient = new Mock<AdoClient>(null, null);
-            mockClient.Setup(x => x.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result).Returns(json);
+            mockClient.Setup(x => x.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result).Returns(json);
 
             var sut = new AdoApi(mockClient.Object);
             var result = await sut.GetBoardsGithubRepoId(orgName, orgId, teamProject, teamProjectId, endpointId, githubOrg, githubRepo);
@@ -639,44 +784,50 @@ namespace OctoshiftCLI.Tests
 
             var endpoint = $"https://dev.azure.com/{orgName}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
-            var payload = $@"
-{{
-    ""contributionIds"": [
-        ""ms.vss-work-web.azure-boards-save-external-connection-data-provider""
-    ],
-    ""dataProviderContext"": {{
-        ""properties"": {{
-            ""externalConnection"": {{
-                ""serviceEndpointId"": ""{endpointId}"",
-                ""operation"": 0,
-                ""externalRepositoryExternalIds"": [
-                    ""{repoId}""
-                ],
-                ""providerKey"": ""github.com"",
-                ""isGitHubApp"": false
-            }},
-            ""sourcePage"": {{
-                ""url"": ""https://dev.azure.com/{orgName}/{teamProject}/_settings/boards-external-integration#"",
-                ""routeId"": ""ms.vss-admin-web.project-admin-hub-route"",
-                ""routeValues"": {{
-                    ""project"": ""{teamProject}"",
-                    ""adminPivot"": ""boards-external-integration"",
-                    ""controller"": ""ContributedPage"",
-                    ""action"": ""Execute"",
-                    ""serviceHost"": ""{orgId} ({orgName})""
-                }}
-            }}
-        }}
-    }}
-}}";
+            var payload = new
+            {
+                contributionIds = new[]
+                {
+                    "ms.vss-work-web.azure-boards-save-external-connection-data-provider"
+                },
+                dataProviderContext = new
+                {
+                    properties = new
+                    {
+                        externalConnection = new
+                        {
+                            serviceEndpointId = endpointId,
+                            operation = 0,
+                            externalRepositoryExternalIds = new[]
+                            {
+                                repoId
+                            },
+                            providerKey = "github.com",
+                            isGitHubApp = false
+                        },
+                        sourcePage = new
+                        {
+                            url = $"https://dev.azure.com/{orgName}/{teamProject}/_settings/boards-external-integration#",
+                            routeId = "ms.vss-admin-web.project-admin-hub-route",
+                            routeValues = new
+                            {
+                                project = teamProject,
+                                adminPivot = "boards-external-integration",
+                                controller = "ContributedPage",
+                                action = "Execute",
+                                serviceHost = $"{orgId} ({orgName})"
+                            }
+                        }
+                    }
+                }
+            };
 
-            payload = JObject.Parse(payload).ToString();
             var mockClient = new Mock<AdoClient>(null, null);
 
             var sut = new AdoApi(mockClient.Object);
             await sut.CreateBoardsGithubConnection(orgName, orgId, teamProject, endpointId, repoId);
 
-            mockClient.Verify(m => m.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result);
+            mockClient.Verify(m => m.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result);
         }
 
         [Fact]
@@ -692,10 +843,9 @@ namespace OctoshiftCLI.Tests
             var sut = new AdoApi(mockClient.Object);
             await sut.DisableRepo(orgName, teamProject, repoId);
 
-            var payload = @"{ ""isDisabled"": true }";
-            payload = JObject.Parse(payload).ToString();
+            var payload = new { isDisabled = true };
 
-            mockClient.Verify(m => m.PatchAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result);
+            mockClient.Verify(m => m.PatchAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result);
         }
 
         [Fact]
@@ -730,32 +880,33 @@ namespace OctoshiftCLI.Tests
 
             var endpoint = $"https://dev.azure.com/{orgName}/_apis/accesscontrolentries/{gitReposNamespace}?api-version=6.1-preview.1";
 
-            var payload = $@"
-{{
-  ""token"": ""repoV2/{teamProjectId}/{repoId}"",
-  ""merge"": true,
-  ""accessControlEntries"": [
-    {{
-      ""descriptor"": ""{identityDescriptor}"",
-      ""allow"": 0,
-      ""deny"": 56828,
-      ""extendedInfo"": {{
-        ""effectiveAllow"": 0,
-        ""effectiveDeny"": 56828,
-        ""inheritedAllow"": 0,
-        ""inheritedDeny"": 56828
-      }}
-    }}
-  ]
-}}
-";
+            var payload = new
+            {
+                token = $"repoV2/{teamProjectId}/{repoId}",
+                merge = true,
+                accessControlEntries = new[]
+                {
+                    new
+                    {
+                        descriptor = identityDescriptor,
+                        allow = 0,
+                        deny = 56828,
+                        extendedInfo = new
+                        {
+                            effectiveAllow = 0,
+                            effectiveDeny = 56828,
+                            inheritedAllow = 0,
+                            inheritedDeny = 56828
+                        }
+                    }
+                }
+            };
 
-            payload = JObject.Parse(payload).ToString();
             var mockClient = new Mock<AdoClient>(null, null);
             var sut = new AdoApi(mockClient.Object);
             await sut.LockRepo(orgName, teamProjectId, repoId, identityDescriptor);
 
-            mockClient.Verify(m => m.PostAsync(endpoint, It.Is<string>(y => JObject.Parse(y).ToString() == payload)).Result);
+            mockClient.Verify(m => m.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result);
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/AdoApiTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoApiTests.cs
@@ -636,11 +636,11 @@ namespace OctoshiftCLI.Tests
             mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(response.ToJson());
 
             var sut = new AdoApi(mockClient.Object);
-            var result = await sut.GetPipeline(org, teamProject, pipelineId);
+            var (DefaultBranch, Clean, CheckoutSubmodules) = await sut.GetPipeline(org, teamProject, pipelineId);
 
-            result.defaultBranch.Should().Be(branchName);
-            result.clean.Should().Be("true");
-            result.checkoutSubmodules.Should().Be("null");
+            DefaultBranch.Should().Be(branchName);
+            Clean.Should().Be("true");
+            CheckoutSubmodules.Should().Be("null");
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh.Commands/RewirePipelineCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh.Commands/RewirePipelineCommandTests.cs
@@ -35,16 +35,18 @@ namespace OctoshiftCLI.Tests.ado2gh.Commands
             var githubRepo = "foo-repo";
             var serviceConnectionId = Guid.NewGuid().ToString();
             var pipelineId = 1234;
-            var pipeline = new AdoPipeline();
+            var defaultBranch = "default-branch";
+            var clean = "true";
+            var checkoutSubmodules = "null";
 
             var mockAdo = new Mock<AdoApi>(null);
             mockAdo.Setup(x => x.GetPipelineId(adoOrg, adoTeamProject, adoPipeline).Result).Returns(pipelineId);
-            mockAdo.Setup(x => x.GetPipeline(adoOrg, adoTeamProject, pipelineId).Result).Returns(pipeline);
+            mockAdo.Setup(x => x.GetPipeline(adoOrg, adoTeamProject, pipelineId).Result).Returns((defaultBranch, clean, checkoutSubmodules));
 
             var command = new RewirePipelineCommand(new Mock<OctoLogger>().Object, new Lazy<AdoApi>(mockAdo.Object));
             await command.Invoke(adoOrg, adoTeamProject, adoPipeline, githubOrg, githubRepo, serviceConnectionId);
 
-            mockAdo.Verify(x => x.ChangePipelineRepo(pipeline, githubOrg, githubRepo, serviceConnectionId));
+            mockAdo.Verify(x => x.ChangePipelineRepo(adoOrg, adoTeamProject, pipelineId, defaultBranch, clean, checkoutSubmodules, githubOrg, githubRepo, serviceConnectionId));
         }
     }
 }

--- a/src/ado2gh/Commands/RewirePipelineCommand.cs
+++ b/src/ado2gh/Commands/RewirePipelineCommand.cs
@@ -72,8 +72,8 @@ namespace OctoshiftCLI.ado2gh.Commands
             var ado = _lazyAdoApi.Value;
 
             var adoPipelineId = await ado.GetPipelineId(adoOrg, adoTeamProject, adoPipeline);
-            var pipeline = await ado.GetPipeline(adoOrg, adoTeamProject, adoPipelineId);
-            await ado.ChangePipelineRepo(adoOrg, adoTeamProject, adoPipelineId, pipeline.defaultBranch, pipeline.clean, pipeline.checkoutSubmodules, githubOrg, githubRepo, serviceConnectionId);
+            var (defaultBranch, clean, checkoutSubmodules) = await ado.GetPipeline(adoOrg, adoTeamProject, adoPipelineId);
+            await ado.ChangePipelineRepo(adoOrg, adoTeamProject, adoPipelineId, defaultBranch, clean, checkoutSubmodules, githubOrg, githubRepo, serviceConnectionId);
 
             _log.LogSuccess("Successfully rewired pipeline");
         }

--- a/src/ado2gh/Commands/RewirePipelineCommand.cs
+++ b/src/ado2gh/Commands/RewirePipelineCommand.cs
@@ -72,8 +72,8 @@ namespace OctoshiftCLI.ado2gh.Commands
             var ado = _lazyAdoApi.Value;
 
             var adoPipelineId = await ado.GetPipelineId(adoOrg, adoTeamProject, adoPipeline);
-            var pipelineDetails = await ado.GetPipeline(adoOrg, adoTeamProject, adoPipelineId);
-            await ado.ChangePipelineRepo(pipelineDetails, githubOrg, githubRepo, serviceConnectionId);
+            var pipeline = await ado.GetPipeline(adoOrg, adoTeamProject, adoPipelineId);
+            await ado.ChangePipelineRepo(adoOrg, adoTeamProject, adoPipelineId, pipeline.defaultBranch, pipeline.clean, pipeline.checkoutSubmodules, githubOrg, githubRepo, serviceConnectionId);
 
             _log.LogSuccess("Successfully rewired pipeline");
         }

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -39,7 +39,7 @@ namespace OctoshiftCLI.gei
 
         private static Parser BuildParser(ServiceProvider serviceProvider)
         {
-            var root = new RootCommand("Automate end-to-end Azure DevOps Repos to GitHub migrations.");
+            var root = new RootCommand("CLI for GitHub Enterprise Importer.");
             var commandLineBuilder = new CommandLineBuilder(root);
 
             foreach (var command in serviceProvider.GetServices<Command>())


### PR DESCRIPTION
Updating AdoApi to use the anonymous object approach instead of giant JSON strings (like was done in GithubApi already). This will make the code cleaner, and also the unit tests will be more robust because they aren't tied to very specific string/format implementation.

#114 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked