### PR TITLE
Support GHES migrations in generate-script command

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,3 +2,4 @@
 - Update `gh gei migrate-repo` to allow for migrations from GHES instances. When `--ghes-api-url` is passed in, it requires an Azure Blob Storage connection string `--azure-storage-connection-string` and an optional flag to disable SSL verification `--no-ssl-verify`. This migration path generates migration archives on the source, uploads them to Azure Blob Storage using the connection string, then kicks off a GitHub Enterprise Importer migration using the uploaded migration archives.
 - Modify `gh gei migrate-repo` to optionally accept two pre-generated archive urls to start a migration (not commonly used) and a target api url parameter
 - Fixed a bug where `configure-autolink` command would fail if your ADO team project had a space in it
+- Update `gh gei generate-script` to allow for migrations from GHES by passing the options `--ghes-api-url`, `--azure-storage-connection-string`, `--no-ssl-verify`.

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -48,8 +48,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var repos = new List<string>() { repo };
 
-            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null);
-            var script = command.GenerateGithubScript(repos, githubSourceOrg, githubTargetOrg, false);
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
+            var script = command.GenerateGithubScript(repos, githubSourceOrg, githubTargetOrg, "", "", false, false);
 
             script = TrimNonExecutableLines(script);
 
@@ -69,8 +69,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var repos = new List<string>() { repo1, repo2, repo3 };
 
-            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null);
-            var script = command.GenerateGithubScript(repos, githubSourceOrg, githubTargetOrg, false);
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
+            var script = command.GenerateGithubScript(repos, githubSourceOrg, githubTargetOrg, "", "", false, false);
 
             script = TrimNonExecutableLines(script);
 
@@ -92,8 +92,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var repos = new List<string>() { repo };
 
-            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null);
-            var script = command.GenerateGithubScript(repos, githubSourceOrg, githubTargetOrg, true);
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
+            var script = command.GenerateGithubScript(repos, githubSourceOrg, githubTargetOrg, "", "", false, true);
 
             script = TrimNonExecutableLines(script);
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -33,8 +33,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         [Fact]
         public void Github_No_Data()
         {
-            var command = new GenerateScriptCommand(null, null, null);
-            var script = command.GenerateGithubScript(null, "foo-source", "foo-target", false);
+            var command = new GenerateScriptCommand(null, null, null, null);
+            var script = command.GenerateGithubScript(null, "foo-source", "foo-target", "", "", false, false);
 
             string.IsNullOrWhiteSpace(script).Should().BeTrue();
         }

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -10,6 +10,9 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 {
     public class GenerateScriptCommandTests
     {
+        private const string SOURCE_ORG = "foo-source-org";
+        private const string TARGET_ORG = "foo-target-org";
+
         [Fact]
         public void Should_Have_Options()
         {
@@ -42,18 +45,15 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         [Fact]
         public void Github_Single_Repo()
         {
-            var githubSourceOrg = "foo-source";
-            var githubTargetOrg = "foo-target";
             var repo = "foo-repo";
-
             var repos = new List<string>() { repo };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateGithubScript(repos, githubSourceOrg, githubTargetOrg, "", "", false, false);
+            var script = command.GenerateGithubScript(repos, SOURCE_ORG, TARGET_ORG, "", "", false, false);
 
             script = TrimNonExecutableLines(script);
 
-            var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\" }}";
+            var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{repo}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{repo}\" }}";
 
             script.Should().Be(expected);
         }
@@ -61,24 +61,21 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         [Fact]
         public void Github_Multiple_Repos()
         {
-            var githubSourceOrg = "foo-source";
-            var githubTargetOrg = "foo-target";
             var repo1 = "foo-repo-1";
             var repo2 = "foo-repo-2";
             var repo3 = "foo-repo-3";
-
             var repos = new List<string>() { repo1, repo2, repo3 };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateGithubScript(repos, githubSourceOrg, githubTargetOrg, "", "", false, false);
+            var script = command.GenerateGithubScript(repos, SOURCE_ORG, TARGET_ORG, "", "", false, false);
 
             script = TrimNonExecutableLines(script);
 
-            var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo1}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo1}\" }}";
+            var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{repo1}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{repo1}\" }}";
             expected += Environment.NewLine;
-            expected += $"Exec {{ gh gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo2}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo2}\" }}";
+            expected += $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{repo2}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{repo2}\" }}";
             expected += Environment.NewLine;
-            expected += $"Exec {{ gh gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo3}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo3}\" }}";
+            expected += $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{repo3}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{repo3}\" }}";
 
             script.Should().Be(expected);
         }
@@ -86,18 +83,15 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         [Fact]
         public void Github_With_Ssh()
         {
-            var githubSourceOrg = "foo-source";
-            var githubTargetOrg = "foo-target";
             var repo = "foo-repo";
-
             var repos = new List<string>() { repo };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateGithubScript(repos, githubSourceOrg, githubTargetOrg, "", "", false, true);
+            var script = command.GenerateGithubScript(repos, SOURCE_ORG, TARGET_ORG, "", "", false, true);
 
             script = TrimNonExecutableLines(script);
 
-            var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\" --ssh }}";
+            var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{repo}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{repo}\" --ssh }}";
 
             script.Should().Be(expected);
         }
@@ -114,19 +108,16 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         [Fact]
         public void Ado_Single_Repo()
         {
-            var adoSourceOrg = "foo-source";
             var adoTeamProject = "foo-team-project";
-            var githubTargetOrg = "foo-target";
             var repo = "foo-repo";
-
             var repos = new Dictionary<string, IEnumerable<string>>() { { adoTeamProject, new List<string>() { repo } } };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateAdoScript(repos, adoSourceOrg, githubTargetOrg, false);
+            var script = command.GenerateAdoScript(repos, SOURCE_ORG, TARGET_ORG, false);
 
             script = TrimNonExecutableLines(script);
 
-            var expected = $"Exec {{ gh gei migrate-repo --ado-source-org \"{adoSourceOrg}\" --ado-team-project \"{adoTeamProject}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{adoTeamProject}-{repo}\" }}";
+            var expected = $"Exec {{ gh gei migrate-repo --ado-source-org \"{SOURCE_ORG}\" --ado-team-project \"{adoTeamProject}\" --source-repo \"{repo}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{adoTeamProject}-{repo}\" }}";
 
             script.Should().Be(expected);
         }
@@ -134,25 +125,22 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         [Fact]
         public void Ado_Multiple_Repos()
         {
-            var adoSourceOrg = "foo-source";
             var adoTeamProject = "foo-team-project";
-            var githubTargetOrg = "foo-target";
             var repo1 = "foo-repo-1";
             var repo2 = "foo-repo-2";
             var repo3 = "foo-repo-3";
-
             var repos = new Dictionary<string, IEnumerable<string>> { { adoTeamProject, new List<string>() { repo1, repo2, repo3 } } };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateAdoScript(repos, adoSourceOrg, githubTargetOrg, false);
+            var script = command.GenerateAdoScript(repos, SOURCE_ORG, TARGET_ORG, false);
 
             script = TrimNonExecutableLines(script);
 
-            var expected = $"Exec {{ gh gei migrate-repo --ado-source-org \"{adoSourceOrg}\" --ado-team-project \"{adoTeamProject}\" --source-repo \"{repo1}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{adoTeamProject}-{repo1}\" }}";
+            var expected = $"Exec {{ gh gei migrate-repo --ado-source-org \"{SOURCE_ORG}\" --ado-team-project \"{adoTeamProject}\" --source-repo \"{repo1}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{adoTeamProject}-{repo1}\" }}";
             expected += Environment.NewLine;
-            expected += $"Exec {{ gh gei migrate-repo --ado-source-org \"{adoSourceOrg}\" --ado-team-project \"{adoTeamProject}\" --source-repo \"{repo2}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{adoTeamProject}-{repo2}\" }}";
+            expected += $"Exec {{ gh gei migrate-repo --ado-source-org \"{SOURCE_ORG}\" --ado-team-project \"{adoTeamProject}\" --source-repo \"{repo2}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{adoTeamProject}-{repo2}\" }}";
             expected += Environment.NewLine;
-            expected += $"Exec {{ gh gei migrate-repo --ado-source-org \"{adoSourceOrg}\" --ado-team-project \"{adoTeamProject}\" --source-repo \"{repo3}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{adoTeamProject}-{repo3}\" }}";
+            expected += $"Exec {{ gh gei migrate-repo --ado-source-org \"{SOURCE_ORG}\" --ado-team-project \"{adoTeamProject}\" --source-repo \"{repo3}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{adoTeamProject}-{repo3}\" }}";
 
             script.Should().Be(expected);
         }
@@ -160,19 +148,16 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         [Fact]
         public void Ado_With_Ssh()
         {
-            var adoSourceOrg = "foo-source";
             var adoTeamProject = "foo-team-project";
-            var githubTargetOrg = "foo-target";
             var repo = "foo-repo";
-
             var repos = new Dictionary<string, IEnumerable<string>>() { { adoTeamProject, new List<string>() { repo } } };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateAdoScript(repos, adoSourceOrg, githubTargetOrg, true);
+            var script = command.GenerateAdoScript(repos, SOURCE_ORG, TARGET_ORG, true);
 
             script = TrimNonExecutableLines(script);
 
-            var expected = $"Exec {{ gh gei migrate-repo --ado-source-org \"{adoSourceOrg}\" --ado-team-project \"{adoTeamProject}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{adoTeamProject}-{repo}\" --ssh }}";
+            var expected = $"Exec {{ gh gei migrate-repo --ado-source-org \"{SOURCE_ORG}\" --ado-team-project \"{adoTeamProject}\" --source-repo \"{repo}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{adoTeamProject}-{repo}\" --ssh }}";
 
             script.Should().Be(expected);
         }

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -105,7 +105,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         [Fact]
         public void Ado_No_Data()
         {
-            var command = new GenerateScriptCommand(null, null, null);
+            var command = new GenerateScriptCommand(null, null, null, null);
             var script = command.GenerateAdoScript(null, "foo-source", "foo-target", false);
 
             string.IsNullOrWhiteSpace(script).Should().BeTrue();
@@ -121,7 +121,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var repos = new Dictionary<string, IEnumerable<string>>() { { adoTeamProject, new List<string>() { repo } } };
 
-            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null);
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
             var script = command.GenerateAdoScript(repos, adoSourceOrg, githubTargetOrg, false);
 
             script = TrimNonExecutableLines(script);
@@ -143,7 +143,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var repos = new Dictionary<string, IEnumerable<string>> { { adoTeamProject, new List<string>() { repo1, repo2, repo3 } } };
 
-            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null);
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
             var script = command.GenerateAdoScript(repos, adoSourceOrg, githubTargetOrg, false);
 
             script = TrimNonExecutableLines(script);
@@ -167,7 +167,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var repos = new Dictionary<string, IEnumerable<string>>() { { adoTeamProject, new List<string>() { repo } } };
 
-            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null);
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
             var script = command.GenerateAdoScript(repos, adoSourceOrg, githubTargetOrg, true);
 
             script = TrimNonExecutableLines(script);

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -97,6 +97,42 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         }
 
         [Fact]
+        public void Github_GHES_Repo()
+        {
+            var repo = "foo-repo";
+            var repos = new List<string>() { repo };
+            var ghesApiUrl = "https://api.foo.com";
+            var azureStorageConnectionString = "foo-storage-connection-string";
+
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
+            var script = command.GenerateGithubScript(repos, SOURCE_ORG, TARGET_ORG, ghesApiUrl, azureStorageConnectionString, false, false);
+
+            script = TrimNonExecutableLines(script);
+
+            var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{repo}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{repo}\" --ghes-api-url \"{ghesApiUrl}\" --azure-storage-connection-string \"{azureStorageConnectionString}\" }}";
+
+            script.Should().Be(expected);
+        }
+
+        [Fact]
+        public void Github_GHES_Repo_No_Ssl()
+        {
+            var repo = "foo-repo";
+            var repos = new List<string>() { repo };
+            var ghesApiUrl = "https://api.foo.com";
+            var azureStorageConnectionString = "foo-storage-connection-string";
+
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
+            var script = command.GenerateGithubScript(repos, SOURCE_ORG, TARGET_ORG, ghesApiUrl, azureStorageConnectionString, true, false);
+
+            script = TrimNonExecutableLines(script);
+
+            var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{repo}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{repo}\" --ghes-api-url \"{ghesApiUrl}\" --azure-storage-connection-string \"{azureStorageConnectionString}\" --no-ssl-verify }}";
+
+            script.Should().Be(expected);
+        }
+
+        [Fact]
         public void Ado_No_Data()
         {
             var command = new GenerateScriptCommand(null, null, null, null);

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -13,15 +13,18 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         [Fact]
         public void Should_Have_Options()
         {
-            var command = new GenerateScriptCommand(null, null, null);
+            var command = new GenerateScriptCommand(null, null, null, null);
 
             command.Should().NotBeNull();
             command.Name.Should().Be("generate-script");
-            command.Options.Count.Should().Be(6);
+            command.Options.Count.Should().Be(9);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-source-org", false);
             TestHelpers.VerifyCommandOption(command.Options, "ado-source-org", false);
             TestHelpers.VerifyCommandOption(command.Options, "github-target-org", true);
+            TestHelpers.VerifyCommandOption(command.Options, "ghes-api-url", false);
+            TestHelpers.VerifyCommandOption(command.Options, "azure-storage-connection-string", false);
+            TestHelpers.VerifyCommandOption(command.Options, "no-ssl-verify", false);
             TestHelpers.VerifyCommandOption(command.Options, "output", false);
             TestHelpers.VerifyCommandOption(command.Options, "ssh", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -45,17 +45,17 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var ghesApiUrl = new Option<string>("--ghes-api-url")
             {
                 IsRequired = false,
-                Description = "If migrating from GHES, the api endpoint for the hostname of your GHES instance. For example: http(s)://api.myghes.com"
+                Description = "Required if migrating from GHES. The api endpoint for the hostname of your GHES instance. For example: http(s)://api.myghes.com"
             };
             var azureStorageConnectionString = new Option<string>("--azure-storage-connection-string")
             {
                 IsRequired = false,
-                Description = "(Required when used with --ghes-api-url) The connection string for the Azure storage account, used to upload data archives pre-migration. For example: DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net"
+                Description = "Required if migrating from GHES. The connection string for the Azure storage account, used to upload data archives pre-migration. For example: DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net"
             };
             var noSslVerify = new Option("--no-ssl-verify")
             {
                 IsRequired = false,
-                Description = "(Only effective when passed in with --ghes-api-url) Disables SSL verification. If your GHES instance has a self-signed SSL certificate then setting this flag will allow data to be extracted. All other migration steps will continue to verify SSL."
+                Description = "Only effective if migrating from GHES. Disables SSL verification when communicating with your GHES instance. All other migration steps will continue to verify SSL. If your GHES instance has a self-signed SSL certificate then setting this flag will allow data to be extracted."
             };
 
             var outputOption = new Option<FileInfo>("--output", () => new FileInfo("./migrate.ps1"))

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -14,12 +14,14 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         private readonly OctoLogger _log;
         private readonly ISourceGithubApiFactory _sourceGithubApiFactory;
         private readonly AdoApiFactory _sourceAdoApiFactory;
+        private readonly EnvironmentVariableProvider _environmentVariableProvider;
 
-        public GenerateScriptCommand(OctoLogger log, ISourceGithubApiFactory sourceGithubApiFactory, AdoApiFactory sourceAdoApiFactory) : base("generate-script")
+        public GenerateScriptCommand(OctoLogger log, ISourceGithubApiFactory sourceGithubApiFactory, AdoApiFactory sourceAdoApiFactory, EnvironmentVariableProvider environmentVariableProvider) : base("generate-script")
         {
             _log = log;
             _sourceGithubApiFactory = sourceGithubApiFactory;
             _sourceAdoApiFactory = sourceAdoApiFactory;
+            _environmentVariableProvider = environmentVariableProvider;
 
             Description = "Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it.";
 
@@ -38,6 +40,24 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 IsRequired = true,
                 Description = "Uses GH_PAT env variable."
             };
+
+            // GHES migration path
+            var ghesApiUrl = new Option<string>("--ghes-api-url")
+            {
+                IsRequired = false,
+                Description = "If migrating from GHES, the api endpoint for the hostname of your GHES instance. For example: http(s)://api.myghes.com"
+            };
+            var azureStorageConnectionString = new Option<string>("--azure-storage-connection-string")
+            {
+                IsRequired = false,
+                Description = "(Required when used with --ghes-api-url) The connection string for the Azure storage account, used to upload data archives pre-migration. For example: DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net"
+            };
+            var noSslVerify = new Option("--no-ssl-verify")
+            {
+                IsRequired = false,
+                Description = "(Only effective when passed in with --ghes-api-url) Disables SSL verification. If your GHES instance has a self-signed SSL certificate then setting this flag will allow data to be extracted. All other migration steps will continue to verify SSL."
+            };
+
             var outputOption = new Option<FileInfo>("--output", () => new FileInfo("./migrate.ps1"))
             {
                 IsRequired = false
@@ -54,14 +74,28 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(githubSourceOrgOption);
             AddOption(adoSourceOrgOption);
             AddOption(githubTargetOrgOption);
+
+            AddOption(ghesApiUrl);
+            AddOption(azureStorageConnectionString);
+            AddOption(noSslVerify);
+
             AddOption(outputOption);
             AddOption(ssh);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, FileInfo, bool, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, FileInfo, string, string, bool, bool, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubSourceOrg, string adoSourceOrg, string githubTargetOrg, FileInfo output, bool ssh = false, bool verbose = false)
+        public async Task Invoke(
+          string githubSourceOrg,
+          string adoSourceOrg,
+          string githubTargetOrg,
+          FileInfo output,
+          string ghesApiUrl = "",
+          string azureStorageConnectionString = "",
+          bool noSslVerify = false,
+          bool ssh = false,
+          bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -74,6 +108,29 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 _log.LogInformation($"ADO SOURCE ORG: {adoSourceOrg}");
             }
+
+            // GHES Migration Path
+            if (!string.IsNullOrWhiteSpace(ghesApiUrl))
+            {
+                _log.LogInformation($"GHES API URL: {ghesApiUrl}");
+
+                if (string.IsNullOrWhiteSpace(azureStorageConnectionString))
+                {
+                    _log.LogInformation("--azure-storage-connection-string not set, using environment variable AZURE_STORAGE_CONNECTION_STRING");
+                    azureStorageConnectionString = _environmentVariableProvider.AzureStorageConnectionString();
+
+                    if (string.IsNullOrWhiteSpace(azureStorageConnectionString))
+                    {
+                        throw new OctoshiftCliException("Please set either --azure-storage-connection-string or AZURE_STORAGE_CONNECTION_STRING");
+                    }
+                }
+
+                if (noSslVerify)
+                {
+                    _log.LogInformation("SSL verification disabled");
+                }
+            }
+
             _log.LogInformation($"GITHUB TARGET ORG: {githubTargetOrg}");
             _log.LogInformation($"OUTPUT: {output}");
             if (ssh)
@@ -88,7 +145,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             var script = string.IsNullOrWhiteSpace(githubSourceOrg) ?
                 await InvokeAdo(adoSourceOrg, githubTargetOrg, ssh) :
-                await InvokeGithub(githubSourceOrg, githubTargetOrg, ssh);
+                await InvokeGithub(githubSourceOrg, githubTargetOrg, ghesApiUrl, azureStorageConnectionString, noSslVerify, ssh);
 
             if (output != null)
             {
@@ -96,11 +153,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             }
         }
 
-        private async Task<string> InvokeGithub(string githubSourceOrg, string githubTargetOrg, bool ssh)
+        private async Task<string> InvokeGithub(string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool ssh)
         {
             var targetApiUrl = "https://api.github.com";
             var repos = await GetGithubRepos(_sourceGithubApiFactory.Create(targetApiUrl), githubSourceOrg);
-            return GenerateGithubScript(repos, githubSourceOrg, githubTargetOrg, ssh);
+            return GenerateGithubScript(repos, githubSourceOrg, githubTargetOrg, ghesApiUrl, azureStorageConnectionString, noSslVerify, ssh);
         }
 
         private async Task<string> InvokeAdo(string adoSourceOrg, string githubTargetOrg, bool ssh)
@@ -153,7 +210,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             throw new ArgumentException("All arguments must be non-null");
         }
 
-        public string GenerateGithubScript(IEnumerable<string> repos, string githubSourceOrg, string githubTargetOrg, bool ssh)
+        public string GenerateGithubScript(IEnumerable<string> repos, string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool ssh)
         {
             if (repos == null)
             {
@@ -177,7 +234,7 @@ function Exec {
 
             foreach (var repo in repos)
             {
-                content.AppendLine(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, repo, ssh));
+                content.AppendLine(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, repo, ghesApiUrl, azureStorageConnectionString, noSslVerify, ssh));
             }
 
             return content.ToString();
@@ -229,14 +286,25 @@ function Exec {
 
         private string GetGithubRepoName(string adoTeamProject, string repo) => $"{adoTeamProject}-{repo.Replace(" ", "-")}";
 
-        private string MigrateGithubRepoScript(string githubSourceOrg, string githubTargetOrg, string repo, bool ssh)
+        private string MigrateGithubRepoScript(string githubSourceOrg, string githubTargetOrg, string repo, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool ssh)
         {
-            return $"Exec {{ gh gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\"{(ssh ? " --ssh" : string.Empty)}{(_log.Verbose ? " --verbose" : string.Empty)} }}";
+            var ghesRepoOptions = "";
+            if (!string.IsNullOrWhiteSpace(ghesApiUrl))
+            {
+                ghesRepoOptions = GHESRepoOptions(ghesApiUrl, azureStorageConnectionString, noSslVerify);
+            }
+
+            return $"Exec {{ gh gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\"{(!string.IsNullOrEmpty(ghesRepoOptions) ? $" {ghesRepoOptions}" : string.Empty)}{(ssh ? " --ssh" : string.Empty)}{(_log.Verbose ? " --verbose" : string.Empty)} }}";
         }
 
         private string MigrateAdoRepoScript(string adoSourceOrg, string teamProject, string adoRepo, string githubTargetOrg, string githubRepo, bool ssh)
         {
             return $"Exec {{ gh gei migrate-repo --ado-source-org \"{adoSourceOrg}\" --ado-team-project \"{teamProject}\" --source-repo \"{adoRepo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{githubRepo}\"{(ssh ? " --ssh" : string.Empty)}{(_log.Verbose ? " --verbose" : string.Empty)} }}";
+        }
+
+        private string GHESRepoOptions(string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify)
+        {
+            return $"--ghes-api-url \"{ghesApiUrl}\" --azure-storage-connection-string \"{azureStorageConnectionString}\" {(noSslVerify ? " --no-ssl-verify" : string.Empty)}";
         }
     }
 }

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -304,7 +304,7 @@ function Exec {
 
         private string GHESRepoOptions(string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify)
         {
-            return $"--ghes-api-url \"{ghesApiUrl}\" --azure-storage-connection-string \"{azureStorageConnectionString}\" {(noSslVerify ? " --no-ssl-verify" : string.Empty)}";
+            return $"--ghes-api-url \"{ghesApiUrl}\" --azure-storage-connection-string \"{azureStorageConnectionString}\"{(noSslVerify ? " --no-ssl-verify" : string.Empty)}";
         }
     }
 }

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -66,17 +66,17 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var ghesApiUrl = new Option<string>("--ghes-api-url")
             {
                 IsRequired = false,
-                Description = "If migrating from GHES, the api endpoint for the hostname of your GHES instance. For example: http(s)://api.myghes.com"
+                Description = "Required if migrating from GHES. The api endpoint for the hostname of your GHES instance. For example: http(s)://api.myghes.com"
             };
             var azureStorageConnectionString = new Option<string>("--azure-storage-connection-string")
             {
                 IsRequired = false,
-                Description = "(Required when used with --ghes-api-url) The connection string for the Azure storage account, used to upload data archives pre-migration. For example: DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net"
+                Description = "Required if migrating from GHES. The connection string for the Azure storage account, used to upload data archives pre-migration. For example: DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net"
             };
             var noSslVerify = new Option("--no-ssl-verify")
             {
                 IsRequired = false,
-                Description = "(Only effective when passed in with --ghes-api-url) Disables SSL verification. If your GHES instance has a self-signed SSL certificate then setting this flag will allow data to be extracted. All other migration steps will continue to verify SSL."
+                Description = "Only effective if migrating from GHES. Disables SSL verification when communicating with your GHES instance. All other migration steps will continue to verify SSL. If your GHES instance has a self-signed SSL certificate then setting this flag will allow data to be extracted."
             };
 
             // Pre-uploaded archive urls, hidden by default

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -66,7 +66,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var ghesApiUrl = new Option<string>("--ghes-api-url")
             {
                 IsRequired = false,
-                Description = "The api endpoint for the hostname of your GHES instance. For example: http(s)://api.myghes.com"
+                Description = "If migrating from GHES, the api endpoint for the hostname of your GHES instance. For example: http(s)://api.myghes.com"
             };
             var azureStorageConnectionString = new Option<string>("--azure-storage-connection-string")
             {


### PR DESCRIPTION
Closes https://github.com/github/octoshift/issues/3664

This PR adds support for migrating from ghes to the gei generate-script command

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked

### Functional Test
<img width="2008" alt="Screen Shot 2022-02-14 at 1 53 32 PM" src="https://user-images.githubusercontent.com/24641573/153944862-40c55bf4-9f52-4045-98f4-28ccd40660aa.png">
<img width="1922" alt="Screen Shot 2022-02-14 at 1 53 40 PM" src="https://user-images.githubusercontent.com/24641573/153944872-f6c889a3-e1f8-4871-866f-239f1ec3c5b2.png">

