### PR TITLE
Add wait option migrate-repo

### DIFF
--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
@@ -16,7 +17,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new MigrateRepoCommand(null, null, null);
             command.Should().NotBeNull();
             command.Name.Should().Be("migrate-repo");
-            command.Options.Count.Should().Be(7);
+            command.Options.Count.Should().Be(8);
 
             TestHelpers.VerifyCommandOption(command.Options, "ado-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", true);
@@ -24,11 +25,76 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "github-repo", true);
             TestHelpers.VerifyCommandOption(command.Options, "ssh", false);
+            TestHelpers.VerifyCommandOption(command.Options, "wait", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
         [Fact]
         public async Task Happy_Path()
+        {
+            // Arrange
+            const string adoOrg = "FooOrg";
+            const string adoTeamProject = "BlahTeamProject";
+            const string adoRepo = "foo-repo";
+            const string githubOrg = "foo-gh-org";
+            const string githubRepo = "gh-repo";
+            var adoRepoUrl = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_git/{adoRepo}";
+            var adoToken = Guid.NewGuid().ToString();
+            var githubOrgId = Guid.NewGuid().ToString();
+            var migrationSourceId = Guid.NewGuid().ToString();
+            var migrationId = Guid.NewGuid().ToString();
+            var githubPat = Guid.NewGuid().ToString();
+
+            var mockGithub = new Mock<GithubApi>(null, null);
+            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, "", "").Result).Returns(migrationId);
+
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+
+            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
+            environmentVariableProviderMock
+                .Setup(m => m.GithubPersonalAccessToken())
+                .Returns(githubPat);
+            environmentVariableProviderMock
+                .Setup(m => m.AdoPersonalAccessToken())
+                .Returns(adoToken);
+
+            var actualLogOutput = new List<string>();
+            var mockLogger = new Mock<OctoLogger>();
+            mockLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
+
+            var expectedLogOutput = new List<string>
+            {
+                "Migrating Repo...",
+                $"ADO ORG: {adoOrg}",
+                $"ADO TEAM PROJECT: {adoTeamProject}",
+                $"ADO REPO: {adoRepo}",
+                $"GITHUB ORG: {githubOrg}",
+                $"GITHUB REPO: {githubRepo}",
+                $"A repository migration (ID: {migrationId}) was successfully queued."
+            };
+
+            // Act
+            var command = new MigrateRepoCommand(mockLogger.Object, mockGithubApiFactory.Object,
+                environmentVariableProviderMock.Object);
+            await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, wait: false);
+
+            // Assert
+            mockGithub.Verify(m => m.GetOrganizationId(githubOrg));
+            mockGithub.Verify(m => m.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat, false));
+            mockGithub.Verify(m => m.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, "", ""));
+
+            mockLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
+            actualLogOutput.Should().Equal(expectedLogOutput);
+
+            mockGithub.VerifyNoOtherCalls();
+            mockLogger.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task Happy_Path_With_Wait()
         {
             var adoOrg = "FooOrg";
             var adoTeamProject = "BlahTeamProject";
@@ -61,7 +127,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object,
                 environmentVariableProviderMock.Object);
-            await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo);
+            await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, wait: true);
 
             mockGithub.Verify(x => x.GetMigrationState(migrationId));
         }
@@ -100,13 +166,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object,
                 environmentVariableProviderMock.Object);
-            await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, true);
+            await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, true, true);
 
             mockGithub.Verify(x => x.GetMigrationState(migrationId));
         }
 
         [Fact]
-        public async Task Retries_When_Hosts_Error()
+        public async Task Retries_When_Hosts_Error_And_Wait_Is_On()
         {
             var adoOrg = "FooOrg";
             var adoTeamProject = "BlahTeamProject";
@@ -139,7 +205,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 .Returns(adoToken);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
-            await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo);
+            await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, wait: true);
 
             mockGithub.Verify(x => x.DeleteRepo(githubOrg, githubRepo));
             mockGithub.Verify(x => x.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, "", ""), Times.Exactly(2));

--- a/src/ado2gh/Commands/MigrateRepoCommand.cs
+++ b/src/ado2gh/Commands/MigrateRepoCommand.cs
@@ -50,6 +50,11 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                 IsRequired = false,
                 Description = "Uses SSH protocol instead of HTTPS to push a Git repository into the target repository on GitHub."
             };
+            var wait = new Option("--wait")
+            {
+                IsRequired = false,
+                Description = "Synchronously waits for the repo migration to finish."
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -61,12 +66,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(githubOrg);
             AddOption(githubRepo);
             AddOption(ssh);
+            AddOption(wait);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, string, bool, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, string, bool, bool, bool>(Invoke);
         }
 
-        public async Task Invoke(string adoOrg, string adoTeamProject, string adoRepo, string githubOrg, string githubRepo, bool ssh = false, bool verbose = false)
+        public async Task Invoke(string adoOrg, string adoTeamProject, string adoRepo, string githubOrg, string githubRepo, bool ssh = false, bool wait = true, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -80,6 +86,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 _log.LogInformation("SSH: true");
             }
+            if (wait)
+            {
+                _log.LogInformation("WAIT: true");
+            }
 
             var adoRepoUrl = GetAdoRepoUrl(adoOrg, adoTeamProject, adoRepo);
 
@@ -89,6 +99,12 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
             var migrationSourceId = await githubApi.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat, ssh);
             var migrationId = await githubApi.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo);
+
+            if (!wait)
+            {
+                _log.LogInformation($"A repository migration (ID: {migrationId}) was successfully queued.");
+                return;
+            }
 
             var migrationState = await githubApi.GetMigrationState(migrationId);
 


### PR DESCRIPTION
Closes #234 

This PR adds the `--wait` option to the `migrate-repo` command. Be default it is `false` so the `migrate-repo` will queue up a migration and print out the returned `migration_id` to be queried later.

NOTE: For the sake of creating smaller PRs, the `--wait` option is set to `true` by default in order to not break the current `generate-script` behavior. Once the new `generate-script` changes are out as part of #241 to generate a parallel migration script, it should be set back to `false`.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked