### PR TITLE
Handle top level exceptions

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,6 @@
+# Release Notes
 
+- Do not log the error's stack trace to console in non-verberse mode.
+- Show a generic error message instead of the actual one for unhandled exceptions in non-verbose mode.
+- Exit code is now 1 instead of 0 in case of an error.
+- Errors are written to std error instead of std out. 

--- a/src/Octoshift/OctoLogger.cs
+++ b/src/Octoshift/OctoLogger.cs
@@ -25,7 +25,7 @@ namespace OctoshiftCLI
         private readonly Action<string> _writeToConsoleOut;
         private readonly Action<string> _writeToConsoleError;
 
-        private const string GENERIC_ERROR_MESSAGE = "An unexpeted error happened. Please see the logs for details.";
+        private const string GENERIC_ERROR_MESSAGE = "An unexpected error happened. Please see the logs for details.";
 
         public OctoLogger()
         {

--- a/src/Octoshift/OctoLogger.cs
+++ b/src/Octoshift/OctoLogger.cs
@@ -22,7 +22,8 @@ namespace OctoshiftCLI
 
         private readonly Action<string> _writeToLog;
         private readonly Action<string> _writeToVerboseLog;
-        private readonly Action<string> _writeToConsole;
+        private readonly Action<string> _writeToConsoleOut;
+        private readonly Action<string> _writeToConsoleError;
 
         private const string GENERIC_ERROR_MESSAGE = "An unexpeted error happened. Please see the logs for details.";
 
@@ -34,21 +35,30 @@ namespace OctoshiftCLI
 
             _writeToLog = msg => File.AppendAllText(_logFilePath, msg);
             _writeToVerboseLog = msg => File.AppendAllText(_verboseFilePath, msg);
-            _writeToConsole = msg => Console.Write(msg);
+            _writeToConsoleOut = msg => Console.Write(msg);
+            _writeToConsoleError = msg => Console.Error.Write(msg);
         }
 
-        public OctoLogger(Action<string> writeToLog, Action<string> writeToVerboseLog, Action<string> writeToConsole)
+        public OctoLogger(Action<string> writeToLog, Action<string> writeToVerboseLog, Action<string> writeToConsoleOut, Action<string> writeToConsoleError)
         {
             _writeToLog = writeToLog;
             _writeToVerboseLog = writeToVerboseLog;
-            _writeToConsole = writeToConsole;
+            _writeToConsoleOut = writeToConsoleOut;
+            _writeToConsoleError = writeToConsoleError;
         }
 
         private void Log(string msg, string level)
         {
             var output = FormatMessage(msg, level);
             output = MaskSecrets(output);
-            _writeToConsole(output);
+            if (level == LogLevel.ERROR)
+            {
+                _writeToConsoleError(output);
+            }
+            else
+            {
+                _writeToConsoleOut(output);
+            }
             _writeToLog(output);
             _writeToVerboseLog(output);
         }
@@ -94,7 +104,7 @@ namespace OctoshiftCLI
             var output = MaskSecrets(FormatMessage(logMessage, LogLevel.ERROR));
 
             Console.ForegroundColor = ConsoleColor.Red;
-            _writeToConsole(output);
+            _writeToConsoleError(output);
             Console.ResetColor();
 
             _writeToLog(output);

--- a/src/Octoshift/OctoLogger.cs
+++ b/src/Octoshift/OctoLogger.cs
@@ -24,6 +24,8 @@ namespace OctoshiftCLI
         private readonly Action<string> _writeToVerboseLog;
         private readonly Action<string> _writeToConsole;
 
+        private const string GENERIC_ERROR_MESSAGE = "An unexpeted error happened. Please see the logs for details.";
+
         public OctoLogger()
         {
             var logStartTime = DateTime.Now;
@@ -81,15 +83,22 @@ namespace OctoshiftCLI
             Console.ResetColor();
         }
 
-        public virtual void LogError(string msg, Exception ex)
-        {
-            // TODO: include details from the exception in the logs
-            throw new NotImplementedException();
-        }
-
         public virtual void LogError(Exception ex)
         {
-            throw new NotImplementedException();
+            if (ex is null)
+            {
+                throw new ArgumentNullException(nameof(ex));
+            }
+
+            var logMessage = Verbose ? ex.ToString() : ex is OctoshiftCliException ? ex.Message : GENERIC_ERROR_MESSAGE;
+            var output = MaskSecrets(FormatMessage(logMessage, LogLevel.ERROR));
+
+            Console.ForegroundColor = ConsoleColor.Red;
+            _writeToConsole(output);
+            Console.ResetColor();
+
+            _writeToLog(output);
+            _writeToVerboseLog(MaskSecrets(FormatMessage(ex.ToString(), LogLevel.ERROR)));
         }
 
         public virtual void LogVerbose(string msg)

--- a/src/Octoshift/OctoshiftCliException.cs
+++ b/src/Octoshift/OctoshiftCliException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace OctoshiftCLI
+{
+    public class OctoshiftCliException : Exception
+    {
+        public OctoshiftCliException()
+        {
+        }
+
+        public OctoshiftCliException(string message) : base(message)
+        {
+        }
+
+        public OctoshiftCliException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/OctoshiftCLI.Tests/OctoLoggerTests.cs
+++ b/src/OctoshiftCLI.Tests/OctoLoggerTests.cs
@@ -115,7 +115,7 @@ namespace OctoshiftCLI.Tests
         public void LogError_For_Any_Exception_Should_Always_Log_Entire_Exception_In_Verbose_Mode()
         {
             // Arrange
-            const string genericErrorMessage = "An unexpeted error happened. Please see the logs for details.";
+            const string genericErrorMessage = "An unexpected error happened. Please see the logs for details.";
 
             string console = null;
             string log = null;

--- a/src/OctoshiftCLI.Tests/OctoLoggerTests.cs
+++ b/src/OctoshiftCLI.Tests/OctoLoggerTests.cs
@@ -76,7 +76,7 @@ namespace OctoshiftCLI.Tests
         public void LogError_For_Unexpected_Exception_Should_Log_Generic_Error_Message_In_Non_Verbose_Mode()
         {
             // Arrange
-            const string genericErrorMessage = "An unexpeted error happened. Please see the logs for details.";
+            const string genericErrorMessage = "An unexpected error happened. Please see the logs for details.";
 
             string console = null;
             string log = null;

--- a/src/OctoshiftCLI.Tests/ado2gh/EnvironmentVariableProviderTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/EnvironmentVariableProviderTests.cs
@@ -55,7 +55,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             // Act, Assert
             _environmentVariableProvider.Invoking(env => env.GithubPersonalAccessToken())
-                .Should().Throw<ArgumentNullException>();
+                .Should().Throw<OctoshiftCliException>();
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             // Act, Assert
             _environmentVariableProvider.Invoking(env => env.AdoPersonalAccessToken())
-                .Should().Throw<ArgumentNullException>();
+                .Should().Throw<OctoshiftCliException>();
         }
 
         private void ResetEnvs(string githubPat = null, string adoPat = null)

--- a/src/OctoshiftCLI.Tests/gei/EnvironmentVariableProviderTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/EnvironmentVariableProviderTests.cs
@@ -42,7 +42,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Act, Assert
             _environmentVariableProvider.Invoking(env => env.SourceGithubPersonalAccessToken())
-                .Should().Throw<ArgumentNullException>();
+                .Should().Throw<OctoshiftCliException>();
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Act, Assert
             _environmentVariableProvider.Invoking(env => env.TargetGithubPersonalAccessToken())
-                .Should().Throw<ArgumentNullException>();
+                .Should().Throw<OctoshiftCliException>();
         }
     }
 }

--- a/src/ado2gh/EnvironmentVariableProvider.cs
+++ b/src/ado2gh/EnvironmentVariableProvider.cs
@@ -20,7 +20,8 @@ public class EnvironmentVariableProvider
 
     private string GetSecret(string secretName)
     {
-        var secret = Environment.GetEnvironmentVariable(secretName) ?? throw new ArgumentNullException($"{secretName} environment variable is not set.");
+        var secret = Environment.GetEnvironmentVariable(secretName) ??
+                     throw new OctoshiftCliException($"{secretName} environment variable is not set.");
 
         _logger?.RegisterSecret(secret);
 

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -10,12 +10,14 @@ namespace OctoshiftCLI.AdoToGithub
 {
     public static class Program
     {
+        private static readonly OctoLogger Logger = new OctoLogger();
+
         public static async Task Main(string[] args)
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection
                 .AddCommands()
-                .AddSingleton<OctoLogger>()
+                .AddSingleton(Logger)
                 .AddSingleton<EnvironmentVariableProvider>()
                 .AddSingleton<AdoApiFactory>()
                 .AddSingleton<GithubApiFactory>()
@@ -38,7 +40,10 @@ namespace OctoshiftCLI.AdoToGithub
                 commandLineBuilder.AddCommand(command);
             }
 
-            return commandLineBuilder.UseDefaults().Build();
+            return commandLineBuilder
+                .UseDefaults()
+                .UseExceptionHandler((ex, _) => Logger.LogError(ex), 1)
+                .Build();
         }
 
         private static IServiceCollection AddCommands(this IServiceCollection services)

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -1,4 +1,5 @@
-﻿using System.CommandLine;
+﻿using System;
+using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
 using System.Linq;
@@ -42,7 +43,11 @@ namespace OctoshiftCLI.AdoToGithub
 
             return commandLineBuilder
                 .UseDefaults()
-                .UseExceptionHandler((ex, _) => Logger.LogError(ex), 1)
+                .UseExceptionHandler((ex, _) =>
+                {
+                    Logger.LogError(ex);
+                    Environment.ExitCode = 1;
+                }, 1)
                 .Build();
         }
 

--- a/src/gei/EnvironmentVariableProvider.cs
+++ b/src/gei/EnvironmentVariableProvider.cs
@@ -17,7 +17,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
         public virtual string TargetGithubPersonalAccessToken() =>
             GetSecret(TARGET_GH_PAT) ??
-            throw new ArgumentNullException($"{TARGET_GH_PAT} environment variable is not set.");
+            throw new OctoshiftCliException($"{TARGET_GH_PAT} environment variable is not set.");
 
         private string GetSecret(string secretName)
         {

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -1,4 +1,5 @@
-﻿using System.CommandLine;
+﻿using System;
+using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
 using System.Linq;
@@ -43,7 +44,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
             return commandLineBuilder
                 .UseDefaults()
-                .UseExceptionHandler((ex, _) => Logger.LogError(ex), 1)
+                .UseExceptionHandler((ex, _) =>
+                {
+                    Logger.LogError(ex);
+                    Environment.ExitCode = 1;
+                }, 1)
                 .Build();
         }
 

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -10,12 +10,14 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 {
     public static class Program
     {
+        private static readonly OctoLogger Logger = new OctoLogger();
+
         public static async Task Main(string[] args)
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection
                 .AddCommands()
-                .AddSingleton<OctoLogger>()
+                .AddSingleton(Logger)
                 .AddSingleton<EnvironmentVariableProvider>()
                 .AddSingleton<GithubApiFactory>()
                 .AddTransient<ITargetGithubApiFactory>(sp => sp.GetRequiredService<GithubApiFactory>())
@@ -39,7 +41,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
                 commandLineBuilder.AddCommand(command);
             }
 
-            return commandLineBuilder.UseDefaults().Build();
+            return commandLineBuilder
+                .UseDefaults()
+                .UseExceptionHandler((ex, _) => Logger.LogError(ex), 1)
+                .Build();
         }
 
         private static IServiceCollection AddCommands(this IServiceCollection services)


### PR DESCRIPTION
Related issue #116

This PR addressed the following issues:
1. Making sure that bubbled up exceptions are being handled properly in `non-verbose` modes:
    1. Don't log the stack trace.
    2. For `OctoshiftCliException`, log the exception message since it is a known exception and should already have a user friendly error message.
    3. For other (unexpected) errors, mask the actual error message and show a generic one to the user and point them to the log files.
2. Returning 1 instead of 0 in case of an error.
3. Writing errors to std error instead of std out.
4. Add `LogError(Exception ex)` overloaded method to `OctoLogger`.
5. Add the new `OctoshifeCliException` to be thrown for all known/handled exceptions.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked