### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Hi there! We're thrilled that you'd like to contribute to this project. Your hel
 
 Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.md).
 
-Please note that this project is released with a [Contributor Code of Conduct][code-of-conduct]. By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
 Here's some helpful notes on how to contribute to this project, including details on how to get started working the codebase.
 


### PR DESCRIPTION
Link isn't set up properly on CONTRIBUTING.md https://github.com/github/gh-gei/blob/main/CONTRIBUTING.md

<img width="474" alt="Screen Shot 2022-02-01 at 11 02 13 AM" src="https://user-images.githubusercontent.com/24641573/152024845-91d18203-165c-4497-9516-ca1dc1cb2197.png">

Rendered file: https://github.com/github/gh-gei/blob/petermeglis-patch-1/CONTRIBUTING.md

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked