### PR TITLE
Add GraphQL pagination support

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,4 +2,3 @@
 - Add `--wait` option to `migrate-repo` command. If set to `true` (default is `false`) it will synchronously wait for the migration to finish, otherwise it will just queue up a repo migration and return the `migration-id`.
 - Support parallel migrations with `generate-script` for both `ado2gh` and `gh gei`. `generate-script` now by default generates a script to perform migrations in parallel. Adding `--sequential` flag will force migrations to perform in a sequential (one by one) fashion.
 - Deprecate `--ssh` flag in `generate-script` and `migrate-repo` commands for both `ado2gh` and `gh gei`.
-- GraphQL API calls now support getting paginated results.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,3 +2,4 @@
 - Add `--wait` option to `migrate-repo` command. If set to `true` (default is `false`) it will synchronously wait for the migration to finish, otherwise it will just queue up a repo migration and return the `migration-id`.
 - Support parallel migrations with `generate-script` for both `ado2gh` and `gh gei`. `generate-script` now by default generates a script to perform migrations in parallel. Adding `--sequential` flag will force migrations to perform in a sequential (one by one) fashion.
 - Deprecate `--ssh` flag in `generate-script` and `migrate-repo` commands for both `ado2gh` and `gh gei`.
+- GraphQL API calls now support getting paginated results.

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -66,6 +66,11 @@ namespace OctoshiftCLI
                 throw new ArgumentNullException(nameof(resultCollectionSelector));
             }
 
+            if (pageInfoSelector is null)
+            {
+                throw new ArgumentNullException(nameof(pageInfoSelector));
+            }
+
             var jBody = JObject.FromObject(body);
             jBody["variables"] ??= new JObject();
             jBody["variables"]["first"] = first;
@@ -82,7 +87,7 @@ namespace OctoshiftCLI
                     yield return jResult;
                 }
 
-                var pageInfo = pageInfoSelector?.Invoke(jContent);
+                var pageInfo = pageInfoSelector(jContent);
                 if (pageInfo is null)
                 {
                     yield break;

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -951,14 +951,14 @@ namespace OctoshiftCLI.Tests
                 .Setup(m => m.PostGraphQLWithPaginationAsync(
                     url,
                     It.Is<object>(x => Compact(x.ToJson()) == Compact(payload)),
-                    It.IsAny<Func<JObject,JArray>>(),
-                    It.IsAny<Func<JObject,JObject>>(),
+                    It.IsAny<Func<JObject, JArray>>(),
+                    It.IsAny<Func<JObject, JObject>>(),
                     It.IsAny<int>(),
                     null))
                 .Returns(new[]
                 {
-                    JToken.FromObject(migration1), 
-                    JToken.FromObject(migration2), 
+                    JToken.FromObject(migration1),
+                    JToken.FromObject(migration2),
                     JToken.FromObject(migration3),
                     JToken.FromObject(migration4)
                 }.ToAsyncEnumerable());

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -906,75 +907,61 @@ namespace OctoshiftCLI.Tests
                                         }
                                     } 
                                 }""" +
-                $",\"variables\":{{\"id\":\"{orgId}\", \"first\": 100, \"after\": null}}}}";
+                $",\"variables\":{{\"id\":\"{orgId}\"}}}}";
 
-            var migration1 = (MigrationId: "MIGRATION_ID_1", State: RepositoryMigrationStatus.Succeeded);
-            var migration2 = (MigrationId: "MIGRATION_ID_2", State: RepositoryMigrationStatus.InProgress);
-            var migration3 = (MigrationId: "MIGRATION_ID_3", State: RepositoryMigrationStatus.Failed);
-            var migration4 = (MigrationId: "MIGRATION_ID_4", State: RepositoryMigrationStatus.Queued);
-            var response = $@"
-            {{
-	            ""data"": {{
-                    ""node"": {{
-                        ""login"": ""github"",
-                        ""repositoryMigrations"": {{
-                            ""pageInfo"": {{
-                                ""endCursor"": ""Y3Vyc29yOnYyOpK5MjAyMi0wMi0xMFQyMzozMDozMCsw="",
-                                ""hasNextPage"": false
-                            }},
-                            ""totalCount"": 2,
-                            ""nodes"": [
-                                {{
-                                    ""id"": ""{migration1.MigrationId}"",
-                                    ""sourceUrl"": ""https://dev.azure.com/org/team_project/_git/repo_1"",
-                                    ""migrationSource"": {{
-                                        ""name"": ""Azure Devops Source""
-                                    }},
-                                    ""state"": ""{migration1.State}"",
-                                    ""failureReason"": """",
-                                    ""createdAt"": ""2022-02-10T23:30:30Z""
-                                }},
-                                {{
-                                    ""id"": ""{migration2.MigrationId}"",
-                                    ""sourceUrl"": ""https://dev.azure.com/org/team_project/_git/repo_2"",
-                                    ""migrationSource"": {{
-                                        ""name"": ""Azure Devops Source""
-                                    }},
-                                    ""state"": ""{migration2.State}"",
-                                    ""failureReason"": """",
-                                    ""createdAt"": ""2022-02-10T23:31:30Z""
-                                }},
-                                {{
-                                    ""id"": ""{migration3.MigrationId}"",
-                                    ""sourceUrl"": ""https://dev.azure.com/org/team_project/_git/repo_2"",
-                                    ""migrationSource"": {{
-                                        ""name"": ""Azure Devops Source""
-                                    }},
-                                    ""state"": ""{migration3.State}"",
-                                    ""failureReason"": """",
-                                    ""createdAt"": ""2022-02-10T23:32:30Z""
-                                }},
-                                {{
-                                    ""id"": ""{migration4.MigrationId}"",
-                                    ""sourceUrl"": ""https://dev.azure.com/org/team_project/_git/repo_2"",
-                                    ""migrationSource"": {{
-                                        ""name"": ""Azure Devops Source""
-                                    }},
-                                    ""state"": ""{migration4.State}"",
-                                    ""failureReason"": """",
-                                    ""createdAt"": ""2022-02-10T23:33:30Z""
-                                }}
-
-                            ]
-                        }}
-                    }}
-                }}
-            }}";
+            var migration1 = new
+            {
+                id = Guid.NewGuid().ToString(),
+                sourceUrl = "https://dev.azure.com/org/team_project/_git/repo_1",
+                migrationSource = new { name = "Azure Devops Source" },
+                state = RepositoryMigrationStatus.Succeeded,
+                failureReason = "",
+                createdAt = DateTime.UtcNow
+            };
+            var migration2 = new
+            {
+                id = Guid.NewGuid().ToString(),
+                sourceUrl = "https://dev.azure.com/org/team_project/_git/repo_2",
+                migrationSource = new { name = "Azure Devops Source" },
+                state = RepositoryMigrationStatus.InProgress,
+                failureReason = "",
+                createdAt = DateTime.UtcNow
+            };
+            var migration3 = new
+            {
+                id = Guid.NewGuid().ToString(),
+                sourceUrl = "https://dev.azure.com/org/team_project/_git/repo_3",
+                migrationSource = new { name = "Azure Devops Source" },
+                state = RepositoryMigrationStatus.Failed,
+                failureReason = "FAILURE_REASON",
+                createdAt = DateTime.UtcNow
+            };
+            var migration4 = new
+            {
+                id = Guid.NewGuid().ToString(),
+                sourceUrl = "https://dev.azure.com/org/team_project/_git/repo_4",
+                migrationSource = new { name = "Azure Devops Source" },
+                state = RepositoryMigrationStatus.Queued,
+                failureReason = "",
+                createdAt = DateTime.UtcNow
+            };
 
             var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => Compact(x.ToJson()) == Compact(payload))))
-                .ReturnsAsync(response);
+                .Setup(m => m.PostGraphQLWithPaginationAsync(
+                    url,
+                    It.Is<object>(x => Compact(x.ToJson()) == Compact(payload)),
+                    It.IsAny<Func<JObject,JArray>>(),
+                    It.IsAny<Func<JObject,JObject>>(),
+                    It.IsAny<int>(),
+                    null))
+                .Returns(new[]
+                {
+                    JToken.FromObject(migration1), 
+                    JToken.FromObject(migration2), 
+                    JToken.FromObject(migration3),
+                    JToken.FromObject(migration4)
+                }.ToAsyncEnumerable());
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
@@ -982,7 +969,13 @@ namespace OctoshiftCLI.Tests
 
             // Assert
             migrationStates.Should().HaveCount(4);
-            migrationStates.Should().Contain(new[] { migration1, migration2, migration3, migration4 });
+            migrationStates.Should().Contain(new[]
+            {
+                (Migration: migration1.id, State: migration1.state),
+                (Migration: migration2.id, State: migration2.state),
+                (Migration: migration3.id, State: migration3.state),
+                (Migration: migration4.id, State: migration4.state)
+            });
         }
 
         private string Compact(string source) =>

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -1178,7 +1178,7 @@ query($id: ID!, $first: Int, $after: String) {
             const string url = "https://example.com/graphql";
             using var httpClient = new HttpClient();
             var githubClient = new GithubClient(null, httpClient, PERSONAL_ACCESS_TOKEN);
-            
+
             // Act, Assert
             await githubClient
                 .Invoking(async client => await client.PostGraphQLWithPaginationAsync(url, "", null, null).ToListAsync())

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -8,6 +9,7 @@ using FluentAssertions;
 using Moq;
 using Moq.Protected;
 using Newtonsoft.Json.Linq;
+using OctoshiftCLI.Extensions;
 using Xunit;
 
 namespace OctoshiftCLI.Tests
@@ -874,6 +876,235 @@ namespace OctoshiftCLI.Tests
                 .ThrowExactlyAsync<HttpRequestException>();
         }
 
+        [Fact]
+        public async Task PostGraphQLWithPaginationAsync_Should_Return_All_Pages()
+        {
+            // Arrange
+            const string url = "https://example.com/graphql";
+            const string orgId = "ORG_ID";
+            const string query = @"
+query($id: ID!, $first: Int, $after: String) {
+    node(id: $id) { 
+        ... on Organization { 
+            login, 
+            repositoryMigrations(first: $first, after: $after) {
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+                totalCount
+                nodes {
+                    id
+                    sourceUrl
+                    migrationSource { name }
+                    state
+                    failureReason
+                    createdAt
+                }
+            }
+        }
+    }
+}";
+
+            // first request/response
+            var firstRequestVariables = new { id = orgId, first = 2, after = (string)null };
+            var firstRequestBody = new { query, variables = firstRequestVariables };
+            var firstResponseEndCursor = Guid.NewGuid().ToString();
+            var repoMigration1 = CreateRepositoryMigration();
+            var repoMigration2 = CreateRepositoryMigration();
+            var firstResponseContent = new
+            {
+                data = new
+                {
+                    node = new
+                    {
+                        login = "github",
+                        repositoryMigrations = new
+                        {
+                            pageInfo = new { endCursor = firstResponseEndCursor, hasNextPage = true },
+                            totalCount = 5,
+                            nodes = new[] { repoMigration1, repoMigration2 }
+                        }
+                    }
+                }
+            };
+            using var firstResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(firstResponseContent.ToJson())
+            };
+
+            // second request/response
+            var secondRequestVariables = new { id = orgId, first = 2, after = firstResponseEndCursor };
+            var secondResponseEndCursor = Guid.NewGuid().ToString();
+            var repoMigration3 = CreateRepositoryMigration();
+            var repoMigration4 = CreateRepositoryMigration();
+            var secondResponseContent = new
+            {
+                data = new
+                {
+                    node = new
+                    {
+                        login = "github",
+                        repositoryMigrations = new
+                        {
+                            pageInfo = new { endCursor = secondResponseEndCursor, hasNextPage = true },
+                            totalCount = 5,
+                            nodes = new[] { repoMigration3, repoMigration4 }
+                        }
+                    }
+                }
+            };
+            using var secondResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(secondResponseContent.ToJson())
+            };
+            var secondRequestBody = new { query, variables = secondRequestVariables };
+
+            // third request/response
+            var thirdRequestVariables = new { id = orgId, first = 2, after = secondResponseEndCursor };
+            var repoMigration5 = CreateRepositoryMigration();
+            var thirdResponseContent = new
+            {
+                data = new
+                {
+                    node = new
+                    {
+                        login = "github",
+                        repositoryMigrations = new
+                        {
+                            pageInfo = new { endCursor = Guid.NewGuid().ToString(), hasNextPage = false },
+                            totalCount = 5,
+                            nodes = new[] { repoMigration5 }
+                        }
+                    }
+                }
+            };
+            using var thirdResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(thirdResponseContent.ToJson())
+            };
+            var thirdRequestBody = new { query, variables = thirdRequestVariables };
+
+            var handlerMock = MockHttpHandler(
+                req => req.Method == HttpMethod.Post && req.RequestUri.ToString() == url && req.Content.ReadAsStringAsync().Result == firstRequestBody.ToJson(),
+                firstResponse); // first request
+            MockHttpHandler(
+                req => req.Method == HttpMethod.Post && req.RequestUri.ToString() == url && req.Content.ReadAsStringAsync().Result == secondRequestBody.ToJson(),
+                secondResponse,
+                handlerMock); // second request
+            MockHttpHandler(
+                req => req.Method == HttpMethod.Post && req.RequestUri.ToString() == url && req.Content.ReadAsStringAsync().Result == thirdRequestBody.ToJson(),
+                thirdResponse,
+                handlerMock); // third request
+
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
+
+            // Act
+            var result = await githubClient.PostGraphQLWithPaginationAsync(
+                    url,
+                    firstRequestBody,
+                    obj => (JArray)obj["data"]["node"]["repositoryMigrations"]["nodes"],
+                    obj => (JObject)obj["data"]["node"]["repositoryMigrations"]["pageInfo"],
+                    2)
+                .ToListAsync();
+
+
+            // Assert
+            result.Should().HaveCount(5);
+            result[0].ToJson().Should().Be(repoMigration1.ToJson());
+            result[1].ToJson().Should().Be(repoMigration2.ToJson());
+            result[2].ToJson().Should().Be(repoMigration3.ToJson());
+            result[3].ToJson().Should().Be(repoMigration4.ToJson());
+            result[4].ToJson().Should().Be(repoMigration5.ToJson());
+        }
+
+        [Fact]
+        public async Task PostGraphQLWithPaginationAsync_Should_Create_Variables_If_Missing()
+        {
+            // Arrange
+            const string url = "https://example.com/graphql";
+            const string query = @"
+query($id: ID!, $first: Int, $after: String) {
+    node(id: $id) { 
+        ... on Organization { 
+            login, 
+            repositoryMigrations(first: $first, after: $after) {
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+                totalCount
+                nodes {
+                    id
+                    sourceUrl
+                    migrationSource { name }
+                    state
+                    failureReason
+                    createdAt
+                }
+            }
+        }
+    }
+}";
+
+            // first request/response
+            var requestVariables = new { first = 2, after = (string)null };
+            var requestBody = new { query, variables = requestVariables };
+            var repoMigration = CreateRepositoryMigration();
+            var responseContent = new
+            {
+                data = new
+                {
+                    node = new
+                    {
+                        login = "github",
+                        repositoryMigrations = new
+                        {
+                            pageInfo = new { endCursor = Guid.NewGuid().ToString(), hasNextPage = false },
+                            totalCount = 1,
+                            nodes = new[] { repoMigration }
+                        }
+                    }
+                }
+            };
+            using var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseContent.ToJson())
+            };
+
+            var handlerMock = MockHttpHandler(
+                req => req.Method == HttpMethod.Post && req.RequestUri.ToString() == url && req.Content.ReadAsStringAsync().Result == requestBody.ToJson(),
+                response);
+
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_loggerMock.Object, httpClient, PERSONAL_ACCESS_TOKEN);
+
+            // Act
+            var result = await githubClient.PostGraphQLWithPaginationAsync(
+                    url,
+                    new { query },
+                    obj => (JArray)obj["data"]["node"]["repositoryMigrations"]["nodes"],
+                    obj => (JObject)obj["data"]["node"]["repositoryMigrations"]["pageInfo"],
+                    2)
+                .ToListAsync();
+
+            // Assert
+            result.Should().HaveCount(1);
+            result[0].ToJson().Should().Be(repoMigration.ToJson());
+        }
+
+        private object CreateRepositoryMigration(string migrationId = null, string state = RepositoryMigrationStatus.Succeeded) =>
+            new
+            {
+                id = migrationId ?? Guid.NewGuid().ToString(),
+                sourceUrl = "SOURCE_URL",
+                migrationSource = new { name = "Azure Devops Source" },
+                state,
+                failureReason = "",
+                createdAt = DateTime.UtcNow
+            };
+
         private Mock<HttpMessageHandler> MockHttpHandlerForGet() =>
             MockHttpHandler(req => req.Method == HttpMethod.Get);
 
@@ -895,16 +1126,19 @@ namespace OctoshiftCLI.Tests
                 req.Content.ReadAsStringAsync().Result == EXPECTED_JSON_REQUEST_BODY
                 && req.Method == HttpMethod.Patch);
 
-        private Mock<HttpMessageHandler> MockHttpHandler(Func<HttpRequestMessage, bool> requestMatcher)
+        private Mock<HttpMessageHandler> MockHttpHandler(
+            Func<HttpRequestMessage, bool> requestMatcher,
+            HttpResponseMessage httpResponse = null,
+            Mock<HttpMessageHandler> handlerMock = null)
         {
-            var handlerMock = new Mock<HttpMessageHandler>();
+            handlerMock ??= new Mock<HttpMessageHandler>();
             handlerMock
                 .Protected()
                 .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
                     ItExpr.Is<HttpRequestMessage>(x => requestMatcher(x)),
                     ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(_httpResponse);
+                .ReturnsAsync(httpResponse ?? _httpResponse);
             return handlerMock;
         }
     }

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -1259,7 +1259,8 @@ query($id: ID!, $first: Int, $after: String) {
             await githubClient
                 .Invoking(async client => await client.PostGraphQLWithPaginationAsync(url, "", null, null).ToListAsync())
                 .Should()
-                .ThrowAsync<ArgumentNullException>();
+                .ThrowAsync<ArgumentNullException>()
+                .WithParameterName("resultCollectionSelector");
         }
 
         [Fact]
@@ -1421,6 +1422,22 @@ query($id: ID!, $first: Int, $after: String) {
                 Times.Once(),
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task PostGraphQLWithPaginationAsync_Throws_If_PageInfo_Selector_Is_Null()
+        {
+            // Arrange
+            const string url = "https://example.com/graphql";
+            using var httpClient = new HttpClient();
+            var githubClient = new GithubClient(null, httpClient, PERSONAL_ACCESS_TOKEN);
+
+            // Act, Assert
+            await githubClient
+                .Invoking(async client => await client.PostGraphQLWithPaginationAsync(url, "", x => (JArray)x["item"], null).ToListAsync())
+                .Should()
+                .ThrowAsync<ArgumentNullException>()
+                .WithParameterName("pageInfoSelector");
         }
 
         private object CreateRepositoryMigration(string migrationId = null, string state = RepositoryMigrationStatus.Succeeded) => new


### PR DESCRIPTION
Closes: #244 

### This PR contains the following changes
1. `GithubClient` now  supports getting paginated GraphQL results. In order to support GQL pagination, a dedicated method (`PostGraphQLWithPaginationAsync`) has been added.
2. In `GithubApi`, `GetMigrationStates` is now calling the `PostGraphQLWithPaginationAsync()` method instead of the generic `PostAsync()`.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked