### PR TITLE
Add support for source and target github pats

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,4 +4,3 @@
 - Released gei.exe that adds support for Github -> Github migrations (GHEC only for now). In the future this will be exposed as an extension to the Github CLI.
 - Automatically remove secrets from log files and console output (previously the verbose logs would contain your PAT's)
 - Added --ssh option to generate-script and migrate-repo commands (in both ado2gh and gei). This forces the migration to use an older version of the API's that uses SSH to push the repos into GitHub. The newer API's use HTTPS instead. However some customers have been running into problems with some repos that work fine using the older SSH API's. In the future this option will be deprecated once the issues with the HTTPS-based API's are resolved.
-- gei.exe can now optionally use GH_SOURCE_PAT for source.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,3 +4,4 @@
 - Released gei.exe that adds support for Github -> Github migrations (GHEC only for now). In the future this will be exposed as an extension to the Github CLI.
 - Automatically remove secrets from log files and console output (previously the verbose logs would contain your PAT's)
 - Added --ssh option to generate-script and migrate-repo commands (in both ado2gh and gei). This forces the migration to use an older version of the API's that uses SSH to push the repos into GitHub. The newer API's use HTTPS instead. However some customers have been running into problems with some repos that work fine using the older SSH API's. In the future this option will be deprecated once the issues with the HTTPS-based API's are resolved.
+- gei.exe can now optionally use GH_SOURCE_PAT for source.

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -142,7 +142,7 @@ namespace OctoshiftCLI
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
 
-        public virtual async Task<string> CreateGhecMigrationSource(string orgId, string githubPat, bool ssh = false)
+        public virtual async Task<string> CreateGhecMigrationSource(string orgId, string sourceGithubPat, string targetGithubPat, bool ssh = false)
         {
             var url = $"https://api.github.com/graphql";
 
@@ -158,8 +158,8 @@ namespace OctoshiftCLI
                     url = "https://github.com",
                     ownerId = orgId,
                     type = "GITHUB_ARCHIVE",
-                    accessToken = githubPat,
-                    githubPat = !ssh ? githubPat : null
+                    accessToken = sourceGithubPat,
+                    githubPat = !ssh ? targetGithubPat : null
                 },
                 operationName = "createMigrationSource"
             };

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -16,10 +16,13 @@ namespace OctoshiftCLI
             _log = log;
             _httpClient = httpClient;
 
-            _httpClient.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
-            _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OctoshiftCLI", "0.1"));
-            _httpClient.DefaultRequestHeaders.Add("GraphQL-Features", "import_api");
-            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", personalAccessToken);
+            if (_httpClient != null)
+            {
+                _httpClient.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+                _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OctoshiftCLI", "0.1"));
+                _httpClient.DefaultRequestHeaders.Add("GraphQL-Features", "import_api");
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", personalAccessToken);
+            }
         }
 
         public virtual async Task<string> GetAsync(string url) => await SendAsync(HttpMethod.Get, url);

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using OctoshiftCLI.Extensions;
 
@@ -10,10 +11,15 @@ namespace OctoshiftCLI
         private readonly HttpClient _httpClient;
         private readonly OctoLogger _log;
 
-        public GithubClient(OctoLogger log, HttpClient httpClient)
+        public GithubClient(OctoLogger log, HttpClient httpClient, string personalAccessToken)
         {
             _log = log;
             _httpClient = httpClient;
+
+            _httpClient.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+            _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OctoshiftCLI", "0.1"));
+            _httpClient.DefaultRequestHeaders.Add("GraphQL-Features", "import_api");
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", personalAccessToken);
         }
 
         public virtual async Task<string> GetAsync(string url) => await SendAsync(HttpMethod.Get, url);

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -197,7 +197,7 @@ namespace OctoshiftCLI.Tests
             var url = $"https://api.github.com/orgs/{org}/teams/{teamName}/repos/{org}/{repo}";
             var payload = new { permission = role };
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object);
@@ -310,7 +310,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -350,7 +350,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -390,7 +390,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -439,7 +439,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -479,7 +479,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -518,7 +518,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -556,7 +556,7 @@ namespace OctoshiftCLI.Tests
                 ]
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.GetAsync(url))
                 .ReturnsAsync(response);
@@ -596,7 +596,7 @@ namespace OctoshiftCLI.Tests
               }}
             ]";
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.GetAsync(url))
                 .ReturnsAsync(response);
@@ -620,7 +620,7 @@ namespace OctoshiftCLI.Tests
             var url = $"https://api.github.com/orgs/{org}/teams/{teamSlug}/external-groups";
             var payload = new { group_id = groupId };
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object);
@@ -654,7 +654,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -682,7 +682,7 @@ namespace OctoshiftCLI.Tests
                 $",\"variables\":{{\"organizationId\":\"{org}\",\"actor\":\"{actor}\",\"actor_type\":\"{actorType}\"}}," +
                 "\"operationName\":\"grantMigratorRole\"}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .Throws<HttpRequestException>();
@@ -719,7 +719,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -747,7 +747,7 @@ namespace OctoshiftCLI.Tests
                 $",\"variables\":{{\"organizationId\":\"{org}\",\"actor\":\"{actor}\",\"actor_type\":\"{actorType}\"}}," +
                 "\"operationName\":\"revokeMigratorRole\"}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null, null);;
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .Throws<HttpRequestException>();

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -26,7 +26,7 @@ namespace OctoshiftCLI.Tests
                 url_template = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/"
             };
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object);
@@ -49,7 +49,7 @@ namespace OctoshiftCLI.Tests
             const string teamId = "TEAM_ID";
             var response = $"{{\"id\": \"{teamId}\"}}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())))
                 .ReturnsAsync(response);
@@ -84,7 +84,7 @@ namespace OctoshiftCLI.Tests
                 }}
             ]";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.GetAsync(url))
                 .ReturnsAsync(response);
@@ -107,7 +107,7 @@ namespace OctoshiftCLI.Tests
 
             var url = $"https://api.github.com/orgs/{org}/teams/{teamName}/memberships/{member}";
 
-            var githubClinetMock = new Mock<GithubClient>(null, null);
+            var githubClinetMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClinetMock.Setup(m => m.DeleteAsync(url));
 
             // Act
@@ -144,7 +144,7 @@ namespace OctoshiftCLI.Tests
                 ]
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.GetAsync(url))
                 .ReturnsAsync(response);
@@ -175,7 +175,7 @@ namespace OctoshiftCLI.Tests
                 groups = new[] { new { group_id = groupId, group_name = groupName, group_description = groupDesc } }
             };
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object);
@@ -197,7 +197,7 @@ namespace OctoshiftCLI.Tests
             var url = $"https://api.github.com/orgs/{org}/teams/{teamName}/repos/{org}/{repo}";
             var payload = new { permission = role };
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object);
@@ -230,7 +230,7 @@ namespace OctoshiftCLI.Tests
                     }} 
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -270,7 +270,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -310,7 +310,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -329,11 +329,12 @@ namespace OctoshiftCLI.Tests
             // Arrange
             const string url = "https://api.github.com/graphql";
             const string orgId = "ORG_ID";
-            const string githubPat = "GITHUB_PAT";
+            const string sourceGithubPat = "SOURCE_GITHUB_PAT";
+            const string targetGithubPat = "TARGET_GITHUB_PAT";
             var payload =
                 "{\"query\":\"mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $accessToken: String!, $type: MigrationSourceType!, $githubPat: String!) " +
                 "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, accessToken: $accessToken, type: $type, githubPat: $githubPat}) { migrationSource { id, name, url, type } } }\"" +
-                $",\"variables\":{{\"name\":\"GHEC Source\",\"url\":\"https://github.com\",\"ownerId\":\"{orgId}\",\"type\":\"GITHUB_ARCHIVE\",\"accessToken\":\"{githubPat}\",\"githubPat\":\"{githubPat}\"}},\"operationName\":\"createMigrationSource\"}}";
+                $",\"variables\":{{\"name\":\"GHEC Source\",\"url\":\"https://github.com\",\"ownerId\":\"{orgId}\",\"type\":\"GITHUB_ARCHIVE\",\"accessToken\":\"{sourceGithubPat}\",\"githubPat\":\"{targetGithubPat}\"}},\"operationName\":\"createMigrationSource\"}}";
             const string actualMigrationSourceId = "MS_kgC4NjFhOTVjOTc4ZTRhZjEwMDA5NjNhOTdm";
             var response = $@"
             {{
@@ -349,14 +350,14 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object);
-            var expectedMigrationSourceId = await githubApi.CreateGhecMigrationSource(orgId, githubPat);
+            var expectedMigrationSourceId = await githubApi.CreateGhecMigrationSource(orgId, sourceGithubPat, targetGithubPat);
 
             // Assert
             expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
@@ -368,11 +369,12 @@ namespace OctoshiftCLI.Tests
             // Arrange
             const string url = "https://api.github.com/graphql";
             const string orgId = "ORG_ID";
-            const string githubPat = "GITHUB_PAT";
+            const string sourceGithubPat = "SOURCE_GITHUB_PAT";
+            const string targetGithubPat = "target_GITHUB_PAT";
             var payload =
                 "{\"query\":\"mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $accessToken: String!, $type: MigrationSourceType!, $githubPat: String!) " +
                 "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, accessToken: $accessToken, type: $type, githubPat: $githubPat}) { migrationSource { id, name, url, type } } }\"" +
-                $",\"variables\":{{\"name\":\"GHEC Source\",\"url\":\"https://github.com\",\"ownerId\":\"{orgId}\",\"type\":\"GITHUB_ARCHIVE\",\"accessToken\":\"{githubPat}\",\"githubPat\":null}},\"operationName\":\"createMigrationSource\"}}";
+                $",\"variables\":{{\"name\":\"GHEC Source\",\"url\":\"https://github.com\",\"ownerId\":\"{orgId}\",\"type\":\"GITHUB_ARCHIVE\",\"accessToken\":\"{sourceGithubPat}\",\"githubPat\":null}},\"operationName\":\"createMigrationSource\"}}";
             const string actualMigrationSourceId = "MS_kgC4NjFhOTVjOTc4ZTRhZjEwMDA5NjNhOTdm";
             var response = $@"
             {{
@@ -388,14 +390,14 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object);
-            var expectedMigrationSourceId = await githubApi.CreateGhecMigrationSource(orgId, githubPat, true);
+            var expectedMigrationSourceId = await githubApi.CreateGhecMigrationSource(orgId, sourceGithubPat, targetGithubPat, true);
 
             // Assert
             expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
@@ -437,7 +439,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -477,7 +479,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -516,7 +518,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -554,7 +556,7 @@ namespace OctoshiftCLI.Tests
                 ]
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.GetAsync(url))
                 .ReturnsAsync(response);
@@ -594,7 +596,7 @@ namespace OctoshiftCLI.Tests
               }}
             ]";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.GetAsync(url))
                 .ReturnsAsync(response);
@@ -618,7 +620,7 @@ namespace OctoshiftCLI.Tests
             var url = $"https://api.github.com/orgs/{org}/teams/{teamSlug}/external-groups";
             var payload = new { group_id = groupId };
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object);
@@ -652,7 +654,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -680,7 +682,7 @@ namespace OctoshiftCLI.Tests
                 $",\"variables\":{{\"organizationId\":\"{org}\",\"actor\":\"{actor}\",\"actor_type\":\"{actorType}\"}}," +
                 "\"operationName\":\"grantMigratorRole\"}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .Throws<HttpRequestException>();
@@ -717,7 +719,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -745,7 +747,7 @@ namespace OctoshiftCLI.Tests
                 $",\"variables\":{{\"organizationId\":\"{org}\",\"actor\":\"{actor}\",\"actor_type\":\"{actorType}\"}}," +
                 "\"operationName\":\"revokeMigratorRole\"}";
 
-            var githubClientMock = new Mock<GithubClient>(null, null);
+            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .Throws<HttpRequestException>();

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -26,7 +26,7 @@ namespace OctoshiftCLI.Tests
                 url_template = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/"
             };
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object);
@@ -49,7 +49,7 @@ namespace OctoshiftCLI.Tests
             const string teamId = "TEAM_ID";
             var response = $"{{\"id\": \"{teamId}\"}}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())))
                 .ReturnsAsync(response);
@@ -84,7 +84,7 @@ namespace OctoshiftCLI.Tests
                 }}
             ]";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.GetAsync(url))
                 .ReturnsAsync(response);
@@ -107,15 +107,15 @@ namespace OctoshiftCLI.Tests
 
             var url = $"https://api.github.com/orgs/{org}/teams/{teamName}/memberships/{member}";
 
-            var githubClinetMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
-            githubClinetMock.Setup(m => m.DeleteAsync(url));
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
+            githubClientMock.Setup(m => m.DeleteAsync(url));
 
             // Act
-            var githubApi = new GithubApi(githubClinetMock.Object);
+            var githubApi = new GithubApi(githubClientMock.Object);
             await githubApi.RemoveTeamMember(org, teamName, member);
 
             // Assert
-            githubClinetMock.Verify(m => m.DeleteAsync(url));
+            githubClientMock.Verify(m => m.DeleteAsync(url));
         }
 
         [Fact]
@@ -144,7 +144,7 @@ namespace OctoshiftCLI.Tests
                 ]
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.GetAsync(url))
                 .ReturnsAsync(response);
@@ -175,7 +175,7 @@ namespace OctoshiftCLI.Tests
                 groups = new[] { new { group_id = groupId, group_name = groupName, group_description = groupDesc } }
             };
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object);
@@ -197,7 +197,7 @@ namespace OctoshiftCLI.Tests
             var url = $"https://api.github.com/orgs/{org}/teams/{teamName}/repos/{org}/{repo}";
             var payload = new { permission = role };
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object);
@@ -230,7 +230,7 @@ namespace OctoshiftCLI.Tests
                     }} 
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -270,7 +270,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -310,7 +310,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -350,7 +350,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -390,7 +390,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -439,7 +439,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -479,7 +479,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -518,7 +518,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -556,7 +556,7 @@ namespace OctoshiftCLI.Tests
                 ]
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
             githubClientMock
                 .Setup(m => m.GetAsync(url))
                 .ReturnsAsync(response);
@@ -596,7 +596,7 @@ namespace OctoshiftCLI.Tests
               }}
             ]";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
             githubClientMock
                 .Setup(m => m.GetAsync(url))
                 .ReturnsAsync(response);
@@ -620,7 +620,7 @@ namespace OctoshiftCLI.Tests
             var url = $"https://api.github.com/orgs/{org}/teams/{teamSlug}/external-groups";
             var payload = new { group_id = groupId };
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object);
@@ -654,7 +654,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -682,7 +682,7 @@ namespace OctoshiftCLI.Tests
                 $",\"variables\":{{\"organizationId\":\"{org}\",\"actor\":\"{actor}\",\"actor_type\":\"{actorType}\"}}," +
                 "\"operationName\":\"grantMigratorRole\"}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .Throws<HttpRequestException>();
@@ -719,7 +719,7 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
@@ -747,7 +747,7 @@ namespace OctoshiftCLI.Tests
                 $",\"variables\":{{\"organizationId\":\"{org}\",\"actor\":\"{actor}\",\"actor_type\":\"{actorType}\"}}," +
                 "\"operationName\":\"revokeMigratorRole\"}";
 
-            var githubClientMock = new Mock<GithubClient>(null, new HttpClient(), "pat");
+            var githubClientMock = new Mock<GithubClient>(null, null, null);;
             githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .Throws<HttpRequestException>();

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -17,6 +17,7 @@ namespace OctoshiftCLI.Tests
         private readonly object _rawRequestBody;
         private const string EXPECTED_JSON_REQUEST_BODY = "{\"id\":\"ID\"}";
         private const string EXPECTED_RESPONSE_CONTENT = "RESPONSE_CONTENT";
+        private const string PERSONAL_ACCESS_TOKEN = "PERSONAL_ACCESS_TOKEN";
 
         public GithubClientTests()
         {
@@ -40,7 +41,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, null);
 
             // Act
             var actualContent = await githubClient.GetAsync("http://example.com");
@@ -55,7 +56,7 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForGet();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -76,7 +77,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP GET: {url}";
@@ -94,7 +95,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({HttpStatusCode.OK}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -124,7 +125,7 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+                    var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
                     return githubClient.GetAsync("http://example.com");
                 })
                 .Should()
@@ -136,7 +137,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var actualContent = await githubClient.PostAsync("http://example.com", _rawRequestBody);
@@ -151,7 +152,7 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForPost();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -172,7 +173,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP POST: {url}";
@@ -190,7 +191,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"HTTP BODY: {EXPECTED_JSON_REQUEST_BODY}";
 
@@ -207,7 +208,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -242,7 +243,7 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var githubClient = new GithubClient(loggerMock.Object, httpClient);
+                    var githubClient = new GithubClient(loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
                     return githubClient.PostAsync("http://example.com", _rawRequestBody);
                 })
                 .Should()
@@ -254,7 +255,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var actualContent = await githubClient.PutAsync("http://example.com", _rawRequestBody);
@@ -269,7 +270,7 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForPut();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -290,7 +291,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP PUT: {url}";
@@ -308,7 +309,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"HTTP BODY: {EXPECTED_JSON_REQUEST_BODY}";
 
@@ -325,7 +326,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -360,7 +361,7 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var githubClient = new GithubClient(loggerMock.Object, httpClient);
+                    var githubClient = new GithubClient(loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
                     return githubClient.PutAsync("http://example.com", _rawRequestBody);
                 })
                 .Should()
@@ -372,7 +373,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var actualContent = await githubClient.PatchAsync("http://example.com", _rawRequestBody);
@@ -387,7 +388,7 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForPatch();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -408,7 +409,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP PATCH: {url}";
@@ -426,7 +427,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"HTTP BODY: {EXPECTED_JSON_REQUEST_BODY}";
 
@@ -443,7 +444,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -478,7 +479,7 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var githubClient = new GithubClient(loggerMock.Object, httpClient);
+                    var githubClient = new GithubClient(loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
                     return githubClient.PatchAsync("http://example.com", _rawRequestBody);
                 })
                 .Should()
@@ -490,7 +491,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var actualContent = await githubClient.DeleteAsync("http://example.com");
@@ -505,7 +506,7 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForDelete();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -526,7 +527,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP DELETE: {url}";
@@ -544,7 +545,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
-            var githubClient = new GithubClient(_loggerMock.Object, httpClient);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({HttpStatusCode.OK}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -576,7 +577,7 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var githubClient = new GithubClient(loggerMock.Object, httpClient);
+                    var githubClient = new GithubClient(loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
                     return githubClient.DeleteAsync("http://example.com");
                 })
                 .Should()

--- a/src/OctoshiftCLI.Tests/TestHelpers.cs
+++ b/src/OctoshiftCLI.Tests/TestHelpers.cs
@@ -11,7 +11,7 @@ namespace OctoshiftCLI.Tests
     public static class TestHelpers
     {
         #region  Constructor, Member variables and misc. helpers
-        private static readonly GithubClient _client = new GithubClient(new Mock<OctoLogger>().Object, null);
+        private static readonly GithubClient _client = new GithubClient(new Mock<OctoLogger>().Object, null, null);
         private const string TARGET_PREFIX = "OCLI-Int";
 
         internal static string GetTargetName(string targetType)

--- a/src/OctoshiftCLI.Tests/gei.Commands/EnvironmentVariableProviderTests.cs
+++ b/src/OctoshiftCLI.Tests/gei.Commands/EnvironmentVariableProviderTests.cs
@@ -1,0 +1,77 @@
+using System;
+using FluentAssertions;
+using Moq;
+using OctoshiftCLI.GithubEnterpriseImporter;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
+{
+    public class EnvironmentVariableProviderTests
+    {
+        private const string SOURCE_GH_PAT = "SOURCE_GH_PAT";
+        private const string TARGET_GH_PAT = "TARGET_GH_PAT";
+
+        private readonly EnvironmentVariableProvider _environmentVariableProvider;
+
+        public EnvironmentVariableProviderTests()
+        {
+            _environmentVariableProvider = new EnvironmentVariableProvider(new Mock<OctoLogger>().Object);
+        }
+
+        [Fact]
+        public void SourceGithubPersonalAccessToken_Should_Return_Github_Source_Pat()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("GH_SOURCE_PAT", SOURCE_GH_PAT);
+
+            // Act
+            var result = _environmentVariableProvider.SourceGithubPersonalAccessToken();
+
+            // Assert
+            result.Should().Be(SOURCE_GH_PAT);
+        }
+
+        [Fact]
+        public void SourceGithubPersonalAccessToken_Throws_If_Github_Source_And_Target_Pats_Are_Not_Set()
+        {
+            // Act, Assert
+            _environmentVariableProvider.Invoking(env => env.SourceGithubPersonalAccessToken())
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void SourceGithubPersonalAccessToken_Falls_Back_To_Github_Target_Pat_If_Github_Source_Pat_Is_Not_Set()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("GH_PAT", TARGET_GH_PAT);
+
+            // Act
+            var result = _environmentVariableProvider.SourceGithubPersonalAccessToken();
+
+            // Assert
+            Environment.GetEnvironmentVariable("GH_SOURCE_PAT").Should().BeNull();
+            result.Should().Be(TARGET_GH_PAT);
+        }
+
+        [Fact]
+        public void TargetGithubPersonalAccessToken_Should_Return_Github_Target_Pat()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("GH_PAT", TARGET_GH_PAT);
+
+            // Act
+            var result = _environmentVariableProvider.TargetGithubPersonalAccessToken();
+
+            // Assert
+            result.Should().Be(TARGET_GH_PAT);
+        }
+
+        [Fact]
+        public void TargetGithubPersonalAccessToken_Throws_If_Github_Source_Pat_Is_Not_Set()
+        {
+            // Act, Assert
+            _environmentVariableProvider.Invoking(env => env.TargetGithubPersonalAccessToken())
+                .Should().Throw<ArgumentNullException>();
+        }
+    }
+}

--- a/src/OctoshiftCLI.Tests/gei.Commands/EnvironmentVariableProviderTests.cs
+++ b/src/OctoshiftCLI.Tests/gei.Commands/EnvironmentVariableProviderTests.cs
@@ -23,6 +23,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         {
             // Arrange
             Environment.SetEnvironmentVariable("GH_SOURCE_PAT", SOURCE_GH_PAT);
+            Environment.SetEnvironmentVariable("GH_PAT", null);
 
             // Act
             var result = _environmentVariableProvider.SourceGithubPersonalAccessToken();
@@ -34,6 +35,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         [Fact]
         public void SourceGithubPersonalAccessToken_Throws_If_Github_Source_And_Target_Pats_Are_Not_Set()
         {
+            // Arrange
+            Environment.SetEnvironmentVariable("GH_SOURCE_PAT", null);
+            Environment.SetEnvironmentVariable("GH_PAT", null);
+
             // Act, Assert
             _environmentVariableProvider.Invoking(env => env.SourceGithubPersonalAccessToken())
                 .Should().Throw<ArgumentNullException>();
@@ -43,6 +48,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         public void SourceGithubPersonalAccessToken_Falls_Back_To_Github_Target_Pat_If_Github_Source_Pat_Is_Not_Set()
         {
             // Arrange
+            Environment.SetEnvironmentVariable("GH_SOURCE_PAT", null);
             Environment.SetEnvironmentVariable("GH_PAT", TARGET_GH_PAT);
 
             // Act
@@ -57,6 +63,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         public void TargetGithubPersonalAccessToken_Should_Return_Github_Target_Pat()
         {
             // Arrange
+            Environment.SetEnvironmentVariable("GH_SOURCE_PAT", null);
             Environment.SetEnvironmentVariable("GH_PAT", TARGET_GH_PAT);
 
             // Act
@@ -69,6 +76,9 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         [Fact]
         public void TargetGithubPersonalAccessToken_Throws_If_Github_Source_Pat_Is_Not_Set()
         {
+            Environment.SetEnvironmentVariable("GH_SOURCE_PAT", SOURCE_GH_PAT);
+            Environment.SetEnvironmentVariable("GH_PAT", null);
+
             // Act, Assert
             _environmentVariableProvider.Invoking(env => env.TargetGithubPersonalAccessToken())
                 .Should().Throw<ArgumentNullException>();

--- a/src/OctoshiftCLI.Tests/gei.Commands/GithubApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/gei.Commands/GithubApiFactoryTests.cs
@@ -1,0 +1,62 @@
+using System.Net.Http;
+using FluentAssertions;
+using Moq;
+using OctoshiftCLI.GithubEnterpriseImporter;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands;
+
+public class GithubApiFactoryTests
+{
+    private const string SOURCE_GH_PAT = "SOURCE_GH_PAT";
+    private const string TARGET_GH_PAT = "TARGET_GH_PAT";
+
+    private readonly OctoLogger _logger;
+
+    public GithubApiFactoryTests()
+    {
+        _logger = new Mock<OctoLogger>().Object;
+    }
+
+    [Fact]
+    public void GithubApiFactory_Should_Create_GithubApi_For_Source_Github_Api()
+    {
+        // Arrange
+        var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(_logger);
+        environmentVariableProviderMock
+            .Setup(m => m.SourceGithubPersonalAccessToken())
+            .Returns(SOURCE_GH_PAT);
+
+        using var httpClient = new HttpClient();
+
+        // Act
+        ISourceGithubApiFactory factory = new GithubApiFactory(_logger, httpClient, environmentVariableProviderMock.Object);
+        var githubApi = factory.Create();
+
+        // Assert
+        githubApi.Should().BeOfType<GithubApi>();
+        httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(SOURCE_GH_PAT);
+        httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
+    }
+
+    [Fact]
+    public void GithubApiFactory_Should_Create_GithubApi_For_Target_Github_Api()
+    {
+        // Arrange
+        var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(_logger);
+        environmentVariableProviderMock
+            .Setup(m => m.TargetGithubPersonalAccessToken())
+            .Returns(TARGET_GH_PAT);
+
+        using var httpClient = new HttpClient();
+
+        // Act
+        ITargetGithubApiFactory factory = new GithubApiFactory(_logger, httpClient, environmentVariableProviderMock.Object);
+        var githubApi = factory.Create();
+
+        // Assert
+        githubApi.Should().BeOfType<GithubApi>();
+        httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(TARGET_GH_PAT);
+        httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
+    }
+}

--- a/src/OctoshiftCLI.Tests/gei.Commands/GithubApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/gei.Commands/GithubApiFactoryTests.cs
@@ -4,59 +4,62 @@ using Moq;
 using OctoshiftCLI.GithubEnterpriseImporter;
 using Xunit;
 
-namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands;
-
-public class GithubApiFactoryTests
+namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 {
-    private const string SOURCE_GH_PAT = "SOURCE_GH_PAT";
-    private const string TARGET_GH_PAT = "TARGET_GH_PAT";
-
-    private readonly OctoLogger _logger;
-
-    public GithubApiFactoryTests()
+    public class GithubApiFactoryTests
     {
-        _logger = new Mock<OctoLogger>().Object;
-    }
+        private const string SOURCE_GH_PAT = "SOURCE_GH_PAT";
+        private const string TARGET_GH_PAT = "TARGET_GH_PAT";
 
-    [Fact]
-    public void GithubApiFactory_Should_Create_GithubApi_For_Source_Github_Api()
-    {
-        // Arrange
-        var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(_logger);
-        environmentVariableProviderMock
-            .Setup(m => m.SourceGithubPersonalAccessToken())
-            .Returns(SOURCE_GH_PAT);
+        private readonly OctoLogger _logger;
 
-        using var httpClient = new HttpClient();
+        public GithubApiFactoryTests()
+        {
+            _logger = new Mock<OctoLogger>().Object;
+        }
 
-        // Act
-        ISourceGithubApiFactory factory = new GithubApiFactory(_logger, httpClient, environmentVariableProviderMock.Object);
-        var githubApi = factory.Create();
+        [Fact]
+        public void GithubApiFactory_Should_Create_GithubApi_For_Source_Github_Api()
+        {
+            // Arrange
+            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(_logger);
+            environmentVariableProviderMock
+                .Setup(m => m.SourceGithubPersonalAccessToken())
+                .Returns(SOURCE_GH_PAT);
 
-        // Assert
-        githubApi.Should().BeOfType<GithubApi>();
-        httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(SOURCE_GH_PAT);
-        httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
-    }
+            using var httpClient = new HttpClient();
 
-    [Fact]
-    public void GithubApiFactory_Should_Create_GithubApi_For_Target_Github_Api()
-    {
-        // Arrange
-        var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(_logger);
-        environmentVariableProviderMock
-            .Setup(m => m.TargetGithubPersonalAccessToken())
-            .Returns(TARGET_GH_PAT);
+            // Act
+            ISourceGithubApiFactory factory =
+                new GithubApiFactory(_logger, httpClient, environmentVariableProviderMock.Object);
+            var githubApi = factory.Create();
 
-        using var httpClient = new HttpClient();
+            // Assert
+            githubApi.Should().BeOfType<GithubApi>();
+            httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(SOURCE_GH_PAT);
+            httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
+        }
 
-        // Act
-        ITargetGithubApiFactory factory = new GithubApiFactory(_logger, httpClient, environmentVariableProviderMock.Object);
-        var githubApi = factory.Create();
+        [Fact]
+        public void GithubApiFactory_Should_Create_GithubApi_For_Target_Github_Api()
+        {
+            // Arrange
+            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(_logger);
+            environmentVariableProviderMock
+                .Setup(m => m.TargetGithubPersonalAccessToken())
+                .Returns(TARGET_GH_PAT);
 
-        // Assert
-        githubApi.Should().BeOfType<GithubApi>();
-        httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(TARGET_GH_PAT);
-        httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
+            using var httpClient = new HttpClient();
+
+            // Act
+            ITargetGithubApiFactory factory =
+                new GithubApiFactory(_logger, httpClient, environmentVariableProviderMock.Object);
+            var githubApi = factory.Create();
+
+            // Assert
+            githubApi.Should().BeOfType<GithubApi>();
+            httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(TARGET_GH_PAT);
+            httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
+        }
     }
 }

--- a/src/OctoshiftCLI.Tests/gei.Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei.Commands/MigrateRepoCommandTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;

--- a/src/OctoshiftCLI.Tests/gei.Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei.Commands/MigrateRepoCommandTests.cs
@@ -59,7 +59,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Setup(m => m.SourceGithubPersonalAccessToken())
                 .Returns(sourceGithubPat);
             environmentVariableProviderMock
-                .Setup(m => m.TargetGitHubPersonalAccessToken())
+                .Setup(m => m.TargetGithubPersonalAccessToken())
                 .Returns(targetGithubPat);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
@@ -97,7 +97,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Setup(m => m.SourceGithubPersonalAccessToken())
                 .Returns(sourceGithubPat);
             environmentVariableProviderMock
-                .Setup(m => m.TargetGitHubPersonalAccessToken())
+                .Setup(m => m.TargetGithubPersonalAccessToken())
                 .Returns(targetGithubPat);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();

--- a/src/OctoshiftCLI.Tests/gei.Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei.Commands/MigrateRepoCommandTests.cs
@@ -63,8 +63,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Setup(m => m.TargetGitHubPersonalAccessToken())
                 .Returns(targetGithubPat);
 
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, new HttpClient(), environmentVariableProviderMock.Object);
-            mockGithubApiFactory.Setup(m => m.CreateTargetGithubClient()).Returns(mockGithub.Object);
+            var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
+            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
             await command.Invoke(githubSourceOrg, sourceRepo, githubTargetOrg, targetRepo);
@@ -101,8 +101,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Setup(m => m.TargetGitHubPersonalAccessToken())
                 .Returns(targetGithubPat);
 
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, new HttpClient(), environmentVariableProviderMock.Object);
-            mockGithubApiFactory.Setup(m => m.CreateTargetGithubClient()).Returns(mockGithub.Object);
+            var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
+            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
             await command.Invoke(githubSourceOrg, sourceRepo, githubTargetOrg, targetRepo, true);

--- a/src/ado2gh/Commands/AddTeamToRepoCommand.cs
+++ b/src/ado2gh/Commands/AddTeamToRepoCommand.cs
@@ -16,6 +16,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _lazyGithubApi = lazyGithubApi;
 
             Description = "Adds a team to a repo with a specific role/permission";
+            Description += Environment.NewLine;
+            Description += "Note: Expects GH_PAT env variable to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/ConfigureAutoLinkCommand.cs
+++ b/src/ado2gh/Commands/ConfigureAutoLinkCommand.cs
@@ -16,6 +16,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _lazyGithubApi = lazyGithubApi;
 
             Description = "Configures Autolink References in GitHub so that references to Azure Boards work items become hyperlinks in GitHub";
+            Description += Environment.NewLine;
+            Description += "Note: Expects GH_PAT env variable to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/CreateTeamCommand.cs
+++ b/src/ado2gh/Commands/CreateTeamCommand.cs
@@ -16,6 +16,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _lazyGithubApi = lazyGithubApi;
 
             Description = "Creates a GitHub team and optionally links it to an IdP group.";
+            Description += Environment.NewLine;
+            Description += "Note: Expects GH_PAT env variable to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/DisableRepoCommand.cs
+++ b/src/ado2gh/Commands/DisableRepoCommand.cs
@@ -16,6 +16,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _lazyAdoApi = lazyAdoApi;
 
             Description = "Disables the repo in Azure DevOps. This makes the repo non-readable for all.";
+            Description += Environment.NewLine;
+            Description += "Note: Expects ADO_PAT env variable to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -21,6 +21,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _lazyAdoApi = lazyAdoApi;
 
             Description = "Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it.";
+            Description += Environment.NewLine;
+            Description += "Note: Expects ADO_PAT env variable to be set.";
 
             var githubOrgOption = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/GrantMigratorRoleCommand.cs
+++ b/src/ado2gh/Commands/GrantMigratorRoleCommand.cs
@@ -16,6 +16,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _lazyGithubApi = lazyGithubApi;
 
             Description = "Allows an organization admin to grant a USER or TEAM the migrator role for a single GitHub organization. The migrator role allows the role assignee to perform migrations into the target organization.";
+            Description += Environment.NewLine;
+            Description += "Note: Expects GH_PAT env variable to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/IntegrateBoardsCommand.cs
+++ b/src/ado2gh/Commands/IntegrateBoardsCommand.cs
@@ -23,6 +23,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _environmentVariableProvider = environmentVariableProvider;
 
             Description = "Configures the Azure Boards<->GitHub integration in Azure DevOps.";
+            Description += Environment.NewLine;
+            Description += "Note: Expects ADO_PAT and GH_PAT env variables to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/LockRepoCommand.cs
+++ b/src/ado2gh/Commands/LockRepoCommand.cs
@@ -16,6 +16,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _lazyAdoApi = lazyAdoApi;
 
             Description = "Makes the ADO repo read-only for all users. It does this by adding Deny permissions for the Project Valid Users group on the repo.";
+            Description += Environment.NewLine;
+            Description += "Note: Expects ADO_PAT env variable to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/MigrateRepoCommand.cs
+++ b/src/ado2gh/Commands/MigrateRepoCommand.cs
@@ -21,6 +21,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _environmentVariableProvider = environmentVariableProvider;
 
             Description = "Invokes the GitHub API's to migrate the repo and all PR data";
+            Description += Environment.NewLine;
+            Description += "Note: Expects ADO_PAT and GH_PAT env variables to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/ado2gh/Commands/RevokeMigratorRoleCommand.cs
@@ -15,6 +15,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log = log;
             _lazyGithubApi = lazyGithubApi;
             Description = "Allows an organization admin to revoke the migrator role for a USER or TEAM for a single GitHub organization. This will remove their ability to run a migration into the target organization.";
+            Description += Environment.NewLine;
+            Description += "Note: Expects GH_PAT env variable to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/RewirePipelineCommand.cs
+++ b/src/ado2gh/Commands/RewirePipelineCommand.cs
@@ -16,6 +16,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _lazyAdoApi = lazyAdoApi;
 
             Description = "Updates an Azure Pipeline to point to a GitHub repo instead of an Azure Repo.";
+            Description += Environment.NewLine;
+            Description += "Note: Expects ADO_PAT env variable to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/ShareServiceConnectionCommand.cs
+++ b/src/ado2gh/Commands/ShareServiceConnectionCommand.cs
@@ -16,6 +16,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _lazyAdoApi = lazyAdoApi;
 
             Description = "Makes an existing GitHub Pipelines App service connection available in another team project. This is required before you can rewire pipelines.";
+            Description += Environment.NewLine;
+            Description += "Note: Expects ADO_PAT env variable to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -19,6 +19,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             _sourceGithubApiFactory = sourceGithubApiFactory;
 
             Description = "Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it.";
+            Description += Environment.NewLine;
+            Description += "Note: Expects GH_SOURCE_PAT or GH_PAT env variable to be set.";
 
             var githubSourceOrgOption = new Option<string>("--github-source-org")
             {

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -11,12 +11,12 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
     public class GenerateScriptCommand : Command
     {
         private readonly OctoLogger _log;
-        private readonly GithubApiFactory _githubApiFactory;
+        private readonly ISourceGithubApiFactory _sourceGithubApiFactory;
 
-        public GenerateScriptCommand(OctoLogger log, GithubApiFactory githubApiFactory) : base("generate-script")
+        public GenerateScriptCommand(OctoLogger log, ISourceGithubApiFactory sourceGithubApiFactory) : base("generate-script")
         {
             _log = log;
-            _githubApiFactory = githubApiFactory;
+            _sourceGithubApiFactory = sourceGithubApiFactory;
 
             Description = "Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it.";
 
@@ -63,7 +63,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 _log.LogInformation("SSH: true");
             }
 
-            var repos = await GetRepos(_githubApiFactory.CreateSourceGithubApi(), githubSourceOrg);
+            var repos = await GetRepos(_sourceGithubApiFactory.Create(), githubSourceOrg);
 
             var script = GenerateScript(repos, githubSourceOrg, githubTargetOrg, ssh);
 

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -11,12 +11,12 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
     public class GenerateScriptCommand : Command
     {
         private readonly OctoLogger _log;
-        private readonly Lazy<GithubApi> _lazyGithubApi;
+        private readonly GithubApiFactory _githubApiFactory;
 
-        public GenerateScriptCommand(OctoLogger log, Lazy<GithubApi> lazyGithubApi) : base("generate-script")
+        public GenerateScriptCommand(OctoLogger log, GithubApiFactory githubApiFactory) : base("generate-script")
         {
             _log = log;
-            _lazyGithubApi = lazyGithubApi;
+            _githubApiFactory = githubApiFactory;
 
             Description = "Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it.";
 
@@ -63,7 +63,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 _log.LogInformation("SSH: true");
             }
 
-            var repos = await GetRepos(_lazyGithubApi.Value, githubSourceOrg);
+            var repos = await GetRepos(_githubApiFactory.CreateSourceGithubApi(), githubSourceOrg);
 
             var script = GenerateScript(repos, githubSourceOrg, githubTargetOrg, ssh);
 

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.CommandLine;
+﻿using System;
+using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;
 
@@ -16,7 +17,9 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             _targetGithubApiFactory = targetGithubApiFactory;
             _environmentVariableProvider = environmentVariableProvider;
 
-            Description = "Invokes the GitHub API's to migrate the repo and all PR data";
+            Description = "Invokes the GitHub API's to migrate the repo and all PR data.";
+            Description += Environment.NewLine;
+            Description += "Note: Expects GH_PAT and GH_SOURCE_PAT env variables to be set. GH_SOURCE_PAT is optional, if not set GH_PAT will be used instead.";
 
             var githubSourceOrg = new Option<string>("--github-source-org")
             {

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -7,13 +7,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
     public class MigrateRepoCommand : Command
     {
         private readonly OctoLogger _log;
-        private readonly GithubApiFactory _githubApiFactory;
+        private readonly ITargetGithubApiFactory _targetGithubApiFactory;
         private readonly EnvironmentVariableProvider _environmentVariableProvider;
 
-        public MigrateRepoCommand(OctoLogger log, GithubApiFactory githubApiFactory, EnvironmentVariableProvider environmentVariableProvider) : base("migrate-repo")
+        public MigrateRepoCommand(OctoLogger log, ITargetGithubApiFactory targetGithubApiFactory, EnvironmentVariableProvider environmentVariableProvider) : base("migrate-repo")
         {
             _log = log;
-            _githubApiFactory = githubApiFactory;
+            _targetGithubApiFactory = targetGithubApiFactory;
             _environmentVariableProvider = environmentVariableProvider;
 
             Description = "Invokes the GitHub API's to migrate the repo and all PR data";
@@ -75,7 +75,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             var githubRepoUrl = GetGithubRepoUrl(githubSourceOrg, sourceRepo);
 
-            var githubApi = _githubApiFactory.CreateTargetGithubClient();
+            var githubApi = _targetGithubApiFactory.Create();
             var sourceGithubPat = _environmentVariableProvider.SourceGithubPersonalAccessToken();
             var targetGithubPat = _environmentVariableProvider.TargetGitHubPersonalAccessToken();
             var githubOrgId = await githubApi.GetOrganizationId(githubTargetOrg);

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -77,7 +77,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             var githubApi = _targetGithubApiFactory.Create();
             var sourceGithubPat = _environmentVariableProvider.SourceGithubPersonalAccessToken();
-            var targetGithubPat = _environmentVariableProvider.TargetGitHubPersonalAccessToken();
+            var targetGithubPat = _environmentVariableProvider.TargetGithubPersonalAccessToken();
             var githubOrgId = await githubApi.GetOrganizationId(githubTargetOrg);
             var migrationSourceId = await githubApi.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat, ssh);
             var migrationId = await githubApi.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, targetRepo);

--- a/src/gei/EnvironmentVariableProvider.cs
+++ b/src/gei/EnvironmentVariableProvider.cs
@@ -2,7 +2,6 @@ using System;
 
 namespace OctoshiftCLI.GithubEnterpriseImporter
 {
-
     public class EnvironmentVariableProvider
     {
         private const string SOURCE_GH_PAT = "GH_SOURCE_PAT";
@@ -14,14 +13,20 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
             _logger = logger;
         }
 
-        public virtual string SourceGithubPersonalAccessToken() => GetSecret(SOURCE_GH_PAT);
+        public virtual string SourceGithubPersonalAccessToken() => GetSecret(SOURCE_GH_PAT) ?? TargetGithubPersonalAccessToken();
 
-        public virtual string TargetGitHubPersonalAccessToken() => GetSecret(TARGET_GH_PAT);
+        public virtual string TargetGithubPersonalAccessToken() =>
+            GetSecret(TARGET_GH_PAT) ??
+            throw new ArgumentNullException($"{TARGET_GH_PAT} environment variable is not set.");
 
         private string GetSecret(string secretName)
         {
-            var secret = Environment.GetEnvironmentVariable(secretName) ??
-                         throw new ArgumentNullException($"{secretName} environment variable is not set.");
+            var secret = Environment.GetEnvironmentVariable(secretName);
+
+            if (secret is null)
+            {
+                return null;
+            }
 
             _logger?.RegisterSecret(secret);
 

--- a/src/gei/EnvironmentVariableProvider.cs
+++ b/src/gei/EnvironmentVariableProvider.cs
@@ -5,8 +5,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
     public class EnvironmentVariableProvider
     {
-        private const string GH_PAT = "GH_PAT";
-
+        private const string SOURCE_GH_PAT = "GH_SOURCE_PAT";
+        private const string TARGET_GH_PAT = "GH_PAT";
         private readonly OctoLogger _logger;
 
         public EnvironmentVariableProvider(OctoLogger logger)
@@ -14,11 +14,14 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
             _logger = logger;
         }
 
-        public virtual string GithubPersonalAccessToken() => GetSecret(GH_PAT);
+        public virtual string SourceGithubPersonalAccessToken() => GetSecret(SOURCE_GH_PAT);
+
+        public virtual string TargetGitHubPersonalAccessToken() => GetSecret(TARGET_GH_PAT);
 
         private string GetSecret(string secretName)
         {
-            var secret = Environment.GetEnvironmentVariable(secretName) ?? throw new ArgumentNullException($"{secretName} environment variable is not set.");
+            var secret = Environment.GetEnvironmentVariable(secretName) ??
+                         throw new ArgumentNullException($"{secretName} environment variable is not set.");
 
             _logger?.RegisterSecret(secret);
 

--- a/src/gei/GithubApiFactory.cs
+++ b/src/gei/GithubApiFactory.cs
@@ -1,0 +1,31 @@
+using System.Net.Http;
+
+namespace OctoshiftCLI.GithubEnterpriseImporter;
+
+public class GithubApiFactory
+{
+    private readonly OctoLogger _octoLogger;
+    private readonly HttpClient _client;
+    private readonly EnvironmentVariableProvider _environmentVariableProvider;
+
+    public GithubApiFactory(OctoLogger octoLogger, HttpClient client, EnvironmentVariableProvider environmentVariableProvider)
+    {
+        _octoLogger = octoLogger;
+        _client = client;
+        _environmentVariableProvider = environmentVariableProvider;
+    }
+
+    public virtual GithubApi CreateSourceGithubApi()
+    {
+        var githubPat = _environmentVariableProvider.SourceGithubPersonalAccessToken();
+        var githubClient = new GithubClient(_octoLogger, _client, githubPat);
+        return new GithubApi(githubClient);
+    }
+
+    public virtual GithubApi CreateTargetGithubClient()
+    {
+        var githubPat = _environmentVariableProvider.TargetGitHubPersonalAccessToken();
+        var githubClient = new GithubClient(_octoLogger, _client, githubPat);
+        return new GithubApi(githubClient);
+    }
+}

--- a/src/gei/GithubApiFactory.cs
+++ b/src/gei/GithubApiFactory.cs
@@ -2,7 +2,7 @@ using System.Net.Http;
 
 namespace OctoshiftCLI.GithubEnterpriseImporter;
 
-public class GithubApiFactory
+public sealed class GithubApiFactory : ISourceGithubApiFactory, ITargetGithubApiFactory
 {
     private readonly OctoLogger _octoLogger;
     private readonly HttpClient _client;
@@ -15,14 +15,14 @@ public class GithubApiFactory
         _environmentVariableProvider = environmentVariableProvider;
     }
 
-    public virtual GithubApi CreateSourceGithubApi()
+    GithubApi ISourceGithubApiFactory.Create()
     {
         var githubPat = _environmentVariableProvider.SourceGithubPersonalAccessToken();
         var githubClient = new GithubClient(_octoLogger, _client, githubPat);
         return new GithubApi(githubClient);
     }
 
-    public virtual GithubApi CreateTargetGithubClient()
+    GithubApi ITargetGithubApiFactory.Create()
     {
         var githubPat = _environmentVariableProvider.TargetGitHubPersonalAccessToken();
         var githubClient = new GithubClient(_octoLogger, _client, githubPat);

--- a/src/gei/GithubApiFactory.cs
+++ b/src/gei/GithubApiFactory.cs
@@ -25,7 +25,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
         GithubApi ITargetGithubApiFactory.Create()
         {
-            var githubPat = _environmentVariableProvider.TargetGitHubPersonalAccessToken();
+            var githubPat = _environmentVariableProvider.TargetGithubPersonalAccessToken();
             var githubClient = new GithubClient(_octoLogger, _client, githubPat);
             return new GithubApi(githubClient);
         }

--- a/src/gei/GithubApiFactory.cs
+++ b/src/gei/GithubApiFactory.cs
@@ -1,31 +1,33 @@
 using System.Net.Http;
 
-namespace OctoshiftCLI.GithubEnterpriseImporter;
-
-public sealed class GithubApiFactory : ISourceGithubApiFactory, ITargetGithubApiFactory
+namespace OctoshiftCLI.GithubEnterpriseImporter
 {
-    private readonly OctoLogger _octoLogger;
-    private readonly HttpClient _client;
-    private readonly EnvironmentVariableProvider _environmentVariableProvider;
-
-    public GithubApiFactory(OctoLogger octoLogger, HttpClient client, EnvironmentVariableProvider environmentVariableProvider)
+    public sealed class GithubApiFactory : ISourceGithubApiFactory, ITargetGithubApiFactory
     {
-        _octoLogger = octoLogger;
-        _client = client;
-        _environmentVariableProvider = environmentVariableProvider;
-    }
+        private readonly OctoLogger _octoLogger;
+        private readonly HttpClient _client;
+        private readonly EnvironmentVariableProvider _environmentVariableProvider;
 
-    GithubApi ISourceGithubApiFactory.Create()
-    {
-        var githubPat = _environmentVariableProvider.SourceGithubPersonalAccessToken();
-        var githubClient = new GithubClient(_octoLogger, _client, githubPat);
-        return new GithubApi(githubClient);
-    }
+        public GithubApiFactory(OctoLogger octoLogger, HttpClient client,
+            EnvironmentVariableProvider environmentVariableProvider)
+        {
+            _octoLogger = octoLogger;
+            _client = client;
+            _environmentVariableProvider = environmentVariableProvider;
+        }
 
-    GithubApi ITargetGithubApiFactory.Create()
-    {
-        var githubPat = _environmentVariableProvider.TargetGitHubPersonalAccessToken();
-        var githubClient = new GithubClient(_octoLogger, _client, githubPat);
-        return new GithubApi(githubClient);
+        GithubApi ISourceGithubApiFactory.Create()
+        {
+            var githubPat = _environmentVariableProvider.SourceGithubPersonalAccessToken();
+            var githubClient = new GithubClient(_octoLogger, _client, githubPat);
+            return new GithubApi(githubClient);
+        }
+
+        GithubApi ITargetGithubApiFactory.Create()
+        {
+            var githubPat = _environmentVariableProvider.TargetGitHubPersonalAccessToken();
+            var githubClient = new GithubClient(_octoLogger, _client, githubPat);
+            return new GithubApi(githubClient);
+        }
     }
 }

--- a/src/gei/ISourceGithubApiFactory.cs
+++ b/src/gei/ISourceGithubApiFactory.cs
@@ -1,0 +1,6 @@
+namespace OctoshiftCLI.GithubEnterpriseImporter;
+
+public interface ISourceGithubApiFactory
+{
+    GithubApi Create();
+}

--- a/src/gei/ISourceGithubApiFactory.cs
+++ b/src/gei/ISourceGithubApiFactory.cs
@@ -1,6 +1,7 @@
-namespace OctoshiftCLI.GithubEnterpriseImporter;
-
-public interface ISourceGithubApiFactory
+namespace OctoshiftCLI.GithubEnterpriseImporter
 {
-    GithubApi Create();
+    public interface ISourceGithubApiFactory
+    {
+        GithubApi Create();
+    }
 }

--- a/src/gei/ITargetGithubApiFactory.cs
+++ b/src/gei/ITargetGithubApiFactory.cs
@@ -1,6 +1,7 @@
-namespace OctoshiftCLI.GithubEnterpriseImporter;
-
-public interface ITargetGithubApiFactory
+namespace OctoshiftCLI.GithubEnterpriseImporter
 {
-    GithubApi Create();
+    public interface ITargetGithubApiFactory
+    {
+        GithubApi Create();
+    }
 }

--- a/src/gei/ITargetGithubApiFactory.cs
+++ b/src/gei/ITargetGithubApiFactory.cs
@@ -1,0 +1,6 @@
+namespace OctoshiftCLI.GithubEnterpriseImporter;
+
+public interface ITargetGithubApiFactory
+{
+    GithubApi Create();
+}

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -18,6 +18,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
                 .AddSingleton<OctoLogger>()
                 .AddSingleton<EnvironmentVariableProvider>()
                 .AddSingleton<GithubApiFactory>()
+                .AddTransient<ITargetGithubApiFactory>(sp => sp.GetRequiredService<GithubApiFactory>())
+                .AddTransient<ISourceGithubApiFactory>(sp => sp.GetRequiredService<GithubApiFactory>())
                 .AddHttpClient();
 
             var serviceProvider = serviceCollection.BuildServiceProvider();

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.CommandLine;
+﻿using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
 using System.Linq;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using OctoshiftCLI.GithubEnterpriseImporter.Commands;
@@ -19,16 +17,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
                 .AddCommands()
                 .AddSingleton<OctoLogger>()
                 .AddSingleton<EnvironmentVariableProvider>()
-                .AddSingleton<GithubApi>()
-                .AddTransient(sp => new Lazy<GithubApi>(sp.GetRequiredService<GithubApi>))
-                .AddHttpClient<GithubClient>((sp, client) =>
-                {
-                    client.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
-                    client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OctoshiftCLI", "0.1"));
-                    client.DefaultRequestHeaders.Add("GraphQL-Features", "import_api");
-                    var githubToken = sp.GetRequiredService<EnvironmentVariableProvider>().GithubPersonalAccessToken();
-                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubToken);
-                });
+                .AddSingleton<GithubApiFactory>()
+                .AddHttpClient();
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
 


### PR DESCRIPTION
Closes #192 

This PR added the support for having two separate Github PATs for GHEC migrations for source and target. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked

### GEI migration
A single repo migration succeeds using different PATs for source and target. This test did a migration within one org.
![image](https://user-images.githubusercontent.com/11265791/149577750-94f03055-1fac-4d44-9ae3-c3a82a892507.png)

### Updated descriptions for `ado2gh` that include required env variables
![image](https://user-images.githubusercontent.com/11265791/149604087-9fcd4555-a4a7-4edc-914c-42e8dc0508e3.png)

### Updated descriptions for `gei` that include required env variables
![image](https://user-images.githubusercontent.com/11265791/149604138-bd3dfc2f-55ab-49cd-ad77-228e317d3a1f.png)
