### PR TITLE
Display summary line right before displaying totals

### DIFF
--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -227,8 +227,6 @@ function ExecAndGetMigrationID {
             expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {SOURCE_ORG} ===========");
             expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\"");
             expected.AppendLine();
-            expected.AppendLine("Write-Host =============== Summary ===============");
-            expected.AppendLine();
             expected.AppendLine($"# === Migration stauts for Team Project: {SOURCE_ORG}/{adoTeamProject} ===");
             expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\" --migration-id $RepoMigrations[\"{adoTeamProject}-{repo1}\"]");
             expected.AppendLine("if ($lastexitcode -eq 0) { $Succeeded++ } else { $Failed++ }");
@@ -236,6 +234,8 @@ function ExecAndGetMigrationID {
             expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\" --migration-id $RepoMigrations[\"{adoTeamProject}-{repo2}\"]");
             expected.AppendLine("if ($lastexitcode -eq 0) { $Succeeded++ } else { $Failed++ }");
             expected.AppendLine();
+            expected.AppendLine();
+            expected.AppendLine("Write-Host =============== Summary ===============");
             expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
             expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
             expected.AppendLine(@"
@@ -312,14 +312,14 @@ function ExecAndGetMigrationID {
             expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {SOURCE_ORG} ===========");
             expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\"");
             expected.AppendLine();
-            expected.AppendLine("Write-Host =============== Summary ===============");
-            expected.AppendLine();
             expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\" --migration-id $RepoMigrations[\"{repo1}\"]");
             expected.AppendLine("if ($lastexitcode -eq 0) { $Succeeded++ } else { $Failed++ }");
             expected.AppendLine();
             expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\" --migration-id $RepoMigrations[\"{repo2}\"]");
             expected.AppendLine("if ($lastexitcode -eq 0) { $Succeeded++ } else { $Failed++ }");
             expected.AppendLine();
+            expected.AppendLine();
+            expected.AppendLine("Write-Host =============== Summary ===============");
             expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
             expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
             expected.AppendLine(@"
@@ -383,11 +383,11 @@ function ExecAndGetMigrationID {
             expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {SOURCE_ORG} ===========");
             expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\"");
             expected.AppendLine();
-            expected.AppendLine("Write-Host =============== Summary ===============");
-            expected.AppendLine();
             expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\" --migration-id $RepoMigrations[\"{repo}\"]");
             expected.AppendLine("if ($lastexitcode -eq 0) { $Succeeded++ } else { $Failed++ }");
             expected.AppendLine();
+            expected.AppendLine();
+            expected.AppendLine("Write-Host =============== Summary ===============");
             expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
             expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
             expected.AppendLine(@"
@@ -451,11 +451,11 @@ function ExecAndGetMigrationID {
             expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {SOURCE_ORG} ===========");
             expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\"");
             expected.AppendLine();
-            expected.AppendLine("Write-Host =============== Summary ===============");
-            expected.AppendLine();
             expected.AppendLine($"gh gei wait-for-migration --github-org \"{TARGET_ORG}\" --migration-id $RepoMigrations[\"{repo}\"]");
             expected.AppendLine("if ($lastexitcode -eq 0) { $Succeeded++ } else { $Failed++ }");
             expected.AppendLine();
+            expected.AppendLine();
+            expected.AppendLine("Write-Host =============== Summary ===============");
             expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
             expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
             expected.AppendLine(@"

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -283,9 +283,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             content.AppendLine();
             content.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {githubSourceOrg} ===========");
             content.AppendLine(WaitForMigrationScript(githubTargetOrg)); // Wait for all migrations to finish
-
-            content.AppendLine();
-            content.AppendLine("Write-Host =============== Summary ===============");
             content.AppendLine();
 
             // Query each migration's status
@@ -297,6 +294,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             }
 
             // Generating the final report
+            content.AppendLine();
+            content.AppendLine("Write-Host =============== Summary ===============");
             content.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
             content.AppendLine("Write-Host Total number of failed migrations: $Failed");
 
@@ -392,9 +391,6 @@ if ($Failed -ne 0) {
             content.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {adoSourceOrg} ===========");
             content.AppendLine(WaitForMigrationScript(githubTargetOrg)); // Wait for all migrations to finish
 
-            content.AppendLine();
-            content.AppendLine("Write-Host =============== Summary ===============");
-
             // Query each migration's status
             foreach (var teamProject in repos.Keys)
             {
@@ -414,6 +410,8 @@ if ($Failed -ne 0) {
             }
 
             // Generating the final report
+            content.AppendLine();
+            content.AppendLine("Write-Host =============== Summary ===============");
             content.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
             content.AppendLine("Write-Host Total number of failed migrations: $Failed");
 


### PR DESCRIPTION
### Description
In the `gh gei`, we wait for all migrations to finish and then query every single migration one by one and display its status. The `=== Summary ===` line used to be displayed after wait for all migrations but it looked weird in the console output. So we decided to move it further down and display it right before the actual summary (`Total ...`) just like the way it is in `ado2gh`.

<details><summary>Migration output</summary>

<p>

```
./migrate.ps1
[12:33 PM] [INFO] Migrating Repo...
[12:33 PM] [INFO] GITHUB SOURCE ORG: ArinTestOrg
[12:33 PM] [INFO] SOURCE REPO: BarProject-BarProject
[12:33 PM] [INFO] GITHUB TARGET ORG: ArinTestOrg
[12:33 PM] [INFO] TARGET REPO: BarProject-BarProject-migrated
[12:33 PM] [INFO] Target API URL: https://api.github.com
[12:33 PM] [INFO] A repository migration (ID: RM_kgC4NjIzMjNiOGIzMzAzODMwMDBhYzc4NjYy) was successfully queued.
[12:33 PM] [INFO] Migrating Repo...
[12:33 PM] [INFO] GITHUB SOURCE ORG: ArinTestOrg
[12:33 PM] [INFO] SOURCE REPO: BarProject-DragonRepo
[12:33 PM] [INFO] GITHUB TARGET ORG: ArinTestOrg
[12:33 PM] [INFO] TARGET REPO: BarProject-DragonRepo-migrated
[12:33 PM] [INFO] Target API URL: https://api.github.com
[12:33 PM] [INFO] A repository migration (ID: RM_kgC4NjIzMjNiOGViODA1ZGYwMDA5YWU5ZmZm) was successfully queued.
[12:33 PM] [INFO] Migrating Repo...
[12:33 PM] [INFO] GITHUB SOURCE ORG: ArinTestOrg
[12:33 PM] [INFO] SOURCE REPO: FooProject-JohnRepo
[12:33 PM] [INFO] GITHUB TARGET ORG: ArinTestOrg
[12:33 PM] [INFO] TARGET REPO: FooProject-JohnRepo-migrated
[12:33 PM] [INFO] Target API URL: https://api.github.com
[12:33 PM] [INFO] A repository migration (ID: RM_kgC4NjIzMjNiOTFmNjRlNmQwMDA5MjYwMGUz) was successfully queued.
[12:33 PM] [INFO] Migrating Repo...
[12:33 PM] [INFO] GITHUB SOURCE ORG: ArinTestOrg
[12:33 PM] [INFO] SOURCE REPO: FooProject-FooProject
[12:33 PM] [INFO] GITHUB TARGET ORG: ArinTestOrg
[12:33 PM] [INFO] TARGET REPO: FooProject-FooProject-migrated
[12:33 PM] [INFO] Target API URL: https://api.github.com
[12:33 PM] [INFO] A repository migration (ID: RM_kgC4NjIzMjNiOTMzMDU4ZmEwMDA4MGZmMjk4) was successfully queued.
[12:33 PM] [INFO] Waiting for all migrations to finish...
[12:33 PM] [INFO] GITHUB ORG: ArinTestOrg
[12:33 PM] [INFO] Total migrations IN_PROGRESS: 2, Total migrations QUEUED: 2
[12:33 PM] [INFO] Waiting 10 seconds...
[12:34 PM] [INFO] Total migrations IN_PROGRESS: 2, Total migrations QUEUED: 2
[12:34 PM] [INFO] Waiting 10 seconds...
[12:34 PM] [INFO] Total migrations IN_PROGRESS: 2, Total migrations QUEUED: 2
[12:34 PM] [INFO] Waiting 10 seconds...
[12:34 PM] [INFO] Total migrations IN_PROGRESS: 2, Total migrations QUEUED: 0
[12:34 PM] [INFO] Waiting 10 seconds...
[12:34 PM] [INFO] Total migrations IN_PROGRESS: 2, Total migrations QUEUED: 0
[12:34 PM] [INFO] Waiting 10 seconds...
[12:35 PM] [INFO] Total migrations IN_PROGRESS: 2, Total migrations QUEUED: 0
[12:35 PM] [INFO] Waiting 10 seconds...
[12:35 PM] [INFO] Total migrations IN_PROGRESS: 2, Total migrations QUEUED: 0
[12:35 PM] [INFO] Waiting 10 seconds...
[12:35 PM] [INFO] Total migrations IN_PROGRESS: 0, Total migrations QUEUED: 0
[12:35 PM] [INFO] Waiting for migration RM_kgC4NjIzMjNiOGIzMzAzODMwMDBhYzc4NjYy to finish...
[12:35 PM] [INFO] GITHUB ORG: ArinTestOrg
[12:35 PM] [INFO] MIGRATION ID: RM_kgC4NjIzMjNiOGIzMzAzODMwMDBhYzc4NjYy
[12:35 PM] [INFO] Migration succeeded for migration RM_kgC4NjIzMjNiOGIzMzAzODMwMDBhYzc4NjYy
[12:35 PM] [INFO] Waiting for migration RM_kgC4NjIzMjNiOGViODA1ZGYwMDA5YWU5ZmZm to finish...
[12:35 PM] [INFO] GITHUB ORG: ArinTestOrg
[12:35 PM] [INFO] MIGRATION ID: RM_kgC4NjIzMjNiOGViODA1ZGYwMDA5YWU5ZmZm
[12:35 PM] [INFO] Migration succeeded for migration RM_kgC4NjIzMjNiOGViODA1ZGYwMDA5YWU5ZmZm
[12:35 PM] [INFO] Waiting for migration RM_kgC4NjIzMjNiOTFmNjRlNmQwMDA5MjYwMGUz to finish...
[12:35 PM] [INFO] GITHUB ORG: ArinTestOrg
[12:35 PM] [INFO] MIGRATION ID: RM_kgC4NjIzMjNiOTFmNjRlNmQwMDA5MjYwMGUz
[12:35 PM] [INFO] Migration succeeded for migration RM_kgC4NjIzMjNiOTFmNjRlNmQwMDA5MjYwMGUz
[12:35 PM] [INFO] Waiting for migration RM_kgC4NjIzMjNiOTMzMDU4ZmEwMDA4MGZmMjk4 to finish...
[12:35 PM] [INFO] GITHUB ORG: ArinTestOrg
[12:35 PM] [INFO] MIGRATION ID: RM_kgC4NjIzMjNiOTMzMDU4ZmEwMDA4MGZmMjk4
[12:35 PM] [INFO] Migration succeeded for migration RM_kgC4NjIzMjNiOTMzMDU4ZmEwMDA4MGZmMjk4
=============== Summary ===============
Total number of successful migrations: 4
Total number of failed migrations: 0
```

</p>

</details>

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate) --> not needed
- [x] Appropriate logging output
- [x] Issue linked --> no tickets were created for this, since it's a quick fix