### PR TITLE
add --ssh option

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,3 +3,4 @@
 - Renamed the CLI from octoshift to ado2gh to indicate that this one is specifically for Azure DevOps -> GitHub migrations (in the future there will be additional CLI's for other migration scenarios)
 - Released gei.exe that adds support for Github -> Github migrations (GHEC only for now). In the future this will be exposed as an extension to the Github CLI.
 - Automatically remove secrets from log files and console output (previously the verbose logs would contain your PAT's)
+- Added --ssh option to generate-script and migrate-repo commands (in both ado2gh and gei). This forces the migration to use an older version of the API's that uses SSH to push the repos into GitHub. The newer API's use HTTPS instead. However some customers have been running into problems with some repos that work fine using the older SSH API's. In the future this option will be deprecated once the issues with the HTTPS-based API's are resolved.

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -114,7 +114,7 @@ namespace OctoshiftCLI
             return (string)data["data"]["organization"]["id"];
         }
 
-        public virtual async Task<string> CreateAdoMigrationSource(string orgId, string adoToken, string githubPat)
+        public virtual async Task<string> CreateAdoMigrationSource(string orgId, string adoToken, string githubPat, bool ssh = false)
         {
             var url = $"https://api.github.com/graphql";
 
@@ -131,7 +131,7 @@ namespace OctoshiftCLI
                     ownerId = orgId,
                     type = "AZURE_DEVOPS",
                     accessToken = adoToken,
-                    githubPat
+                    githubPat = !ssh ? githubPat : null
                 },
                 operationName = "createMigrationSource"
             };
@@ -142,34 +142,7 @@ namespace OctoshiftCLI
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
 
-        public virtual async Task<string> CreateAdoMigrationSourceSsh(string orgId, string adoToken)
-        {
-            var url = $"https://api.github.com/graphql";
-
-            var query = "mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $accessToken: String!, $type: MigrationSourceType!)";
-            var gql = "createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, accessToken: $accessToken, type: $type}) { migrationSource { id, name, url, type } }";
-
-            var payload = new
-            {
-                query = $"{query} {{ {gql} }}",
-                variables = new
-                {
-                    name = "Azure DevOps Source",
-                    url = "https://dev.azure.com",
-                    ownerId = orgId,
-                    type = "AZURE_DEVOPS",
-                    accessToken = adoToken
-                },
-                operationName = "createMigrationSource"
-            };
-
-            var response = await _client.PostAsync(url, payload);
-            var data = JObject.Parse(response);
-
-            return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
-        }
-
-        public virtual async Task<string> CreateGhecMigrationSource(string orgId, string githubPat)
+        public virtual async Task<string> CreateGhecMigrationSource(string orgId, string githubPat, bool ssh = false)
         {
             var url = $"https://api.github.com/graphql";
 
@@ -186,34 +159,7 @@ namespace OctoshiftCLI
                     ownerId = orgId,
                     type = "GITHUB_ARCHIVE",
                     accessToken = githubPat,
-                    githubPat
-                },
-                operationName = "createMigrationSource"
-            };
-
-            var response = await _client.PostAsync(url, payload);
-            var data = JObject.Parse(response);
-
-            return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
-        }
-
-        public virtual async Task<string> CreateGhecMigrationSourceSsh(string orgId, string githubPat)
-        {
-            var url = $"https://api.github.com/graphql";
-
-            var query = "mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $accessToken: String!, $type: MigrationSourceType!)";
-            var gql = "createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, accessToken: $accessToken, type: $type}) { migrationSource { id, name, url, type } }";
-
-            var payload = new
-            {
-                query = $"{query} {{ {gql} }}",
-                variables = new
-                {
-                    name = "GHEC Source",
-                    url = "https://github.com",
-                    ownerId = orgId,
-                    type = "GITHUB_ARCHIVE",
-                    accessToken = githubPat
+                    githubPat = !ssh ? githubPat : null
                 },
                 operationName = "createMigrationSource"
             };

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -142,6 +142,33 @@ namespace OctoshiftCLI
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
 
+        public virtual async Task<string> CreateAdoMigrationSourceSsh(string orgId, string adoToken)
+        {
+            var url = $"https://api.github.com/graphql";
+
+            var query = "mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $accessToken: String!, $type: MigrationSourceType!)";
+            var gql = "createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, accessToken: $accessToken, type: $type}) { migrationSource { id, name, url, type } }";
+
+            var payload = new
+            {
+                query = $"{query} {{ {gql} }}",
+                variables = new
+                {
+                    name = "Azure DevOps Source",
+                    url = "https://dev.azure.com",
+                    ownerId = orgId,
+                    type = "AZURE_DEVOPS",
+                    accessToken = adoToken
+                },
+                operationName = "createMigrationSource"
+            };
+
+            var response = await _client.PostAsync(url, payload);
+            var data = JObject.Parse(response);
+
+            return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
+        }
+
         public virtual async Task<string> CreateGhecMigrationSource(string orgId, string githubPat)
         {
             var url = $"https://api.github.com/graphql";
@@ -160,6 +187,33 @@ namespace OctoshiftCLI
                     type = "GITHUB_ARCHIVE",
                     accessToken = githubPat,
                     githubPat
+                },
+                operationName = "createMigrationSource"
+            };
+
+            var response = await _client.PostAsync(url, payload);
+            var data = JObject.Parse(response);
+
+            return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
+        }
+
+        public virtual async Task<string> CreateGhecMigrationSourceSsh(string orgId, string githubPat)
+        {
+            var url = $"https://api.github.com/graphql";
+
+            var query = "mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $accessToken: String!, $type: MigrationSourceType!)";
+            var gql = "createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, accessToken: $accessToken, type: $type}) { migrationSource { id, name, url, type } }";
+
+            var payload = new
+            {
+                query = $"{query} {{ {gql} }}",
+                variables = new
+                {
+                    name = "GHEC Source",
+                    url = "https://github.com",
+                    ownerId = orgId,
+                    type = "GITHUB_ARCHIVE",
+                    accessToken = githubPat
                 },
                 operationName = "createMigrationSource"
             };

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -244,7 +244,7 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task CreateADOMigrationSource_Returns_New_Migration_Source_Id()
+        public async Task CreateAdoMigrationSource_Returns_New_Migration_Source_Id()
         {
             // Arrange
             const string url = "https://api.github.com/graphql";
@@ -284,7 +284,7 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task CreateADOMigrationSource_Using_SSH()
+        public async Task CreateAdoMigrationSource_Using_Ssh()
         {
             // Arrange
             const string url = "https://api.github.com/graphql";
@@ -324,7 +324,7 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task CreateGHECMigrationSource_Returns_New_Migration_Source_Id()
+        public async Task CreateGhecMigrationSource_Returns_New_Migration_Source_Id()
         {
             // Arrange
             const string url = "https://api.github.com/graphql";
@@ -363,7 +363,7 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task CreateGHECMigrationSource_With_Ssh()
+        public async Task CreateGhecMigrationSource_Using_Ssh()
         {
             // Arrange
             const string url = "https://api.github.com/graphql";

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -284,6 +284,46 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task CreateADOMigrationSource_Using_SSH()
+        {
+            // Arrange
+            const string url = "https://api.github.com/graphql";
+            const string orgId = "ORG_ID";
+            const string adoToken = "ADO_TOKEN";
+            const string githubPat = "GITHUB_PAT";
+            var payload =
+                "{\"query\":\"mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $accessToken: String!, $type: MigrationSourceType!, $githubPat: String!) " +
+                "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, accessToken: $accessToken, type: $type, githubPat: $githubPat}) { migrationSource { id, name, url, type } } }\"" +
+                $",\"variables\":{{\"name\":\"Azure DevOps Source\",\"url\":\"https://dev.azure.com\",\"ownerId\":\"{orgId}\",\"type\":\"AZURE_DEVOPS\",\"accessToken\":\"{adoToken}\",\"githubPat\":null}},\"operationName\":\"createMigrationSource\"}}";
+            const string actualMigrationSourceId = "MS_kgC4NjFhOTVjOTc4ZTRhZjEwMDA5NjNhOTdm";
+            var response = $@"
+            {{
+                ""data"": {{
+                    ""createMigrationSource"": {{
+                        ""migrationSource"": {{
+                            ""id"": ""{actualMigrationSourceId}"",
+                            ""name"": ""Azure Devops Source"",
+                            ""url"": ""https://dev.azure.com"",
+                            ""type"": ""AZURE_DEVOPS""
+                        }}
+                    }}
+                }}
+            }}";
+
+            var githubClientMock = new Mock<GithubClient>(null, null);
+            githubClientMock
+                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
+                .ReturnsAsync(response);
+
+            // Act
+            var githubApi = new GithubApi(githubClientMock.Object);
+            var expectedMigrationSourceId = await githubApi.CreateAdoMigrationSource(orgId, adoToken, githubPat, true);
+
+            // Assert
+            expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
+        }
+
+        [Fact]
         public async Task CreateGHECMigrationSource_Returns_New_Migration_Source_Id()
         {
             // Arrange
@@ -317,6 +357,45 @@ namespace OctoshiftCLI.Tests
             // Act
             var githubApi = new GithubApi(githubClientMock.Object);
             var expectedMigrationSourceId = await githubApi.CreateGhecMigrationSource(orgId, githubPat);
+
+            // Assert
+            expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
+        }
+
+        [Fact]
+        public async Task CreateGHECMigrationSource_With_Ssh()
+        {
+            // Arrange
+            const string url = "https://api.github.com/graphql";
+            const string orgId = "ORG_ID";
+            const string githubPat = "GITHUB_PAT";
+            var payload =
+                "{\"query\":\"mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $accessToken: String!, $type: MigrationSourceType!, $githubPat: String!) " +
+                "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, accessToken: $accessToken, type: $type, githubPat: $githubPat}) { migrationSource { id, name, url, type } } }\"" +
+                $",\"variables\":{{\"name\":\"GHEC Source\",\"url\":\"https://github.com\",\"ownerId\":\"{orgId}\",\"type\":\"GITHUB_ARCHIVE\",\"accessToken\":\"{githubPat}\",\"githubPat\":null}},\"operationName\":\"createMigrationSource\"}}";
+            const string actualMigrationSourceId = "MS_kgC4NjFhOTVjOTc4ZTRhZjEwMDA5NjNhOTdm";
+            var response = $@"
+            {{
+                ""data"": {{
+                    ""createMigrationSource"": {{
+                        ""migrationSource"": {{
+                            ""id"": ""{actualMigrationSourceId}"",
+                            ""name"": ""GHEC Source"",
+                            ""url"": ""https://github.com"",
+                            ""type"": ""GITHUB_ARCHIVE""
+                        }}
+                    }}
+                }}
+            }}";
+
+            var githubClientMock = new Mock<GithubClient>(null, null);
+            githubClientMock
+                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
+                .ReturnsAsync(response);
+
+            // Act
+            var githubApi = new GithubApi(githubClientMock.Object);
+            var expectedMigrationSourceId = await githubApi.CreateGhecMigrationSource(orgId, githubPat, true);
 
             // Assert
             expectedMigrationSourceId.Should().Be(actualMigrationSourceId);

--- a/src/OctoshiftCLI.Tests/ado2gh.Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh.Commands/GenerateScriptCommandTests.cs
@@ -250,6 +250,34 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         }
 
         [Fact]
+        public void Single_Repo_Repos_Only_With_Ssh()
+        {
+            var githubOrg = "foo-gh-org";
+            var adoOrg = "foo-ado-org";
+            var adoTeamProject = "foo-team-project";
+            var repo = "foo-repo";
+
+            var repos = new Dictionary<string, IDictionary<string, IEnumerable<string>>>
+            {
+                { adoOrg, new Dictionary<string, IEnumerable<string>>() }
+            };
+
+            repos[adoOrg].Add(adoTeamProject, new List<string>() { repo });
+
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
+            var reposOnlyField = typeof(GenerateScriptCommand).GetField("_reposOnly", BindingFlags.Instance | BindingFlags.NonPublic);
+            reposOnlyField.SetValue(command, true);
+
+            var script = command.GenerateScript(repos, null, null, githubOrg, false, true);
+
+            script = TrimNonExecutableLines(script);
+
+            var expected = $"./ado2gh migrate-repo --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{repo}\" --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\" --ssh";
+
+            Assert.Equal(expected, script);
+        }
+
+        [Fact]
         public void Single_Repo_Skip_Idp()
         {
             var githubOrg = "foo-gh-org";

--- a/src/OctoshiftCLI.Tests/ado2gh.Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh.Commands/GenerateScriptCommandTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using OctoshiftCLI.AdoToGithub.Commands;
 using Xunit;
@@ -15,15 +16,16 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         public void Should_Have_Options()
         {
             var command = new GenerateScriptCommand(null, null);
-            Assert.NotNull(command);
-            Assert.Equal("generate-script", command.Name);
-            Assert.Equal(6, command.Options.Count);
+            command.Should().NotBeNull();
+            command.Name.Should().Be("generate-script");
+            command.Options.Count.Should().Be(7);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-org", false);
             TestHelpers.VerifyCommandOption(command.Options, "output", false);
             TestHelpers.VerifyCommandOption(command.Options, "repos-only", false);
             TestHelpers.VerifyCommandOption(command.Options, "skip-idp", false);
+            TestHelpers.VerifyCommandOption(command.Options, "ssh", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -33,7 +35,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var githubOrg = "foo-gh-org";
 
             var command = new GenerateScriptCommand(null, null);
-            var script = command.GenerateScript(null, null, null, githubOrg, false);
+            var script = command.GenerateScript(null, null, null, githubOrg, false, false);
 
             Assert.True(string.IsNullOrWhiteSpace(script));
         }
@@ -54,7 +56,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             repos[adoOrg].Add(adoTeamProject, new List<string>() { repo });
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var script = command.GenerateScript(repos, null, null, githubOrg, false);
+            var script = command.GenerateScript(repos, null, null, githubOrg, false, false);
 
             script = TrimNonExecutableLines(script);
 
@@ -94,7 +96,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             repos[adoOrg].Add(adoTeamProject, new List<string>());
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var script = command.GenerateScript(repos, null, null, githubOrg, false);
+            var script = command.GenerateScript(repos, null, null, githubOrg, false, false);
 
             script = TrimNonExecutableLines(script);
 
@@ -133,7 +135,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var script = command.GenerateScript(repos, pipelines, appIds, githubOrg, false);
+            var script = command.GenerateScript(repos, pipelines, appIds, githubOrg, false, false);
 
             script = TrimNonExecutableLines(script);
 
@@ -192,7 +194,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var appIds = new Dictionary<string, string>();
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var script = command.GenerateScript(repos, pipelines, appIds, githubOrg, false);
+            var script = command.GenerateScript(repos, pipelines, appIds, githubOrg, false, false);
 
             script = TrimNonExecutableLines(script);
 
@@ -238,7 +240,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var reposOnlyField = typeof(GenerateScriptCommand).GetField("_reposOnly", BindingFlags.Instance | BindingFlags.NonPublic);
             reposOnlyField.SetValue(command, true);
 
-            var script = command.GenerateScript(repos, null, null, githubOrg, false);
+            var script = command.GenerateScript(repos, null, null, githubOrg, false, false);
 
             script = TrimNonExecutableLines(script);
 
@@ -263,7 +265,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             repos[adoOrg].Add(adoTeamProject, new List<string>() { repo });
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var script = command.GenerateScript(repos, null, null, githubOrg, true);
+            var script = command.GenerateScript(repos, null, null, githubOrg, true, false);
 
             script = TrimNonExecutableLines(script);
 

--- a/src/OctoshiftCLI.Tests/ado2gh.Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh.Commands/MigrateRepoCommandTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using OctoshiftCLI.AdoToGithub.Commands;
 using Xunit;
@@ -12,15 +13,16 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         public void Should_Have_Options()
         {
             var command = new MigrateRepoCommand(null, null, null);
-            Assert.NotNull(command);
-            Assert.Equal("migrate-repo", command.Name);
-            Assert.Equal(6, command.Options.Count);
+            command.Should().NotBeNull();
+            command.Name.Should().Be("migrate-repo");
+            command.Options.Count.Should().Be(7);
 
             TestHelpers.VerifyCommandOption(command.Options, "ado-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-repo", true);
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "github-repo", true);
+            TestHelpers.VerifyCommandOption(command.Options, "ssh", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 

--- a/src/OctoshiftCLI.Tests/ado2gh.Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh.Commands/MigrateRepoCommandTests.cs
@@ -43,7 +43,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             var mockGithub = new Mock<GithubApi>(null);
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat, false).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo).Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
@@ -79,7 +79,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             var mockGithub = new Mock<GithubApi>(null);
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateAdoMigrationSourceSsh(githubOrgId, adoToken).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat, true).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo).Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 

--- a/src/OctoshiftCLI.Tests/ado2gh.Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh.Commands/MigrateRepoCommandTests.cs
@@ -61,5 +61,41 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             mockGithub.Verify(x => x.GetMigrationState(migrationId));
         }
+
+        [Fact]
+        public async Task With_Ssh()
+        {
+            var adoOrg = "FooOrg";
+            var adoTeamProject = "BlahTeamProject";
+            var adoRepo = "foo-repo";
+            var githubOrg = "foo-gh-org";
+            var githubRepo = "gh-repo";
+            var adoRepoUrl = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_git/{adoRepo}";
+            var adoToken = Guid.NewGuid().ToString();
+            var githubOrgId = Guid.NewGuid().ToString();
+            var migrationSourceId = Guid.NewGuid().ToString();
+            var migrationId = Guid.NewGuid().ToString();
+            var githubPat = Guid.NewGuid().ToString();
+
+            var mockGithub = new Mock<GithubApi>(null);
+            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.CreateAdoMigrationSourceSsh(githubOrgId, adoToken).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo).Result).Returns(migrationId);
+            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
+
+            var environmentVariableProviderMock = new Mock<OctoshiftCLI.AdoToGithub.EnvironmentVariableProvider>(null);
+            environmentVariableProviderMock
+                .Setup(m => m.GithubPersonalAccessToken())
+                .Returns(githubPat);
+            environmentVariableProviderMock
+                .Setup(m => m.AdoPersonalAccessToken())
+                .Returns(adoToken);
+
+            var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, new Lazy<GithubApi>(mockGithub.Object),
+                environmentVariableProviderMock.Object);
+            await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, true);
+
+            mockGithub.Verify(x => x.GetMigrationState(migrationId));
+        }
     }
 }

--- a/src/OctoshiftCLI.Tests/gei.Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei.Commands/GenerateScriptCommandTests.cs
@@ -80,7 +80,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         }
 
         [Fact]
-        public void With_SSH()
+        public void With_Ssh()
         {
             var githubSourceOrg = "foo-source";
             var githubTargetOrg = "foo-target";

--- a/src/OctoshiftCLI.Tests/gei.Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei.Commands/GenerateScriptCommandTests.cs
@@ -17,11 +17,12 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             command.Should().NotBeNull();
             command.Name.Should().Be("generate-script");
-            command.Options.Count.Should().Be(4);
+            command.Options.Count.Should().Be(5);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-source-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "github-target-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "output", false);
+            TestHelpers.VerifyCommandOption(command.Options, "ssh", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -29,7 +30,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         public void No_Data()
         {
             var command = new GenerateScriptCommand(null, null);
-            var script = command.GenerateScript(null, "foo-source", "foo-target");
+            var script = command.GenerateScript(null, "foo-source", "foo-target", false);
 
             string.IsNullOrWhiteSpace(script).Should().BeTrue();
         }
@@ -44,7 +45,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var repos = new List<string>() { repo };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var script = command.GenerateScript(repos, githubSourceOrg, githubTargetOrg);
+            var script = command.GenerateScript(repos, githubSourceOrg, githubTargetOrg, false);
 
             script = TrimNonExecutableLines(script);
 
@@ -65,7 +66,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var repos = new List<string>() { repo1, repo2, repo3 };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var script = command.GenerateScript(repos, githubSourceOrg, githubTargetOrg);
+            var script = command.GenerateScript(repos, githubSourceOrg, githubTargetOrg, false);
 
             script = TrimNonExecutableLines(script);
 

--- a/src/OctoshiftCLI.Tests/gei.Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei.Commands/GenerateScriptCommandTests.cs
@@ -79,6 +79,24 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             script.Should().Be(expected);
         }
 
+        [Fact]
+        public void With_SSH()
+        {
+            var githubSourceOrg = "foo-source";
+            var githubTargetOrg = "foo-target";
+            var repo = "foo-repo";
+
+            var repos = new List<string>() { repo };
+
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
+            var script = command.GenerateScript(repos, githubSourceOrg, githubTargetOrg, true);
+
+            script = TrimNonExecutableLines(script);
+
+            var expected = $"./gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\" --ssh";
+
+            script.Should().Be(expected);
+        }
 
         private string TrimNonExecutableLines(string script)
         {

--- a/src/OctoshiftCLI.Tests/gei.Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei.Commands/MigrateRepoCommandTests.cs
@@ -15,12 +15,13 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var command = new MigrateRepoCommand(null, null, null);
             command.Should().NotBeNull();
             command.Name.Should().Be("migrate-repo");
-            command.Options.Count.Should().Be(5);
+            command.Options.Count.Should().Be(6);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-source-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "source-repo", true);
             TestHelpers.VerifyCommandOption(command.Options, "github-target-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "target-repo", false);
+            TestHelpers.VerifyCommandOption(command.Options, "ssh", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 

--- a/src/OctoshiftCLI.Tests/gei.Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei.Commands/MigrateRepoCommandTests.cs
@@ -41,7 +41,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = new Mock<GithubApi>(null);
             mockGithub.Setup(x => x.GetOrganizationId(githubTargetOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, githubPat).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, githubPat, false).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, targetRepo).Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
@@ -72,7 +72,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = new Mock<GithubApi>(null);
             mockGithub.Setup(x => x.GetOrganizationId(githubTargetOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSourceSsh(githubOrgId, githubPat).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, githubPat, true).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, targetRepo).Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 

--- a/src/ado2gh/Commands/MigrateRepoCommand.cs
+++ b/src/ado2gh/Commands/MigrateRepoCommand.cs
@@ -42,6 +42,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = true
             };
+            var ssh = new Option("--ssh")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -52,12 +56,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(adoRepo);
             AddOption(githubOrg);
             AddOption(githubRepo);
+            AddOption(ssh);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, string, bool, bool>(Invoke);
         }
 
-        public async Task Invoke(string adoOrg, string adoTeamProject, string adoRepo, string githubOrg, string githubRepo, bool verbose = false)
+        public async Task Invoke(string adoOrg, string adoTeamProject, string adoRepo, string githubOrg, string githubRepo, bool ssh = false, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -67,6 +72,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log.LogInformation($"ADO REPO: {adoRepo}");
             _log.LogInformation($"GITHUB ORG: {githubOrg}");
             _log.LogInformation($"GITHUB REPO: {githubRepo}");
+            if (ssh)
+            {
+                _log.LogInformation("SSH: true");
+            }
 
             var adoRepoUrl = GetAdoRepoUrl(adoOrg, adoTeamProject, adoRepo);
 
@@ -74,7 +83,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             var githubPat = _environmentVariableProvider.GithubPersonalAccessToken();
             var githubApi = _lazyGithubApi.Value;
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
-            var migrationSourceId = await githubApi.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat);
+            var migrationSourceId = ssh ? await githubApi.CreateAdoMigrationSourceSsh(githubOrgId, adoToken)
+                                        : await githubApi.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat);
             var migrationId = await githubApi.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo);
 
             var migrationState = await githubApi.GetMigrationState(migrationId);

--- a/src/ado2gh/Commands/MigrateRepoCommand.cs
+++ b/src/ado2gh/Commands/MigrateRepoCommand.cs
@@ -83,8 +83,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             var githubPat = _environmentVariableProvider.GithubPersonalAccessToken();
             var githubApi = _lazyGithubApi.Value;
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
-            var migrationSourceId = ssh ? await githubApi.CreateAdoMigrationSourceSsh(githubOrgId, adoToken)
-                                        : await githubApi.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat);
+            var migrationSourceId = await githubApi.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat, ssh);
             var migrationId = await githubApi.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo);
 
             var migrationState = await githubApi.GetMigrationState(migrationId);

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -35,6 +35,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 IsRequired = false
             };
+            var ssh = new Option("--ssh")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -44,12 +48,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(sourceRepo);
             AddOption(githubTargetOrg);
             AddOption(targetRepo);
+            AddOption(ssh);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, bool, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubSourceOrg, string sourceRepo, string githubTargetOrg, string targetRepo, bool verbose = false)
+        public async Task Invoke(string githubSourceOrg, string sourceRepo, string githubTargetOrg, string targetRepo, bool ssh = false, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -58,6 +63,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             _log.LogInformation($"SOURCE REPO: {sourceRepo}");
             _log.LogInformation($"GITHUB TARGET ORG: {githubTargetOrg}");
             _log.LogInformation($"TARGET REPO: {targetRepo}");
+            if (ssh)
+            {
+                _log.LogInformation("SSH: true");
+            }
 
             if (string.IsNullOrWhiteSpace(targetRepo))
             {
@@ -70,7 +79,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var githubApi = _lazyGithubApi.Value;
             var githubPat = _environmentVariableProvider.GithubPersonalAccessToken();
             var githubOrgId = await githubApi.GetOrganizationId(githubTargetOrg);
-            var migrationSourceId = await githubApi.CreateGhecMigrationSource(githubOrgId, githubPat);
+            var migrationSourceId = ssh ? await githubApi.CreateGhecMigrationSourceSsh(githubOrgId, githubPat)
+                                        : await githubApi.CreateGhecMigrationSource(githubOrgId, githubPat);
             var migrationId = await githubApi.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, targetRepo);
 
             var migrationState = await githubApi.GetMigrationState(migrationId);

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -79,8 +79,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var githubApi = _lazyGithubApi.Value;
             var githubPat = _environmentVariableProvider.GithubPersonalAccessToken();
             var githubOrgId = await githubApi.GetOrganizationId(githubTargetOrg);
-            var migrationSourceId = ssh ? await githubApi.CreateGhecMigrationSourceSsh(githubOrgId, githubPat)
-                                        : await githubApi.CreateGhecMigrationSource(githubOrgId, githubPat);
+            var migrationSourceId = await githubApi.CreateGhecMigrationSource(githubOrgId, githubPat, ssh);
             var migrationId = await githubApi.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, targetRepo);
 
             var migrationState = await githubApi.GetMigrationState(migrationId);

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -39,7 +39,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
         private static Parser BuildParser(ServiceProvider serviceProvider)
         {
-            var root = new RootCommand("Automate end-to-end Azure DevOps Repos to GitHub migrations.");
+            var root = new RootCommand("CLI for GitHub Enterprise Importer.");
             var commandLineBuilder = new CommandLineBuilder(root);
 
             foreach (var command in serviceProvider.GetServices<Command>())


### PR DESCRIPTION
#193 

Adds --ssh flag to generate-script and migrate-repo command in both ado2gh and gei.

When provided this flag forces the use of the old API schema (for CreateMigrationSource) which uses SSH instead of HTTPS.

In the future this flag can hopefully be removed once we've worked all the kinks out of the HTTPS migration flow.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked