### PR TITLE
Update `wait-for-migration` notes.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,4 @@
-- Add `wait-for-migration` command. By default it waits for all ongoing migrations to finish and reports the number of in progress and queued migrations. If an optional `migration-id` is provided, it will return as soon as that migration is complete.
+- Add `wait-for-migration` command. It waits for the provided migration and returns as soon as it is complete.
 - Add `--wait` option to `migrate-repo` command. If set to `true` (default is `false`) it will synchronously wait for the migration to finish, otherwise it will just queue up a repo migration and return the `migration-id`.
 - Support parallel migrations with `generate-script` for both `ado2gh` and `gh gei`. `generate-script` now by default generates a script to perform migrations in parallel. Adding `--sequential` flag will force migrations to perform in a sequential (one by one) fashion.
 - Deprecate `--ssh` flag in `generate-script` and `migrate-repo` commands for both `ado2gh` and `gh gei`.


### PR DESCRIPTION
I just noticed that I had forgotten to update the release notes for `wait-for-migration` command as part of #281 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked