### PR TITLE
Enable direct execution of generated script in linux/macos

### DIFF
--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -29,6 +29,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
+
         [Fact]
         public void No_Data()
         {
@@ -39,6 +40,28 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             Assert.True(string.IsNullOrWhiteSpace(script));
         }
+
+        [Fact]
+        public void Github_StartsWithShebang()
+        {
+            var githubOrg = "foo-gh-org";
+            var adoOrg = "foo-ado-org";
+            var adoTeamProject = "foo-team-project";
+            var repo = "foo-repo";
+
+            var repos = new Dictionary<string, IDictionary<string, IEnumerable<string>>>
+            {
+                { adoOrg, new Dictionary<string, IEnumerable<string>>() }
+            };
+
+            repos[adoOrg].Add(adoTeamProject, new List<string>() { repo });
+
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
+            var script = command.GenerateScript(repos, null, null, githubOrg, false, false);
+
+            script.Should().StartWith("#!/usr/bin/pwsh");
+        }
+
 
         [Fact]
         public void Single_Repo()

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -43,6 +43,19 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         }
 
         [Fact]
+        public void Github_StartsWithShebang()
+        {
+            var repo = "foo-repo";
+            var repos = new List<string>() { repo };
+
+            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
+            var script = command.GenerateGithubScript(repos, SOURCE_ORG, TARGET_ORG, "", "", false, false);
+
+            script.Should().StartWith("#!/usr/bin/pwsh");
+
+        }
+
+        [Fact]
         public void Github_Single_Repo()
         {
             var repo = "foo-repo";

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -233,7 +233,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             var content = new StringBuilder();
 
-            content.AppendLine(@"
+            content.AppendLine(@"#!/usr/bin/pwsh
+
 function Exec {
     param (
         [scriptblock]$ScriptBlock

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -4,8 +4,10 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using Mono.Unix;
 
 namespace OctoshiftCLI.AdoToGithub.Commands
 {
@@ -93,6 +95,12 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             if (output != null)
             {
                 File.WriteAllText(output.FullName, script);
+                // +x so script can be executed on macos and linux
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    var unixFileInfo = new UnixFileInfo(output.FullName);
+                    unixFileInfo.FileAccessPermissions |= FileAccessPermissions.UserExecute | FileAccessPermissions.GroupExecute | FileAccessPermissions.OtherExecute;
+                }
             }
         }
 

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -7,8 +7,8 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
-using OctoshiftCLI.Extensions;
 using Mono.Unix;
+using OctoshiftCLI.Extensions;
 
 namespace OctoshiftCLI.AdoToGithub.Commands
 {

--- a/src/ado2gh/ado2gh.csproj
+++ b/src/ado2gh/ado2gh.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />    
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.21216.1" />
   </ItemGroup>

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -4,8 +4,10 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using Mono.Unix;
 
 namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 {
@@ -150,6 +152,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             if (output != null)
             {
                 File.WriteAllText(output.FullName, script);
+
+                // +x so script can be executed on macos and linux
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    var unixFileInfo = new UnixFileInfo(output.FullName);
+                    unixFileInfo.FileAccessPermissions |= FileAccessPermissions.UserExecute | FileAccessPermissions.GroupExecute | FileAccessPermissions.OtherExecute;
+                }
             }
         }
 
@@ -219,7 +228,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             var content = new StringBuilder();
 
-            content.AppendLine(@"
+            content.AppendLine(@"#!/usr/bin/pwsh
+
 function Exec {
     param (
         [scriptblock]$ScriptBlock

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -7,8 +7,8 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
-using OctoshiftCLI.Extensions;
 using Mono.Unix;
+using OctoshiftCLI.Extensions;
 
 namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 {

--- a/src/gei/gei.csproj
+++ b/src/gei/gei.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.21216.1" />
   </ItemGroup>


### PR DESCRIPTION
Add a `pwsh` shebang to the generated script and if the script is generated on a linux/macos operating system than executable bits are added to the generated file

generated script now starts with
```pwsh
#!/usr/bin/pwsh
....
```

This allows scripts to be executed directly from the CLI like explained in the docs.

Implements #279 

- [x] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [x] Issue linked