### PR TITLE
Deprecate `--ssh` flag

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
 - Add `wait-for-migration` command. By default it waits for all ongoing migrations to finish and reports the number of in progress and queued migrations. If an optional `migration-id` is provided, it will return as soon as that migration is complete.
 - Add `--wait` option to `migrate-repo` command. If set to `true` (default is `false`) it will synchronously wait for the migration to finish, otherwise it will just queue up a repo migration and return the `migration-id`.
-- Support parallel migrations with `generate-script` for both `ado2gh` and `gh gei`. `generate-script` now by default generates a script to perform migrations in parallel. Adding `--sequential` flag will force migrations to perform in a sequential (one by one) fashion. 
+- Support parallel migrations with `generate-script` for both `ado2gh` and `gh gei`. `generate-script` now by default generates a script to perform migrations in parallel. Adding `--sequential` flag will force migrations to perform in a sequential (one by one) fashion.
+- Deprecate `--ssh` flag in `generate-script` and `migrate-repo` commands for both `ado2gh` and `gh gei`.

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -102,7 +102,7 @@ namespace OctoshiftCLI
             return (string)data["data"]["organization"]["id"];
         }
 
-        public virtual async Task<string> CreateAdoMigrationSource(string orgId, string adoToken, string githubPat, bool ssh = false)
+        public virtual async Task<string> CreateAdoMigrationSource(string orgId, string adoToken, string githubPat)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -119,7 +119,7 @@ namespace OctoshiftCLI
                     ownerId = orgId,
                     type = "AZURE_DEVOPS",
                     accessToken = adoToken,
-                    githubPat = !ssh ? githubPat : null
+                    githubPat
                 },
                 operationName = "createMigrationSource"
             };
@@ -130,7 +130,7 @@ namespace OctoshiftCLI
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
 
-        public virtual async Task<string> CreateGhecMigrationSource(string orgId, string sourceGithubPat, string targetGithubPat, bool ssh = false)
+        public virtual async Task<string> CreateGhecMigrationSource(string orgId, string sourceGithubPat, string targetGithubPat)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -147,7 +147,7 @@ namespace OctoshiftCLI
                     ownerId = orgId,
                     type = "GITHUB_ARCHIVE",
                     accessToken = sourceGithubPat,
-                    githubPat = !ssh ? targetGithubPat : null
+                    githubPat = targetGithubPat
                 },
                 operationName = "createMigrationSource"
             };

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -366,46 +366,6 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task CreateAdoMigrationSource_Using_Ssh()
-        {
-            // Arrange
-            const string url = "https://api.github.com/graphql";
-            const string orgId = "ORG_ID";
-            const string adoToken = "ADO_TOKEN";
-            const string githubPat = "GITHUB_PAT";
-            var payload =
-                "{\"query\":\"mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $accessToken: String!, $type: MigrationSourceType!, $githubPat: String) " +
-                "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, accessToken: $accessToken, type: $type, githubPat: $githubPat}) { migrationSource { id, name, url, type } } }\"" +
-                $",\"variables\":{{\"name\":\"Azure DevOps Source\",\"url\":\"https://dev.azure.com\",\"ownerId\":\"{orgId}\",\"type\":\"AZURE_DEVOPS\",\"accessToken\":\"{adoToken}\",\"githubPat\":null}},\"operationName\":\"createMigrationSource\"}}";
-            const string actualMigrationSourceId = "MS_kgC4NjFhOTVjOTc4ZTRhZjEwMDA5NjNhOTdm";
-            var response = $@"
-            {{
-                ""data"": {{
-                    ""createMigrationSource"": {{
-                        ""migrationSource"": {{
-                            ""id"": ""{actualMigrationSourceId}"",
-                            ""name"": ""Azure Devops Source"",
-                            ""url"": ""https://dev.azure.com"",
-                            ""type"": ""AZURE_DEVOPS""
-                        }}
-                    }}
-                }}
-            }}";
-
-            var githubClientMock = new Mock<GithubClient>(null, null, null);
-            githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
-                .ReturnsAsync(response);
-
-            // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
-            var expectedMigrationSourceId = await githubApi.CreateAdoMigrationSource(orgId, adoToken, githubPat, true);
-
-            // Assert
-            expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
-        }
-
-        [Fact]
         public async Task CreateGhecMigrationSource_Returns_New_Migration_Source_Id()
         {
             // Arrange
@@ -440,46 +400,6 @@ namespace OctoshiftCLI.Tests
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
             var expectedMigrationSourceId = await githubApi.CreateGhecMigrationSource(orgId, sourceGithubPat, targetGithubPat);
-
-            // Assert
-            expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
-        }
-
-        [Fact]
-        public async Task CreateGhecMigrationSource_Using_Ssh()
-        {
-            // Arrange 
-            const string url = "https://api.github.com/graphql";
-            const string orgId = "ORG_ID";
-            const string sourceGithubPat = "SOURCE_GITHUB_PAT";
-            const string targetGithubPat = "target_GITHUB_PAT";
-            var payload =
-                "{\"query\":\"mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $accessToken: String!, $type: MigrationSourceType!, $githubPat: String) " +
-                "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, accessToken: $accessToken, type: $type, githubPat: $githubPat}) { migrationSource { id, name, url, type } } }\"" +
-                $",\"variables\":{{\"name\":\"GHEC Source\",\"url\":\"https://github.com\",\"ownerId\":\"{orgId}\",\"type\":\"GITHUB_ARCHIVE\",\"accessToken\":\"{sourceGithubPat}\",\"githubPat\":null}},\"operationName\":\"createMigrationSource\"}}";
-            const string actualMigrationSourceId = "MS_kgC4NjFhOTVjOTc4ZTRhZjEwMDA5NjNhOTdm";
-            var response = $@"
-            {{
-                ""data"": {{
-                    ""createMigrationSource"": {{
-                        ""migrationSource"": {{
-                            ""id"": ""{actualMigrationSourceId}"",
-                            ""name"": ""GHEC Source"",
-                            ""url"": ""https://github.com"",
-                            ""type"": ""GITHUB_ARCHIVE""
-                        }}
-                    }}
-                }}
-            }}";
-
-            var githubClientMock = new Mock<GithubClient>(null, null, null);
-            githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
-                .ReturnsAsync(response);
-
-            // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
-            var expectedMigrationSourceId = await githubApi.CreateGhecMigrationSource(orgId, sourceGithubPat, targetGithubPat, true);
 
             // Assert
             expectedMigrationSourceId.Should().Be(actualMigrationSourceId);

--- a/src/OctoshiftCLI.Tests/TestHelpers.cs
+++ b/src/OctoshiftCLI.Tests/TestHelpers.cs
@@ -31,11 +31,12 @@ namespace OctoshiftCLI.Tests
         #endregion
 
         #region Command Helpers
-        public static void VerifyCommandOption(IReadOnlyList<Option> options, string name, bool required)
+        public static void VerifyCommandOption(IReadOnlyList<Option> options, string name, bool required, bool isHidden = false)
         {
             var option = options.Single(x => x.Name == name);
 
             Assert.Equal(required, option.IsRequired);
+            Assert.Equal(isHidden, option.IsHidden);
         }
         #endregion
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -37,7 +37,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var githubOrg = "foo-gh-org";
 
             var command = new GenerateScriptCommand(null, null);
-            var script = command.GenerateSequentialScript(null, null, null, githubOrg, false, false);
+            var script = command.GenerateSequentialScript(null, null, null, githubOrg, false);
 
             Assert.True(string.IsNullOrWhiteSpace(script));
         }
@@ -58,7 +58,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             repos[adoOrg].Add(adoTeamProject, new List<string>() { repo });
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var script = command.GenerateSequentialScript(repos, null, null, githubOrg, false, false);
+            var script = command.GenerateSequentialScript(repos, null, null, githubOrg, false);
 
             script = TrimNonExecutableLines(script);
 
@@ -98,7 +98,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             repos[adoOrg].Add(adoTeamProject, new List<string>());
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var script = command.GenerateSequentialScript(repos, null, null, githubOrg, false, false);
+            var script = command.GenerateSequentialScript(repos, null, null, githubOrg, false);
 
             script = TrimNonExecutableLines(script);
 
@@ -137,7 +137,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var script = command.GenerateSequentialScript(repos, pipelines, appIds, githubOrg, false, false);
+            var script = command.GenerateSequentialScript(repos, pipelines, appIds, githubOrg, false);
 
             script = TrimNonExecutableLines(script);
 
@@ -196,7 +196,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var appIds = new Dictionary<string, string>();
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var script = command.GenerateSequentialScript(repos, pipelines, appIds, githubOrg, false, false);
+            var script = command.GenerateSequentialScript(repos, pipelines, appIds, githubOrg, false);
 
             script = TrimNonExecutableLines(script);
 
@@ -242,39 +242,11 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var reposOnlyField = typeof(GenerateScriptCommand).GetField("_reposOnly", BindingFlags.Instance | BindingFlags.NonPublic);
             reposOnlyField.SetValue(command, true);
 
-            var script = command.GenerateSequentialScript(repos, null, null, githubOrg, false, false);
+            var script = command.GenerateSequentialScript(repos, null, null, githubOrg, false);
 
             script = TrimNonExecutableLines(script);
 
             var expected = $"Exec {{ ./ado2gh migrate-repo --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{repo}\" --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\" --wait }}";
-
-            Assert.Equal(expected, script);
-        }
-
-        [Fact]
-        public void Single_Repo_Repos_Only_With_Ssh()
-        {
-            var githubOrg = "foo-gh-org";
-            var adoOrg = "foo-ado-org";
-            var adoTeamProject = "foo-team-project";
-            var repo = "foo-repo";
-
-            var repos = new Dictionary<string, IDictionary<string, IEnumerable<string>>>
-            {
-                { adoOrg, new Dictionary<string, IEnumerable<string>>() }
-            };
-
-            repos[adoOrg].Add(adoTeamProject, new List<string>() { repo });
-
-            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var reposOnlyField = typeof(GenerateScriptCommand).GetField("_reposOnly", BindingFlags.Instance | BindingFlags.NonPublic);
-            reposOnlyField.SetValue(command, true);
-
-            var script = command.GenerateSequentialScript(repos, null, null, githubOrg, false, true);
-
-            script = TrimNonExecutableLines(script);
-
-            var expected = $"Exec {{ ./ado2gh migrate-repo --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{repo}\" --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{repo}\" --ssh --wait }}";
 
             Assert.Equal(expected, script);
         }
@@ -295,7 +267,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             repos[adoOrg].Add(adoTeamProject, new List<string>() { repo });
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var script = command.GenerateSequentialScript(repos, null, null, githubOrg, true, false);
+            var script = command.GenerateSequentialScript(repos, null, null, githubOrg, true);
 
             script = TrimNonExecutableLines(script);
 
@@ -573,7 +545,7 @@ if ($Failed -ne 0) {
 
             // Act
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var actual = command.GenerateParallelScript(repos, pipelines, appIds, githubOrg, false, false);
+            var actual = command.GenerateParallelScript(repos, pipelines, appIds, githubOrg, false);
 
             // Assert
             actual.Should().Be(expected.ToString());
@@ -698,7 +670,7 @@ if ($Failed -ne 0) {
             var reposOnlyField = typeof(GenerateScriptCommand).GetField("_reposOnly", BindingFlags.Instance | BindingFlags.NonPublic);
             reposOnlyField.SetValue(command, true);
 
-            var actual = command.GenerateParallelScript(repos, pipelines, appIds, githubOrg, false, false);
+            var actual = command.GenerateParallelScript(repos, pipelines, appIds, githubOrg, false);
 
             // Assert
             actual.Should().Be(expected.ToString());
@@ -711,135 +683,10 @@ if ($Failed -ne 0) {
             var command = new GenerateScriptCommand(null, null);
 
             // Act
-            var script = command.GenerateParallelScript(null, null, null, null, false, false);
+            var script = command.GenerateParallelScript(null, null, null, null, false);
 
             // Assert
             script.Should().BeEmpty();
-        }
-
-        [Fact]
-        public void GenerateParallelScript_Single_Repo_Repos_Only_With_Ssh()
-        {
-            // Arrange
-            const string adoOrg = "ADO_ORG";
-            const string adoTeamProject = "ADO_TEAM_PROJECT";
-            const string fooRepo = "FOO_REPO";
-            const string fooPipeline = "FOO_PIPELINE";
-            const string appId = "d9edf292-c6fd-4440-af2b-d08fcc9c9dd1";
-            const string githubOrg = "GITHUB_ORG";
-
-            var repos = new Dictionary<string, IDictionary<string, IEnumerable<string>>>
-            {
-                {
-                    adoOrg,
-                    new Dictionary<string, IEnumerable<string>>
-                    {
-                        { adoTeamProject, new[] { fooRepo } }
-                    }
-                }
-            };
-
-            var pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>
-            {
-                {
-                    adoOrg,
-                    new Dictionary<string, IDictionary<string, IEnumerable<string>>>
-                    {
-                        {
-                            adoTeamProject,
-                            new Dictionary<string, IEnumerable<string>>
-                            {
-                                { fooRepo, new[] { fooPipeline } }
-                            }
-                        }
-                    }
-                }
-            };
-
-            var appIds = new Dictionary<string, string> { { adoOrg, appId } };
-
-            var expected = new StringBuilder();
-            expected.AppendLine(@"
-function Exec {
-    param (
-        [scriptblock]$ScriptBlock
-    )
-    & @ScriptBlock
-    if ($lastexitcode -ne 0) {
-        exit $lastexitcode
-    }
-}");
-            expected.AppendLine(@"
-function ExecAndGetMigrationID {
-    param (
-        [scriptblock]$ScriptBlock
-    )
-    $MigrationID = Exec $ScriptBlock | ForEach-Object {
-        Write-Host $_
-        $_
-    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
-    return $MigrationID
-}");
-            expected.AppendLine(@"
-function ExecBatch {
-    param (
-        [scriptblock[]]$ScriptBlocks
-    )
-    $Global:LastBatchFailures = 0
-    foreach ($ScriptBlock in $ScriptBlocks)
-    {
-        & @ScriptBlock
-        if ($lastexitcode -ne 0) {
-            $Global:LastBatchFailures++
-        }
-    }
-}");
-            expected.AppendLine();
-            expected.AppendLine("$Succeeded = 0");
-            expected.AppendLine("$Failed = 0");
-            expected.AppendLine("$RepoMigrations = [ordered]@{}");
-            expected.AppendLine();
-            expected.AppendLine($"# =========== Queueing migration for Organization: {adoOrg} ===========");
-            expected.AppendLine();
-            expected.AppendLine($"# === Queueing repo migrations for Team Project: {adoOrg}/{adoTeamProject} ===");
-            expected.AppendLine();
-            expected.AppendLine();
-            expected.AppendLine();
-            expected.AppendLine();
-            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{fooRepo}\" --github-org \"{githubOrg}\" --github-repo \"{adoTeamProject}-{fooRepo}\" --ssh }}");
-            expected.AppendLine($"$RepoMigrations[\"{adoOrg}/{adoTeamProject}-{fooRepo}\"] = $MigrationID");
-            expected.AppendLine();
-            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {adoOrg} ===========");
-            expected.AppendLine();
-            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {adoTeamProject} and Repo: {fooRepo}. Will then complete the below post migration steps. ===");
-            expected.AppendLine($"./ado2gh wait-for-migration --github-org \"{githubOrg}\" --migration-id $RepoMigrations[\"{adoOrg}/{adoTeamProject}-{fooRepo}\"]");
-            expected.AppendLine("if ($lastexitcode -eq 0) {");
-            expected.AppendLine("    $Succeeded++");
-            expected.AppendLine("} else {");
-            expected.AppendLine("    $Failed++");
-            expected.AppendLine("}");
-            expected.AppendLine();
-            expected.AppendLine("Write-Host =============== Summary ===============");
-            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
-            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
-            expected.AppendLine(@"
-if ($Failed -ne 0) {
-    exit 1
-}");
-            expected.AppendLine();
-            expected.AppendLine();
-
-            // Act
-            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            // The way reposOnly is implemented is kind of hacky, this will change when we refactor all the options in issue #21
-            // for now going to leave it as is and use reflection to force the test to work
-            var reposOnlyField = typeof(GenerateScriptCommand).GetField("_reposOnly", BindingFlags.Instance | BindingFlags.NonPublic);
-            reposOnlyField.SetValue(command, true);
-
-            var actual = command.GenerateParallelScript(repos, pipelines, appIds, githubOrg, false, true);
-
-            // Assert
-            actual.Should().Be(expected.ToString());
         }
 
         [Fact]
@@ -965,7 +812,7 @@ if ($Failed -ne 0) {
 
             // Act
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var actual = command.GenerateParallelScript(repos, pipelines, appIds, githubOrg, true, false);
+            var actual = command.GenerateParallelScript(repos, pipelines, appIds, githubOrg, true);
 
             // Assert
             actual.Should().Be(expected.ToString());
@@ -1094,7 +941,7 @@ if ($Failed -ne 0) {
 
             // Act
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null);
-            var actual = command.GenerateParallelScript(repos, pipelines, appIds, githubOrg, false, false);
+            var actual = command.GenerateParallelScript(repos, pipelines, appIds, githubOrg, false);
 
             // Assert
             actual.Should().Be(expected.ToString());

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -26,7 +26,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             TestHelpers.VerifyCommandOption(command.Options, "output", false);
             TestHelpers.VerifyCommandOption(command.Options, "repos-only", false);
             TestHelpers.VerifyCommandOption(command.Options, "skip-idp", false);
-            TestHelpers.VerifyCommandOption(command.Options, "ssh", false);
+            TestHelpers.VerifyCommandOption(command.Options, "ssh", false, true);
             TestHelpers.VerifyCommandOption(command.Options, "sequential", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
@@ -47,7 +47,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, "", "").Result).Returns(migrationId);
 
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
@@ -83,7 +83,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             // Assert
             mockGithub.Verify(m => m.GetOrganizationId(githubOrg));
-            mockGithub.Verify(m => m.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat, false));
+            mockGithub.Verify(m => m.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat));
             mockGithub.Verify(m => m.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, "", ""));
 
             mockLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
@@ -110,7 +110,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, "", "").Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
@@ -133,45 +133,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         }
 
         [Fact]
-        public async Task With_Ssh()
-        {
-            var adoOrg = "FooOrg";
-            var adoTeamProject = "BlahTeamProject";
-            var adoRepo = "foo-repo";
-            var githubOrg = "foo-gh-org";
-            var githubRepo = "gh-repo";
-            var adoRepoUrl = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_git/{adoRepo}";
-            var adoToken = Guid.NewGuid().ToString();
-            var githubOrgId = Guid.NewGuid().ToString();
-            var migrationSourceId = Guid.NewGuid().ToString();
-            var migrationId = Guid.NewGuid().ToString();
-            var githubPat = Guid.NewGuid().ToString();
-
-            var mockGithub = new Mock<GithubApi>(null, null);
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat, true).Result).Returns(migrationSourceId);
-            mockGithub.Setup(x => x.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, "", "").Result).Returns(migrationId);
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
-
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
-
-            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
-            environmentVariableProviderMock
-                .Setup(m => m.GithubPersonalAccessToken())
-                .Returns(githubPat);
-            environmentVariableProviderMock
-                .Setup(m => m.AdoPersonalAccessToken())
-                .Returns(adoToken);
-
-            var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object,
-                environmentVariableProviderMock.Object);
-            await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, true, true);
-
-            mockGithub.Verify(x => x.GetMigrationState(migrationId));
-        }
-
-        [Fact]
         public async Task Retries_When_Hosts_Error_And_Wait_Is_On()
         {
             var adoOrg = "FooOrg";
@@ -188,7 +149,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, "", "").Result).Returns(migrationId);
             mockGithub.SetupSequence(x => x.GetMigrationState(migrationId).Result).Returns("FAILED").Returns("SUCCEEDED");
             mockGithub.Setup(x => x.GetMigrationFailureReason(migrationId).Result).Returns("Warning: Permanently added XXXXX (ECDSA) to the list of known hosts");

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
@@ -131,45 +131,5 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             mockGithub.Verify(x => x.GetMigrationState(migrationId));
         }
-
-        [Fact]
-        public async Task Retries_When_Hosts_Error_And_Wait_Is_On()
-        {
-            var adoOrg = "FooOrg";
-            var adoTeamProject = "BlahTeamProject";
-            var adoRepo = "foo-repo";
-            var githubOrg = "foo-gh-org";
-            var githubRepo = "gh-repo";
-            var adoRepoUrl = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_git/{adoRepo}";
-            var adoToken = Guid.NewGuid().ToString();
-            var githubOrgId = Guid.NewGuid().ToString();
-            var migrationSourceId = Guid.NewGuid().ToString();
-            var migrationId = Guid.NewGuid().ToString();
-            var githubPat = Guid.NewGuid().ToString();
-
-            var mockGithub = new Mock<GithubApi>(null, null);
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat).Result).Returns(migrationSourceId);
-            mockGithub.Setup(x => x.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, "", "").Result).Returns(migrationId);
-            mockGithub.SetupSequence(x => x.GetMigrationState(migrationId).Result).Returns("FAILED").Returns("SUCCEEDED");
-            mockGithub.Setup(x => x.GetMigrationFailureReason(migrationId).Result).Returns("Warning: Permanently added XXXXX (ECDSA) to the list of known hosts");
-
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
-
-            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
-            environmentVariableProviderMock
-                .Setup(m => m.GithubPersonalAccessToken())
-                .Returns(githubPat);
-            environmentVariableProviderMock
-                .Setup(m => m.AdoPersonalAccessToken())
-                .Returns(adoToken);
-
-            var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
-            await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, wait: true);
-
-            mockGithub.Verify(x => x.DeleteRepo(githubOrg, githubRepo));
-            mockGithub.Verify(x => x.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, "", ""), Times.Exactly(2));
-        }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
@@ -24,7 +24,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             TestHelpers.VerifyCommandOption(command.Options, "ado-repo", true);
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "github-repo", true);
-            TestHelpers.VerifyCommandOption(command.Options, "ssh", false);
+            TestHelpers.VerifyCommandOption(command.Options, "ssh", false, true);
             TestHelpers.VerifyCommandOption(command.Options, "wait", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -39,7 +39,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         public void Github_No_Data()
         {
             var command = new GenerateScriptCommand(null, null, null, null);
-            var script = command.GenerateSequentialGithubScript(null, "foo-source", "foo-target", "", "", false, false);
+            var script = command.GenerateSequentialGithubScript(null, "foo-source", "foo-target", "", "", false);
 
             string.IsNullOrWhiteSpace(script).Should().BeTrue();
         }
@@ -51,7 +51,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var repos = new List<string>() { repo };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateSequentialGithubScript(repos, SOURCE_ORG, TARGET_ORG, "", "", false, false);
+            var script = command.GenerateSequentialGithubScript(repos, SOURCE_ORG, TARGET_ORG, "", "", false);
 
             script = TrimNonExecutableLines(script);
 
@@ -69,7 +69,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var repos = new List<string>() { repo1, repo2, repo3 };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateSequentialGithubScript(repos, SOURCE_ORG, TARGET_ORG, "", "", false, false);
+            var script = command.GenerateSequentialGithubScript(repos, SOURCE_ORG, TARGET_ORG, "", "", false);
 
             script = TrimNonExecutableLines(script);
 
@@ -83,22 +83,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         }
 
         [Fact]
-        public void Github_With_Ssh()
-        {
-            var repo = "foo-repo";
-            var repos = new List<string>() { repo };
-
-            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateSequentialGithubScript(repos, SOURCE_ORG, TARGET_ORG, "", "", false, true);
-
-            script = TrimNonExecutableLines(script);
-
-            var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{repo}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{repo}\" --ssh --wait }}";
-
-            script.Should().Be(expected);
-        }
-
-        [Fact]
         public void Github_GHES_Repo()
         {
             var repo = "foo-repo";
@@ -107,7 +91,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var azureStorageConnectionString = "foo-storage-connection-string";
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateSequentialGithubScript(repos, SOURCE_ORG, TARGET_ORG, ghesApiUrl, azureStorageConnectionString, false, false);
+            var script = command.GenerateSequentialGithubScript(repos, SOURCE_ORG, TARGET_ORG, ghesApiUrl, azureStorageConnectionString, false);
 
             script = TrimNonExecutableLines(script);
 
@@ -125,7 +109,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var azureStorageConnectionString = "foo-storage-connection-string";
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateSequentialGithubScript(repos, SOURCE_ORG, TARGET_ORG, ghesApiUrl, azureStorageConnectionString, true, false);
+            var script = command.GenerateSequentialGithubScript(repos, SOURCE_ORG, TARGET_ORG, ghesApiUrl, azureStorageConnectionString, true);
 
             script = TrimNonExecutableLines(script);
 
@@ -138,7 +122,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         public void Ado_No_Data()
         {
             var command = new GenerateScriptCommand(null, null, null, null);
-            var script = command.GenerateSequentialAdoScript(null, "foo-source", "foo-target", false);
+            var script = command.GenerateSequentialAdoScript(null, "foo-source", "foo-target");
 
             string.IsNullOrWhiteSpace(script).Should().BeTrue();
         }
@@ -151,7 +135,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var repos = new Dictionary<string, IEnumerable<string>>() { { adoTeamProject, new List<string>() { repo } } };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateSequentialAdoScript(repos, SOURCE_ORG, TARGET_ORG, false);
+            var script = command.GenerateSequentialAdoScript(repos, SOURCE_ORG, TARGET_ORG);
 
             script = TrimNonExecutableLines(script);
 
@@ -170,7 +154,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var repos = new Dictionary<string, IEnumerable<string>> { { adoTeamProject, new List<string>() { repo1, repo2, repo3 } } };
 
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateSequentialAdoScript(repos, SOURCE_ORG, TARGET_ORG, false);
+            var script = command.GenerateSequentialAdoScript(repos, SOURCE_ORG, TARGET_ORG);
 
             script = TrimNonExecutableLines(script);
 
@@ -184,99 +168,14 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         }
 
         [Fact]
-        public void Ado_With_Ssh()
-        {
-            var adoTeamProject = "foo-team-project";
-            var repo = "foo-repo";
-            var repos = new Dictionary<string, IEnumerable<string>>() { { adoTeamProject, new List<string>() { repo } } };
-
-            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateSequentialAdoScript(repos, SOURCE_ORG, TARGET_ORG, true);
-
-            script = TrimNonExecutableLines(script);
-
-            var expected = $"Exec {{ gh gei migrate-repo --ado-source-org \"{SOURCE_ORG}\" --ado-team-project \"{adoTeamProject}\" --source-repo \"{repo}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{adoTeamProject}-{repo}\" --ssh --wait }}";
-
-            script.Should().Be(expected);
-        }
-
-        [Fact]
         public void GenerateParallelAdoScript_No_Data()
         {
             // Arrange, Act
             var command = new GenerateScriptCommand(null, null, null, null);
-            var script = command.GenerateParallelAdoScript(null, "foo-source", "foo-target", false);
+            var script = command.GenerateParallelAdoScript(null, "foo-source", "foo-target");
 
             // Assert
             script.Should().BeEmpty();
-        }
-
-        [Fact]
-        public void GenerateParallelAdoScript_Single_Repo_With_Ssh()
-        {
-            // Arrange
-            const string adoTeamProject = "foo-team-project";
-            const string repo = "foo-repo";
-            var repos = new Dictionary<string, IEnumerable<string>> { { adoTeamProject, new[] { repo } } };
-
-            var expected = new StringBuilder();
-            expected.AppendLine(@"
-function Exec {
-    param (
-        [scriptblock]$ScriptBlock
-    )
-    & @ScriptBlock
-    if ($lastexitcode -ne 0) {
-        exit $lastexitcode
-    }
-}");
-            expected.AppendLine(@"
-function ExecAndGetMigrationID {
-    param (
-        [scriptblock]$ScriptBlock
-    )
-    $MigrationID = Exec $ScriptBlock | ForEach-Object {
-        Write-Host $_
-        $_
-    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
-    return $MigrationID
-}");
-            expected.AppendLine();
-            expected.AppendLine("$Succeeded = 0");
-            expected.AppendLine("$Failed = 0");
-            expected.AppendLine("$RepoMigrations = [ordered]@{}");
-            expected.AppendLine();
-            expected.AppendLine($"# =========== Organization: {SOURCE_ORG} ===========");
-            expected.AppendLine();
-            expected.AppendLine($"# === Queuing repo migrations for Team Project: {SOURCE_ORG}/{adoTeamProject} ===");
-            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ gh gei migrate-repo --ado-source-org \"{SOURCE_ORG}\" --ado-team-project \"{adoTeamProject}\" --source-repo \"{repo}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{adoTeamProject}-{repo}\" --ssh }}");
-            expected.AppendLine($"$RepoMigrations[\"{adoTeamProject}-{repo}\"] = $MigrationID");
-            expected.AppendLine();
-            expected.AppendLine();
-            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {SOURCE_ORG} ===========");
-            expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\"");
-            expected.AppendLine();
-            expected.AppendLine("Write-Host =============== Summary ===============");
-            expected.AppendLine();
-            expected.AppendLine($"# === Migration stauts for Team Project: {SOURCE_ORG}/{adoTeamProject} ===");
-            expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\" --migration-id $RepoMigrations[\"{adoTeamProject}-{repo}\"]");
-            expected.AppendLine("if ($lastexitcode -eq 0) { $Succeeded++ } else { $Failed++ }");
-            expected.AppendLine();
-            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
-            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
-            expected.AppendLine(@"
-if ($Failed -ne 0) {
-    exit 1
-}");
-            expected.AppendLine();
-            expected.AppendLine();
-
-            // Act
-            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateParallelAdoScript(repos, SOURCE_ORG, TARGET_ORG, true);
-
-            // Assert
-            script.Should().Be(expected.ToString());
         }
 
         [Fact]
@@ -348,7 +247,7 @@ if ($Failed -ne 0) {
 
             // Act
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateParallelAdoScript(repos, SOURCE_ORG, TARGET_ORG, false);
+            var script = command.GenerateParallelAdoScript(repos, SOURCE_ORG, TARGET_ORG);
 
             // Assert
             script.Should().Be(expected.ToString());
@@ -359,76 +258,10 @@ if ($Failed -ne 0) {
         {
             // Arrange, Act
             var command = new GenerateScriptCommand(null, null, null, null);
-            var script = command.GenerateParallelGithubScript(null, "github-source", "github-target", "", "", false, false);
+            var script = command.GenerateParallelGithubScript(null, "github-source", "github-target", "", "", false);
 
             // Assert
             script.Should().BeEmpty();
-        }
-
-        [Fact]
-        public void GenerateParallelGithubScript_Single_Repo_With_Ssh()
-        {
-            // Arrange
-            const string repo = "foo-repo";
-            var repos = new[] { repo };
-
-            var expected = new StringBuilder();
-            expected.AppendLine(@"
-function Exec {
-    param (
-        [scriptblock]$ScriptBlock
-    )
-    & @ScriptBlock
-    if ($lastexitcode -ne 0) {
-        exit $lastexitcode
-    }
-}");
-            expected.AppendLine(@"
-function ExecAndGetMigrationID {
-    param (
-        [scriptblock]$ScriptBlock
-    )
-    $MigrationID = Exec $ScriptBlock | ForEach-Object {
-        Write-Host $_
-        $_
-    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
-    return $MigrationID
-}");
-            expected.AppendLine();
-            expected.AppendLine("$Succeeded = 0");
-            expected.AppendLine("$Failed = 0");
-            expected.AppendLine("$RepoMigrations = [ordered]@{}");
-            expected.AppendLine();
-            expected.AppendLine($"# =========== Organization: {SOURCE_ORG} ===========");
-            expected.AppendLine();
-            expected.AppendLine("# === Queuing repo migrations ===");
-            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{repo}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{repo}\" --ssh }}");
-            expected.AppendLine($"$RepoMigrations[\"{repo}\"] = $MigrationID");
-            expected.AppendLine();
-            expected.AppendLine();
-            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {SOURCE_ORG} ===========");
-            expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\"");
-            expected.AppendLine();
-            expected.AppendLine("Write-Host =============== Summary ===============");
-            expected.AppendLine();
-            expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\" --migration-id $RepoMigrations[\"{repo}\"]");
-            expected.AppendLine("if ($lastexitcode -eq 0) { $Succeeded++ } else { $Failed++ }");
-            expected.AppendLine();
-            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
-            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
-            expected.AppendLine(@"
-if ($Failed -ne 0) {
-    exit 1
-}");
-            expected.AppendLine();
-            expected.AppendLine();
-
-            // Act
-            var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateParallelGithubScript(repos, SOURCE_ORG, TARGET_ORG, "", "", false, true);
-
-            // Assert
-            script.Should().Be(expected.ToString());
         }
 
         [Fact]
@@ -498,7 +331,7 @@ if ($Failed -ne 0) {
 
             // Act
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateParallelGithubScript(repos, SOURCE_ORG, TARGET_ORG, "", "", false, false);
+            var script = command.GenerateParallelGithubScript(repos, SOURCE_ORG, TARGET_ORG, "", "", false);
 
             // Assert
             script.Should().Be(expected.ToString());
@@ -566,7 +399,7 @@ if ($Failed -ne 0) {
 
             // Act
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateParallelGithubScript(repos, SOURCE_ORG, TARGET_ORG, ghesApiUrl, azureStorageConnectionString, false, false);
+            var script = command.GenerateParallelGithubScript(repos, SOURCE_ORG, TARGET_ORG, ghesApiUrl, azureStorageConnectionString, false);
 
             // Assert
             script.Should().Be(expected.ToString());
@@ -634,7 +467,7 @@ if ($Failed -ne 0) {
 
             // Act
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, null, null, null);
-            var script = command.GenerateParallelGithubScript(repos, SOURCE_ORG, TARGET_ORG, ghesApiUrl, azureStorageConnectionString, true, false);
+            var script = command.GenerateParallelGithubScript(repos, SOURCE_ORG, TARGET_ORG, ghesApiUrl, azureStorageConnectionString, true);
 
             // Assert
             script.Should().Be(expected.ToString());

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -30,7 +30,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(command.Options, "azure-storage-connection-string", false);
             TestHelpers.VerifyCommandOption(command.Options, "no-ssl-verify", false);
             TestHelpers.VerifyCommandOption(command.Options, "output", false);
-            TestHelpers.VerifyCommandOption(command.Options, "ssh", false);
+            TestHelpers.VerifyCommandOption(command.Options, "ssh", false, true);
             TestHelpers.VerifyCommandOption(command.Options, "sequential", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -39,7 +39,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(command.Options, "no-ssl-verify", false);
             TestHelpers.VerifyCommandOption(command.Options, "git-archive-url", false);
             TestHelpers.VerifyCommandOption(command.Options, "metadata-archive-url", false);
-            TestHelpers.VerifyCommandOption(command.Options, "ssh", false);
+            TestHelpers.VerifyCommandOption(command.Options, "ssh", false, true);
             TestHelpers.VerifyCommandOption(command.Options, "wait", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -57,7 +57,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, "", "").Result).Returns(migrationId);
 
             var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
@@ -88,7 +88,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Assert
             mockGithub.Verify(m => m.GetOrganizationId(TARGET_ORG));
-            mockGithub.Verify(m => m.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat, false));
+            mockGithub.Verify(m => m.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat));
             mockGithub.Verify(m => m.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, "", ""));
 
             mockLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
@@ -110,7 +110,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, "", "").Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
@@ -141,7 +141,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, sourceAdoPat, targetGithubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, sourceAdoPat, targetGithubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, TARGET_REPO, "", "").Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
@@ -179,7 +179,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, authenticatedGitArchiveUrl.ToString(), authenticatedMetadataArchiveUrl.ToString()).Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
@@ -217,35 +217,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         }
 
         [Fact]
-        public async Task Github_With_Ssh()
-        {
-            var githubOrgId = Guid.NewGuid().ToString();
-            var migrationSourceId = Guid.NewGuid().ToString();
-            var sourceGithubPat = Guid.NewGuid().ToString();
-            var targetGithubPat = Guid.NewGuid().ToString();
-            var githubRepoUrl = $"https://github.com/{SOURCE_ORG}/{SOURCE_REPO}";
-            var migrationId = Guid.NewGuid().ToString();
-
-            var mockGithub = new Mock<GithubApi>(null, null);
-            mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat, true).Result).Returns(migrationSourceId);
-            mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, "", "").Result).Returns(migrationId);
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
-
-            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
-            environmentVariableProviderMock.Setup(m => m.SourceGithubPersonalAccessToken()).Returns(sourceGithubPat);
-            environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
-
-            var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL)).Returns(mockGithub.Object);
-
-            var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, mockGithubApiFactory.Object, environmentVariableProviderMock.Object, null);
-            await command.Invoke(SOURCE_ORG, null, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, TARGET_API_URL, ssh: true, wait: true);
-
-            mockGithub.Verify(x => x.GetMigrationState(migrationId));
-        }
-
-        [Fact]
         public async Task Ado_With_Ssh()
         {
             var adoTeamProject = "foo-team-project";
@@ -259,7 +230,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, sourceAdoPat, targetGithubPat, true).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, sourceAdoPat, targetGithubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, TARGET_REPO, "", "").Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
@@ -291,7 +262,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, gitArchiveUrl, metadataArchiveUrl).Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
@@ -331,7 +302,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, "", "").Result).Returns(migrationId);
             mockGithub.SetupSequence(x => x.GetMigrationState(migrationId).Result).Returns("FAILED").Returns("SUCCEEDED");
             mockGithub.Setup(x => x.GetMigrationFailureReason(migrationId).Result).Returns("Warning: Permanently added XXXXX (ECDSA) to the list of known hosts");
@@ -362,7 +333,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, "", "").Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("FAILED");
             mockGithub.Setup(x => x.GetMigrationFailureReason(migrationId).Result).Returns("Warning: Permanently added XXXXX (ECDSA) to the list of known hosts");
@@ -410,7 +381,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, SOURCE_REPO, "", "").Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
@@ -459,7 +430,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, authenticatedGitArchiveUrl.ToString(), authenticatedMetadataArchiveUrl.ToString()).Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
@@ -519,7 +490,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat, false).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, authenticatedGitArchiveUrl.ToString(), authenticatedMetadataArchiveUrl.ToString()).Result).Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -37,8 +37,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(command.Options, "ghes-api-url", false);
             TestHelpers.VerifyCommandOption(command.Options, "azure-storage-connection-string", false);
             TestHelpers.VerifyCommandOption(command.Options, "no-ssl-verify", false);
-            TestHelpers.VerifyCommandOption(command.Options, "git-archive-url", false);
-            TestHelpers.VerifyCommandOption(command.Options, "metadata-archive-url", false);
+            TestHelpers.VerifyCommandOption(command.Options, "git-archive-url", false, true);
+            TestHelpers.VerifyCommandOption(command.Options, "metadata-archive-url", false, true);
             TestHelpers.VerifyCommandOption(command.Options, "ssh", false, true);
             TestHelpers.VerifyCommandOption(command.Options, "wait", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);

--- a/src/ado2gh/Commands/MigrateRepoCommand.cs
+++ b/src/ado2gh/Commands/MigrateRepoCommand.cs
@@ -10,7 +10,6 @@ namespace OctoshiftCLI.AdoToGithub.Commands
         private readonly OctoLogger _log;
         private readonly GithubApiFactory _githubApiFactory;
         private readonly EnvironmentVariableProvider _environmentVariableProvider;
-        private bool _isRetry;
 
         public MigrateRepoCommand(
             OctoLogger log,
@@ -118,27 +117,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             if (migrationState.Trim().ToUpper() == "FAILED")
             {
+                _log.LogError($"Migration Failed. Migration ID: {migrationId}");
+
                 var failureReason = await githubApi.GetMigrationFailureReason(migrationId);
-
-                if (!_isRetry && failureReason.Contains("Warning: Permanently added") && failureReason.Contains("(ECDSA) to the list of known hosts"))
-                {
-                    _log.LogWarning(failureReason);
-                    _log.LogWarning("This is a known issue. Retrying the migration should resolve it. Retrying migration now...");
-
-                    _isRetry = true;
-                    await githubApi.DeleteRepo(githubOrg, githubRepo);
-                    await Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, ssh, wait, verbose);
-                }
-                else
-                {
-                    _log.LogError($"Migration Failed. Migration ID: {migrationId}");
-                    throw new OctoshiftCliException(failureReason);
-                }
+                throw new OctoshiftCliException(failureReason);
             }
-            else
-            {
-                _log.LogSuccess($"Migration completed (ID: {migrationId})! State: {migrationState}");
-            }
+
+            _log.LogSuccess($"Migration completed (ID: {migrationId})! State: {migrationState}");
         }
 
         private string GetAdoRepoUrl(string org, string project, string repo) => $"https://dev.azure.com/{org}/{project}/_git/{repo}".Replace(" ", "%20");

--- a/src/ado2gh/Commands/MigrateRepoCommand.cs
+++ b/src/ado2gh/Commands/MigrateRepoCommand.cs
@@ -48,6 +48,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             var ssh = new Option("--ssh")
             {
                 IsRequired = false,
+                IsHidden = true,
                 Description = "Uses SSH protocol instead of HTTPS to push a Git repository into the target repository on GitHub."
             };
             var wait = new Option("--wait")
@@ -84,7 +85,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log.LogInformation($"GITHUB REPO: {githubRepo}");
             if (ssh)
             {
-                _log.LogInformation("SSH: true");
+                _log.LogWarning("SSH mode is no longer supported. --ssh flag will be ignored.");
             }
             if (wait)
             {
@@ -97,7 +98,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             var githubPat = _environmentVariableProvider.GithubPersonalAccessToken();
             var githubApi = _githubApiFactory.Create();
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
-            var migrationSourceId = await githubApi.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat, ssh);
+            var migrationSourceId = await githubApi.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat);
             var migrationId = await githubApi.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo);
 
             if (!wait)

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -65,7 +65,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             };
             var ssh = new Option("--ssh")
             {
-                IsRequired = false
+                IsRequired = false,
+                IsHidden = true
             };
             var sequential = new Option("--sequential")
             {
@@ -143,7 +144,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             _log.LogInformation($"OUTPUT: {output}");
             if (ssh)
             {
-                _log.LogInformation("SSH: true");
+                _log.LogWarning("SSH mode is no longer supported. --ssh flag will be ignored.");
             }
             if (sequential)
             {
@@ -156,8 +157,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             }
 
             var script = string.IsNullOrWhiteSpace(githubSourceOrg) ?
-                await InvokeAdo(adoSourceOrg, githubTargetOrg, ssh, sequential) :
-                await InvokeGithub(githubSourceOrg, githubTargetOrg, ghesApiUrl, azureStorageConnectionString, noSslVerify, ssh, sequential);
+                await InvokeAdo(adoSourceOrg, githubTargetOrg, sequential) :
+                await InvokeGithub(githubSourceOrg, githubTargetOrg, ghesApiUrl, azureStorageConnectionString, noSslVerify, sequential);
 
             if (output != null)
             {
@@ -165,21 +166,21 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             }
         }
 
-        private async Task<string> InvokeGithub(string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool ssh, bool sequential)
+        private async Task<string> InvokeGithub(string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool sequential)
         {
             var targetApiUrl = "https://api.github.com";
             var repos = await GetGithubRepos(_sourceGithubApiFactory.Create(targetApiUrl), githubSourceOrg);
             return sequential
-                ? GenerateSequentialGithubScript(repos, githubSourceOrg, githubTargetOrg, ghesApiUrl, azureStorageConnectionString, noSslVerify, ssh)
-                : GenerateParallelGithubScript(repos, githubSourceOrg, githubTargetOrg, ghesApiUrl, azureStorageConnectionString, noSslVerify, ssh);
+                ? GenerateSequentialGithubScript(repos, githubSourceOrg, githubTargetOrg, ghesApiUrl, azureStorageConnectionString, noSslVerify)
+                : GenerateParallelGithubScript(repos, githubSourceOrg, githubTargetOrg, ghesApiUrl, azureStorageConnectionString, noSslVerify);
         }
 
-        private async Task<string> InvokeAdo(string adoSourceOrg, string githubTargetOrg, bool ssh, bool sequential)
+        private async Task<string> InvokeAdo(string adoSourceOrg, string githubTargetOrg, bool sequential)
         {
             var repos = await GetAdoRepos(_sourceAdoApiFactory.Create(), adoSourceOrg);
             return sequential
-                ? GenerateSequentialAdoScript(repos, adoSourceOrg, githubTargetOrg, ssh)
-                : GenerateParallelAdoScript(repos, adoSourceOrg, githubTargetOrg, ssh);
+                ? GenerateSequentialAdoScript(repos, adoSourceOrg, githubTargetOrg)
+                : GenerateParallelAdoScript(repos, adoSourceOrg, githubTargetOrg);
         }
 
         public async Task<IEnumerable<string>> GetGithubRepos(GithubApi github, string githubOrg)
@@ -226,7 +227,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             throw new ArgumentException("All arguments must be non-null");
         }
 
-        public string GenerateSequentialGithubScript(IEnumerable<string> repos, string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool ssh)
+        public string GenerateSequentialGithubScript(IEnumerable<string> repos, string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify)
         {
             if (repos == null)
             {
@@ -241,13 +242,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             foreach (var repo in repos)
             {
-                content.AppendLine(Exec(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, repo, ghesApiUrl, azureStorageConnectionString, noSslVerify, ssh, true)));
+                content.AppendLine(Exec(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, repo, ghesApiUrl, azureStorageConnectionString, noSslVerify, true)));
             }
 
             return content.ToString();
         }
 
-        public string GenerateParallelGithubScript(IEnumerable<string> repos, string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool ssh)
+        public string GenerateParallelGithubScript(IEnumerable<string> repos, string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify)
         {
             if (repos == null)
             {
@@ -273,7 +274,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             // Queuing migrations
             foreach (var repo in repos)
             {
-                content.AppendLine($"$MigrationID = {ExecAndGetMigrationId(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, repo, ghesApiUrl, azureStorageConnectionString, noSslVerify, ssh, false))}");
+                content.AppendLine($"$MigrationID = {ExecAndGetMigrationId(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, repo, ghesApiUrl, azureStorageConnectionString, noSslVerify, false))}");
                 content.AppendLine($"$RepoMigrations[\"{repo}\"] = $MigrationID");
                 content.AppendLine();
             }
@@ -310,7 +311,7 @@ if ($Failed -ne 0) {
             return content.ToString();
         }
 
-        public string GenerateSequentialAdoScript(IDictionary<string, IEnumerable<string>> repos, string adoSourceOrg, string githubTargetOrg, bool ssh)
+        public string GenerateSequentialAdoScript(IDictionary<string, IEnumerable<string>> repos, string adoSourceOrg, string githubTargetOrg)
         {
             if (repos == null)
             {
@@ -337,7 +338,7 @@ if ($Failed -ne 0) {
                     foreach (var repo in repos[teamProject])
                     {
                         var githubRepo = GetGithubRepoName(teamProject, repo);
-                        content.AppendLine(Exec(MigrateAdoRepoScript(adoSourceOrg, teamProject, repo, githubTargetOrg, githubRepo, ssh, true)));
+                        content.AppendLine(Exec(MigrateAdoRepoScript(adoSourceOrg, teamProject, repo, githubTargetOrg, githubRepo, true)));
                     }
                 }
             }
@@ -345,7 +346,7 @@ if ($Failed -ne 0) {
             return content.ToString();
         }
 
-        public string GenerateParallelAdoScript(IDictionary<string, IEnumerable<string>> repos, string adoSourceOrg, string githubTargetOrg, bool ssh)
+        public string GenerateParallelAdoScript(IDictionary<string, IEnumerable<string>> repos, string adoSourceOrg, string githubTargetOrg)
         {
             if (repos == null)
             {
@@ -380,7 +381,7 @@ if ($Failed -ne 0) {
                 foreach (var repo in repos[teamProject])
                 {
                     var githubRepo = GetGithubRepoName(teamProject, repo);
-                    content.AppendLine($"$MigrationID = {ExecAndGetMigrationId(MigrateAdoRepoScript(adoSourceOrg, teamProject, repo, githubTargetOrg, githubRepo, ssh, false))}");
+                    content.AppendLine($"$MigrationID = {ExecAndGetMigrationId(MigrateAdoRepoScript(adoSourceOrg, teamProject, repo, githubTargetOrg, githubRepo, false))}");
                     content.AppendLine($"$RepoMigrations[\"{githubRepo}\"] = $MigrationID");
                     content.AppendLine();
                 }
@@ -429,7 +430,7 @@ if ($Failed -ne 0) {
 
         private string GetGithubRepoName(string adoTeamProject, string repo) => $"{adoTeamProject}-{repo.Replace(" ", "-")}";
 
-        private string MigrateGithubRepoScript(string githubSourceOrg, string githubTargetOrg, string repo, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool ssh, bool wait)
+        private string MigrateGithubRepoScript(string githubSourceOrg, string githubTargetOrg, string repo, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool wait)
         {
             var ghesRepoOptions = "";
             if (!string.IsNullOrWhiteSpace(ghesApiUrl))
@@ -437,11 +438,11 @@ if ($Failed -ne 0) {
                 ghesRepoOptions = GetGhesRepoOptions(ghesApiUrl, azureStorageConnectionString, noSslVerify);
             }
 
-            return $"gh gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\"{(!string.IsNullOrEmpty(ghesRepoOptions) ? $" {ghesRepoOptions}" : string.Empty)}{(ssh ? " --ssh" : string.Empty)}{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? " --wait" : string.Empty)}";
+            return $"gh gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\"{(!string.IsNullOrEmpty(ghesRepoOptions) ? $" {ghesRepoOptions}" : string.Empty)}{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? " --wait" : string.Empty)}";
         }
 
-        private string MigrateAdoRepoScript(string adoSourceOrg, string teamProject, string adoRepo, string githubTargetOrg, string githubRepo, bool ssh, bool wait) =>
-            $"gh gei migrate-repo --ado-source-org \"{adoSourceOrg}\" --ado-team-project \"{teamProject}\" --source-repo \"{adoRepo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{githubRepo}\"{(ssh ? " --ssh" : string.Empty)}{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? " --wait" : string.Empty)}";
+        private string MigrateAdoRepoScript(string adoSourceOrg, string teamProject, string adoRepo, string githubTargetOrg, string githubRepo, bool wait) =>
+            $"gh gei migrate-repo --ado-source-org \"{adoSourceOrg}\" --ado-team-project \"{teamProject}\" --source-repo \"{adoRepo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{githubRepo}\"{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? " --wait" : string.Empty)}";
 
         private string GetGhesRepoOptions(string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify)
         {

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -96,6 +96,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var ssh = new Option("--ssh")
             {
                 IsRequired = false,
+                IsHidden = true,
                 Description = "Uses SSH protocol instead of HTTPS to push a Git repository into the target repository on GitHub."
             };
             var wait = new Option("--wait")
@@ -176,7 +177,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             if (ssh)
             {
-                _log.LogInformation("SSH: true");
+                _log.LogWarning("SSH mode is no longer supported. --ssh flag will be ignored");
             }
 
             if (wait)
@@ -233,13 +234,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 sourceRepoUrl = GetAdoRepoUrl(adoSourceOrg, adoTeamProject, sourceRepo);
                 var sourceAdoPat = _environmentVariableProvider.AdoPersonalAccessToken();
-                migrationSourceId = await githubApi.CreateAdoMigrationSource(githubOrgId, sourceAdoPat, targetGithubPat, ssh);
+                migrationSourceId = await githubApi.CreateAdoMigrationSource(githubOrgId, sourceAdoPat, targetGithubPat);
             }
             else
             {
                 sourceRepoUrl = GetGithubRepoUrl(githubSourceOrg, sourceRepo);
                 var sourceGithubPat = _environmentVariableProvider.SourceGithubPersonalAccessToken();
-                migrationSourceId = await githubApi.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat, ssh);
+                migrationSourceId = await githubApi.CreateGhecMigrationSource(githubOrgId, sourceGithubPat, targetGithubPat);
             }
 
             var migrationId = await githubApi.StartMigration(migrationSourceId, sourceRepoUrl, githubOrgId, targetRepo, gitArchiveUrl, metadataArchiveUrl);


### PR DESCRIPTION
Closes #265 

Because of the latest BE changes and the fact that the problems we had with `https` are now resolved, we can deprecate the `--ssh` flag and use `https` permanently. For backward compatibility, we are not going to remove it completely just yet so passing it will do noting (keep using `https`) and log a warning to notify the user. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked