### PR TITLE
Accept PATs as CLI args

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- All commands in both `ado2gh` and `gei` now optionally accept required PATs as args as an alternate way to setting them as env variables. 

--- a/src/Octoshift/Extensions/StringExtensions.cs
+++ b/src/Octoshift/Extensions/StringExtensions.cs
@@ -8,5 +8,7 @@ namespace OctoshiftCLI.Extensions
         public static StringContent ToStringContent(this string s) => new(s, Encoding.UTF8, "application/json");
 
         public static bool IsNullOrWhiteSpace(this string s) => string.IsNullOrWhiteSpace(s);
+
+        public static bool HasValue(this string s) => !s.IsNullOrWhiteSpace();
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/AdoApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/AdoApiFactoryTests.cs
@@ -13,7 +13,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub
         private const string ADO_PAT = "ADO_PAT";
 
         [Fact]
-        public void Create_Should_Create_Ado_Api_With_Ado_Pat()
+        public void Create_Should_Create_Ado_Api_With_Ado_Pat_From_Environment_If_Not_Provided()
         {
             // Arrange
             var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
@@ -31,6 +31,31 @@ namespace OctoshiftCLI.Tests.AdoToGithub
             var authToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{ADO_PAT}"));
             httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(authToken);
             httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Basic");
+            
+            environmentVariableProviderMock.Verify(m => m.AdoPersonalAccessToken());
+        }
+
+        [Fact]
+        public void Create_Should_Create_Ado_Api_With_Provided_Ado_Pat()
+        {
+            // Arrange
+            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
+            environmentVariableProviderMock.Setup(m => m.AdoPersonalAccessToken()).Returns(ADO_PAT);
+
+            using var httpClient = new HttpClient();
+
+            // Act
+            var factory = new AdoApiFactory(null, httpClient, environmentVariableProviderMock.Object);
+            var result = factory.Create(ADO_PAT);
+
+            // Assert
+            result.Should().NotBeNull();
+
+            var authToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{ADO_PAT}"));
+            httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(authToken);
+            httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Basic");
+            
+            environmentVariableProviderMock.Verify(m => m.AdoPersonalAccessToken(), Times.Never);
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/AdoApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/AdoApiFactoryTests.cs
@@ -31,7 +31,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub
             var authToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{ADO_PAT}"));
             httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(authToken);
             httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Basic");
-            
+
             environmentVariableProviderMock.Verify(m => m.AdoPersonalAccessToken());
         }
 
@@ -54,7 +54,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub
             var authToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{ADO_PAT}"));
             httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(authToken);
             httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Basic");
-            
+
             environmentVariableProviderMock.Verify(m => m.AdoPersonalAccessToken(), Times.Never);
         }
     }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
@@ -15,12 +15,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new AddTeamToRepoCommand(null, null);
             Assert.NotNull(command);
             Assert.Equal("add-team-to-repo", command.Name);
-            Assert.Equal(5, command.Options.Count);
+            Assert.Equal(6, command.Options.Count);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "github-repo", true);
             TestHelpers.VerifyCommandOption(command.Options, "team", true);
             TestHelpers.VerifyCommandOption(command.Options, "role", true);
+            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -40,6 +41,21 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await command.Invoke(githubOrg, githubRepo, team, role);
 
             mockGithub.Verify(x => x.AddTeamToRepo(githubOrg, githubRepo, team, role));
+        }
+
+        [Fact]
+        public async Task It_Uses_The_Github_Pat_When_Provided()
+        {
+            const string githubPat = "github-pat";
+
+            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(mockGithub.Object);
+
+            var command = new AddTeamToRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
+            await command.Invoke("githubOrg", "githubRepo", "team", "role", githubPat);
+
+            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.Threading.Tasks;
 using Moq;
+using Moq.Protected;
 using OctoshiftCLI.AdoToGithub;
 using OctoshiftCLI.AdoToGithub.Commands;
 using Xunit;
@@ -34,7 +35,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new AddTeamToRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, githubRepo, team, role);
@@ -52,7 +53,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             var mockGithub = new Mock<GithubApi>(null, null);
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new AddTeamToRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
@@ -55,7 +55,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new AddTeamToRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke("githubOrg", "githubRepo", "team", "role", githubPat);
 
-            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
+            mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
@@ -1,7 +1,6 @@
 using System.CommandLine;
 using System.Threading.Tasks;
 using Moq;
-using Moq.Protected;
 using OctoshiftCLI.AdoToGithub;
 using OctoshiftCLI.AdoToGithub.Commands;
 using Xunit;

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ConfigureAutoLinkCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ConfigureAutoLinkCommandTests.cs
@@ -39,7 +39,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Setup(x => x.GetAutoLinks(It.IsAny<string>(), It.IsAny<string>()))
                       .ReturnsAsync(new List<(int Id, string KeyPrefix, string UrlTemplate)>());
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new ConfigureAutoLinkCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, githubRepo, adoOrg, adoTeamProject);
@@ -65,7 +65,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                           (1, keyPrefix, urlTemplate),
                       }));
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var actualLogOutput = new List<string>();
             var mockLogger = new Mock<OctoLogger>();
@@ -97,7 +97,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                           (1, keyPrefix, "SomethingElse"),
                       });
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var actualLogOutput = new List<string>();
             var mockLogger = new Mock<OctoLogger>();

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ConfigureAutoLinkCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ConfigureAutoLinkCommandTests.cs
@@ -16,12 +16,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new ConfigureAutoLinkCommand(null, null);
             Assert.NotNull(command);
             Assert.Equal("configure-autolink", command.Name);
-            Assert.Equal(5, command.Options.Count);
+            Assert.Equal(6, command.Options.Count);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "github-repo", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", true);
+            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -46,6 +47,23 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             mockGithub.Verify(x => x.DeleteAutoLink(githubOrg, githubRepo, 1), Times.Never);
             mockGithub.Verify(x => x.AddAutoLink(githubOrg, githubRepo, keyPrefix, urlTemplate));
+        }
+
+        [Fact]
+        public async Task It_Uses_The_Github_Pat_When_Provided()
+        {
+            const string githubPat = "github-pat";
+
+            var mockGithub = new Mock<GithubApi>(null, null);
+            mockGithub.Setup(x => x.GetAutoLinks(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new List<(int Id, string KeyPrefix, string UrlTemplate)>());
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(mockGithub.Object);
+
+            var command = new ConfigureAutoLinkCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
+            await command.Invoke("githubOrg", "githubRepo", "adoOrg", "adoTeamProject", githubPat);
+
+            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ConfigureAutoLinkCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ConfigureAutoLinkCommandTests.cs
@@ -63,7 +63,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new ConfigureAutoLinkCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke("githubOrg", "githubRepo", "adoOrg", "adoTeamProject", githubPat);
 
-            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
+            mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/CreateTeamCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/CreateTeamCommandTests.cs
@@ -64,7 +64,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new CreateTeamCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke("githubOrg", "teamName", "idpGroup", githubPat);
 
-            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
+            mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/CreateTeamCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/CreateTeamCommandTests.cs
@@ -40,7 +40,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Setup(x => x.GetTeams(githubOrg).Result).Returns(new List<string>());
 
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new CreateTeamCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, teamName, idpGroup);
@@ -68,7 +68,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Setup(x => x.GetTeams(githubOrg).Result).Returns(new List<string> { teamName });
 
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var actualLogOutput = new List<string>();
             var mockLogger = new Mock<OctoLogger>();

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/CreateTeamCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/CreateTeamCommandTests.cs
@@ -15,11 +15,12 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new CreateTeamCommand(null, null);
             Assert.NotNull(command);
             Assert.Equal("create-team", command.Name);
-            Assert.Equal(4, command.Options.Count);
+            Assert.Equal(5, command.Options.Count);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "team-name", true);
             TestHelpers.VerifyCommandOption(command.Options, "idp-group", false);
+            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -49,6 +50,21 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Verify(x => x.RemoveTeamMember(githubOrg, teamName, teamMembers[0]));
             mockGithub.Verify(x => x.RemoveTeamMember(githubOrg, teamName, teamMembers[1]));
             mockGithub.Verify(x => x.AddEmuGroupToTeam(githubOrg, teamSlug, idpGroupId));
+        }
+
+        [Fact]
+        public async Task It_Uses_The_Github_Pat_When_Provided()
+        {
+            const string githubPat = "github-pat";
+
+            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(mockGithub.Object);
+
+            var command = new CreateTeamCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
+            await command.Invoke("githubOrg", "teamName", "idpGroup", githubPat);
+
+            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/DisableRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/DisableRepoCommandTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Moq;
-using Moq.Protected;
 using OctoshiftCLI.AdoToGithub;
 using OctoshiftCLI.AdoToGithub.Commands;
 using Xunit;

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/DisableRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/DisableRepoCommandTests.cs
@@ -15,11 +15,12 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new DisableRepoCommand(null, null);
             Assert.NotNull(command);
             Assert.Equal("disable-ado-repo", command.Name);
-            Assert.Equal(4, command.Options.Count);
+            Assert.Equal(5, command.Options.Count);
 
             TestHelpers.VerifyCommandOption(command.Options, "ado-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-repo", true);
+            TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -41,6 +42,21 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await command.Invoke(adoOrg, adoTeamProject, adoRepo);
 
             mockAdo.Verify(x => x.DisableRepo(adoOrg, adoTeamProject, repoId));
+        }
+
+        [Fact]
+        public async Task It_Uses_The_Ado_Pat_When_Provided()
+        {
+            const string adoPat = "ado-pat";
+
+            var mockAdo = new Mock<AdoApi>(null);
+            var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
+            mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(mockAdo.Object);
+
+            var command = new DisableRepoCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object);
+            await command.Invoke("adoOrg", "adoTeamProject", "adoRepo", adoPat);
+
+            mockAdoApiFactory.Verify(m => m.Create(adoPat));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/DisableRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/DisableRepoCommandTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Moq;
+using Moq.Protected;
 using OctoshiftCLI.AdoToGithub;
 using OctoshiftCLI.AdoToGithub.Commands;
 using Xunit;
@@ -35,7 +36,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockAdo.Setup(x => x.GetRepoId(adoOrg, adoTeamProject, adoRepo).Result).Returns(repoId);
 
             var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
-            mockAdoApiFactory.Setup(m => m.Create()).Returns(mockAdo.Object);
+            mockAdoApiFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(mockAdo.Object);
 
             var command = new DisableRepoCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object);
             await command.Invoke(adoOrg, adoTeamProject, adoRepo);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -20,7 +20,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new GenerateScriptCommand(null, null);
             command.Should().NotBeNull();
             command.Name.Should().Be("generate-script");
-            command.Options.Count.Should().Be(9);
+            command.Options.Count.Should().Be(10);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-org", false);
@@ -1058,7 +1058,7 @@ if ($Failed -ne 0) {
 
             // Act
             var command = new GenerateScriptCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object);
-            await command.Invoke("githubOrg", "adoOrg", null, false, false, adoPat: adoPat);
+            await command.Invoke("githubOrg", "adoOrg", null, null, false, false, adoPat: adoPat);
 
             // Assert
             mockAdoApiFactory.Verify(m => m.Create(adoPat));

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRoleCommandTests.cs
@@ -15,11 +15,12 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new GrantMigratorRoleCommand(null, null);
             Assert.NotNull(command);
             Assert.Equal("grant-migrator-role", command.Name);
-            Assert.Equal(4, command.Options.Count);
+            Assert.Equal(5, command.Options.Count);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "actor", true);
             TestHelpers.VerifyCommandOption(command.Options, "actor-type", true);
+            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -41,6 +42,21 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await command.Invoke(githubOrg, actor, actorType);
 
             mockGithub.Verify(x => x.GrantMigratorRole(githubOrgId, actor, actorType));
+        }
+
+        [Fact]
+        public async Task It_Uses_The_Github_Pat_When_Provided()
+        {
+            const string githubPat = "github-pat";
+
+            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(mockGithub.Object);
+
+            var command = new GrantMigratorRoleCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
+            await command.Invoke("githubOrg", "actor", "TEAM", githubPat);
+
+            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRoleCommandTests.cs
@@ -35,7 +35,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
 
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new GrantMigratorRoleCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, actor, actorType);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRoleCommandTests.cs
@@ -56,7 +56,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new GrantMigratorRoleCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke("githubOrg", "actor", "TEAM", githubPat);
 
-            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
+            mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/IntegrateBoardsCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/IntegrateBoardsCommandTests.cs
@@ -56,7 +56,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 .Returns(githubToken);
 
             var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
-            mockAdoApiFactory.Setup(m => m.Create()).Returns(mockAdo.Object);
+            mockAdoApiFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(mockAdo.Object);
 
             var command = new IntegrateBoardsCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object,
                 environmentVariableProviderMock.Object);
@@ -97,7 +97,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 .Returns(githubToken);
 
             var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
-            mockAdoApiFactory.Setup(m => m.Create()).Returns(mockAdo.Object);
+            mockAdoApiFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(mockAdo.Object);
 
             var command = new IntegrateBoardsCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object,
                 environmentVariableProviderMock.Object);
@@ -141,7 +141,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 .Returns(githubToken);
 
             var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
-            mockAdoApiFactory.Setup(m => m.Create()).Returns(mockAdo.Object);
+            mockAdoApiFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(mockAdo.Object);
 
             var command = new IntegrateBoardsCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object,
                 environmentVariableProviderMock.Object);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/IntegrateBoardsCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/IntegrateBoardsCommandTests.cs
@@ -17,12 +17,14 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new IntegrateBoardsCommand(null, null, null);
             Assert.NotNull(command);
             Assert.Equal("integrate-boards", command.Name);
-            Assert.Equal(5, command.Options.Count);
+            Assert.Equal(7, command.Options.Count);
 
             TestHelpers.VerifyCommandOption(command.Options, "ado-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", true);
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "github-repo", true);
+            TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
+            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -149,6 +151,52 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             mockAdo.Verify(x => x.CreateBoardsGithubEndpoint(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             mockAdo.Verify(x => x.AddRepoToBoardsGithubConnection(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task It_Uses_The_Ado_And_Github_Pats_When_Provided()
+        {
+            const string adoPat = "ado-pat";
+            const string githubPat = "github-pat";
+
+            var mockAdo = new Mock<AdoApi>(null);
+            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
+            environmentVariableProviderMock
+                .Setup(m => m.GithubPersonalAccessToken())
+                .Returns(githubPat);
+
+            var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
+            mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(mockAdo.Object);
+
+            var command = new IntegrateBoardsCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object,
+                environmentVariableProviderMock.Object);
+            await command.Invoke("adoOrg", "adoTeamProject", "githubOrg", "githubRepo", adoPat, githubPat);
+
+            mockAdoApiFactory.Verify(m => m.Create(adoPat));
+            environmentVariableProviderMock.Verify(m => m.GithubPersonalAccessToken(), Times.Never);
+        }
+
+        [Fact]
+        public async Task It_Falls_Back_To_Github_Pat_From_Environment_When_Not_Provided()
+        {
+            const string adoPat = "ado-pat";
+            const string githubPat = "github-pat";
+
+            var mockAdo = new Mock<AdoApi>(null);
+            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
+            environmentVariableProviderMock
+                .Setup(m => m.GithubPersonalAccessToken())
+                .Returns(githubPat);
+
+            var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
+            mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(mockAdo.Object);
+
+            var command = new IntegrateBoardsCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object,
+                environmentVariableProviderMock.Object);
+            await command.Invoke("adoOrg", "adoTeamProject", "githubOrg", "githubRepo", adoPat);
+
+            mockAdoApiFactory.Verify(m => m.Create(adoPat));
+            environmentVariableProviderMock.Verify(m => m.GithubPersonalAccessToken(), Times.Once);
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/LockRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/LockRepoCommandTests.cs
@@ -15,11 +15,12 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new LockRepoCommand(null, null);
             Assert.NotNull(command);
             Assert.Equal("lock-ado-repo", command.Name);
-            Assert.Equal(4, command.Options.Count);
+            Assert.Equal(5, command.Options.Count);
 
             TestHelpers.VerifyCommandOption(command.Options, "ado-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-repo", true);
+            TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -45,6 +46,21 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await command.Invoke(adoOrg, adoTeamProject, adoRepo);
 
             mockAdo.Verify(x => x.LockRepo(adoOrg, teamProjectId, repoId, identityDescriptor));
+        }
+
+        [Fact]
+        public async Task It_Uses_The_Ado_Pat_When_Provided()
+        {
+            const string adoPat = "ado-pat";
+
+            var mockAdo = new Mock<AdoApi>(null);
+            var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
+            mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(mockAdo.Object);
+
+            var command = new LockRepoCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object);
+            await command.Invoke("adoOrg", "adoTeamProject", "adoRepo", adoPat);
+
+            mockAdoApiFactory.Verify(m => m.Create(adoPat));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/LockRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/LockRepoCommandTests.cs
@@ -39,7 +39,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockAdo.Setup(x => x.GetIdentityDescriptor(adoOrg, teamProjectId, "Project Valid Users").Result).Returns(identityDescriptor);
 
             var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
-            mockAdoApiFactory.Setup(m => m.Create()).Returns(mockAdo.Object);
+            mockAdoApiFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(mockAdo.Object);
 
             var command = new LockRepoCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object);
             await command.Invoke(adoOrg, adoTeamProject, adoRepo);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
@@ -62,7 +62,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
             environmentVariableProviderMock
@@ -136,7 +136,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
             environmentVariableProviderMock

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
@@ -177,7 +177,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
             await command.Invoke("adoOrg", "adoTeamProject", "adoRepo", "githubOrg", "githubRepo", wait: true, adoPat: adoPat, githubPat: githubPat);
 
-            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
+            mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
             environmentVariableProviderMock.Verify(m => m.AdoPersonalAccessToken(), Times.Never);
             environmentVariableProviderMock.Verify(m => m.GithubPersonalAccessToken(), Times.Never);
         }
@@ -204,7 +204,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
             await command.Invoke("adoOrg", "adoTeamProject", "adoRepo", "githubOrg", "githubRepo", wait: true);
 
-            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
+            mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
             environmentVariableProviderMock.Verify(m => m.AdoPersonalAccessToken());
             environmentVariableProviderMock.Verify(m => m.GithubPersonalAccessToken());
         }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
@@ -17,7 +17,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new MigrateRepoCommand(null, null, null);
             command.Should().NotBeNull();
             command.Name.Should().Be("migrate-repo");
-            command.Options.Count.Should().Be(8);
+            command.Options.Count.Should().Be(10);
 
             TestHelpers.VerifyCommandOption(command.Options, "ado-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", true);
@@ -26,6 +26,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             TestHelpers.VerifyCommandOption(command.Options, "github-repo", true);
             TestHelpers.VerifyCommandOption(command.Options, "ssh", false, true);
             TestHelpers.VerifyCommandOption(command.Options, "wait", false);
+            TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
+            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -151,6 +153,60 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, wait: true);
 
             mockGithub.Verify(x => x.GetMigrationState(migrationId));
+        }
+
+        [Fact]
+        public async Task It_Uses_Ado_And_Github_Pats_When_Provided()
+        {
+            const string adoPat = "ado-pat";
+            const string githubPat = "github-pat";
+
+            var mockGithub = new Mock<GithubApi>(null, null);
+            mockGithub.Setup(x => x.GetMigrationState(It.IsAny<string>()).Result).Returns("SUCCEEDED");
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(mockGithub.Object);
+
+            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
+            environmentVariableProviderMock
+                .Setup(m => m.GithubPersonalAccessToken())
+                .Returns(githubPat);
+            environmentVariableProviderMock
+                .Setup(m => m.AdoPersonalAccessToken())
+                .Returns(adoPat);
+
+            var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
+            await command.Invoke("adoOrg", "adoTeamProject", "adoRepo", "githubOrg", "githubRepo", wait: true, adoPat: adoPat, githubPat: githubPat);
+
+            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
+            environmentVariableProviderMock.Verify(m => m.AdoPersonalAccessToken(), Times.Never);
+            environmentVariableProviderMock.Verify(m => m.GithubPersonalAccessToken(), Times.Never);
+        }
+
+        [Fact]
+        public async Task It_Falls_Back_To_Ado_And_Github_Pats_From_Environment_When_Not_Provided()
+        {
+            const string adoPat = "ado-pat";
+            const string githubPat = "github-pat";
+
+            var mockGithub = new Mock<GithubApi>(null, null);
+            mockGithub.Setup(x => x.GetMigrationState(It.IsAny<string>()).Result).Returns("SUCCEEDED");
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(mockGithub.Object);
+
+            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
+            environmentVariableProviderMock
+                .Setup(m => m.GithubPersonalAccessToken())
+                .Returns(githubPat);
+            environmentVariableProviderMock
+                .Setup(m => m.AdoPersonalAccessToken())
+                .Returns(adoPat);
+
+            var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
+            await command.Invoke("adoOrg", "adoTeamProject", "adoRepo", "githubOrg", "githubRepo", wait: true);
+
+            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
+            environmentVariableProviderMock.Verify(m => m.AdoPersonalAccessToken());
+            environmentVariableProviderMock.Verify(m => m.GithubPersonalAccessToken());
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
@@ -56,7 +56,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new RevokeMigratorRoleCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke("githubOrg", "actor", "TEAM", githubPat);
 
-            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
+            mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
@@ -35,7 +35,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
 
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new RevokeMigratorRoleCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, actor, actorType);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
@@ -15,11 +15,12 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new RevokeMigratorRoleCommand(null, null);
             Assert.NotNull(command);
             Assert.Equal("revoke-migrator-role", command.Name);
-            Assert.Equal(4, command.Options.Count);
+            Assert.Equal(5, command.Options.Count);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "actor", true);
             TestHelpers.VerifyCommandOption(command.Options, "actor-type", true);
+            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -41,6 +42,21 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await command.Invoke(githubOrg, actor, actorType);
 
             mockGithub.Verify(x => x.RevokeMigratorRole(githubOrgId, actor, actorType));
+        }
+
+        [Fact]
+        public async Task It_Uses_The_Github_Pat_When_Provided()
+        {
+            const string githubPat = "github-pat";
+
+            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(mockGithub.Object);
+
+            var command = new RevokeMigratorRoleCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
+            await command.Invoke("githubOrg", "actor", "TEAM", githubPat);
+
+            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/RewirePipelineCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/RewirePipelineCommandTests.cs
@@ -15,7 +15,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new RewirePipelineCommand(null, null);
             Assert.NotNull(command);
             Assert.Equal("rewire-pipeline", command.Name);
-            Assert.Equal(7, command.Options.Count);
+            Assert.Equal(8, command.Options.Count);
 
             TestHelpers.VerifyCommandOption(command.Options, "ado-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", true);
@@ -23,6 +23,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "github-repo", true);
             TestHelpers.VerifyCommandOption(command.Options, "service-connection-id", true);
+            TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -51,6 +52,21 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await command.Invoke(adoOrg, adoTeamProject, adoPipeline, githubOrg, githubRepo, serviceConnectionId);
 
             mockAdo.Verify(x => x.ChangePipelineRepo(adoOrg, adoTeamProject, pipelineId, defaultBranch, clean, checkoutSubmodules, githubOrg, githubRepo, serviceConnectionId));
+        }
+
+        [Fact]
+        public async Task It_Uses_The_Ado_Pat_When_Provided()
+        {
+            const string adoPat = "ado-pat";
+
+            var mockAdo = new Mock<AdoApi>(null);
+            var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
+            mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(mockAdo.Object);
+
+            var command = new RewirePipelineCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object);
+            await command.Invoke("adoOrg", "adoTeamProject", "adoPipeline", "githubOrg", "githubRepo", "serviceConnectionId", adoPat);
+
+            mockAdoApiFactory.Verify(m => m.Create(adoPat));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/RewirePipelineCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/RewirePipelineCommandTests.cs
@@ -45,7 +45,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockAdo.Setup(x => x.GetPipeline(adoOrg, adoTeamProject, pipelineId).Result).Returns((defaultBranch, clean, checkoutSubmodules));
 
             var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
-            mockAdoApiFactory.Setup(m => m.Create()).Returns(mockAdo.Object);
+            mockAdoApiFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(mockAdo.Object);
 
             var command = new RewirePipelineCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object);
             await command.Invoke(adoOrg, adoTeamProject, adoPipeline, githubOrg, githubRepo, serviceConnectionId);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ShareServiceConnectionCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ShareServiceConnectionCommandTests.cs
@@ -35,7 +35,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockAdo.Setup(x => x.GetTeamProjectId(adoOrg, adoTeamProject).Result).Returns(teamProjectId);
 
             var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
-            mockAdoApiFactory.Setup(m => m.Create()).Returns(mockAdo.Object);
+            mockAdoApiFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(mockAdo.Object);
 
             var command = new ShareServiceConnectionCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object);
             await command.Invoke(adoOrg, adoTeamProject, serviceConnectionId);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ShareServiceConnectionCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ShareServiceConnectionCommandTests.cs
@@ -15,11 +15,12 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new ShareServiceConnectionCommand(null, null);
             Assert.NotNull(command);
             Assert.Equal("share-service-connection", command.Name);
-            Assert.Equal(4, command.Options.Count);
+            Assert.Equal(5, command.Options.Count);
 
             TestHelpers.VerifyCommandOption(command.Options, "ado-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", true);
             TestHelpers.VerifyCommandOption(command.Options, "service-connection-id", true);
+            TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -41,6 +42,21 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await command.Invoke(adoOrg, adoTeamProject, serviceConnectionId);
 
             mockAdo.Verify(x => x.ShareServiceConnection(adoOrg, adoTeamProject, teamProjectId, serviceConnectionId));
+        }
+
+        [Fact]
+        public async Task It_Uses_The_Ado_Pat_When_Provided()
+        {
+            const string adoPat = "ado-pat";
+
+            var mockAdo = new Mock<AdoApi>(null);
+            var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
+            mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(mockAdo.Object);
+
+            var command = new ShareServiceConnectionCommand(new Mock<OctoLogger>().Object, mockAdoApiFactory.Object);
+            await command.Invoke("adoOrg", "adoTeamProject", "serviceConnectionId", adoPat);
+
+            mockAdoApiFactory.Verify(m => m.Create(adoPat));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/WaitForMigrationCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/WaitForMigrationCommandTests.cs
@@ -155,7 +155,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await command.Invoke(specifiedMigrationId, githubPat);
 
             // Assert
-            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
+            mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/WaitForMigrationCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/WaitForMigrationCommandTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 {
-    public class WaitForMigrationTests
+    public class WaitForMigrationCommandTests
     {
         [Fact]
         public void Should_Have_Options()
@@ -16,9 +16,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new WaitForMigrationCommand(null, null);
             command.Should().NotBeNull();
             command.Name.Should().Be("wait-for-migration");
-            command.Options.Count.Should().Be(2);
+            command.Options.Count.Should().Be(3);
 
             TestHelpers.VerifyCommandOption(command.Options, "migration-id", true);
+            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -128,6 +129,33 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             mockLogger.VerifyNoOtherCalls();
             mockGithubApi.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task It_Uses_The_Github_Pat_When_Provided()
+        {
+            // Arrange
+            const string specifiedMigrationId = "MIGRATION_ID";
+            const int waitIntervalInSeconds = 1;
+            const string githubPat = "github-pat";
+
+            var mockGithubApi = new Mock<GithubApi>(null, null);
+            mockGithubApi
+                .Setup(x => x.GetMigrationState(specifiedMigrationId).Result)
+                .Returns(RepositoryMigrationStatus.Succeeded);
+
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(mockGithubApi.Object);
+
+            // Act
+            var command = new WaitForMigrationCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object)
+            {
+                WaitIntervalInSeconds = waitIntervalInSeconds
+            };
+            await command.Invoke(specifiedMigrationId, githubPat);
+
+            // Assert
+            mockGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/WaitForMigrationTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/WaitForMigrationTests.cs
@@ -36,7 +36,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 .Returns(RepositoryMigrationStatus.Succeeded);
 
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithubApi.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithubApi.Object);
 
             var actualLogOutput = new List<string>();
             var mockLogger = new Mock<OctoLogger>();
@@ -89,7 +89,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 .Returns(RepositoryMigrationStatus.Failed);
 
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithubApi.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithubApi.Object);
 
             var actualLogOutput = new List<string>();
             var mockLogger = new Mock<OctoLogger>();

--- a/src/OctoshiftCLI.Tests/ado2gh/GithubApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/GithubApiFactoryTests.cs
@@ -27,7 +27,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             result.Should().NotBeNull();
             httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(GH_PAT);
             httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
-            
+
             environmentVariableProviderMock.Verify(m => m.GithubPersonalAccessToken());
         }
 

--- a/src/OctoshiftCLI.Tests/ado2gh/GithubApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/GithubApiFactoryTests.cs
@@ -11,7 +11,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private const string GH_PAT = "GH_PAT";
 
         [Fact]
-        public void Create_Should_Create_Github_Api_With_Github_Pat()
+        public void Create_Should_Create_Github_Api_With_Github_Pat_From_Environment_If_Not_Provided()
         {
             // Arrange
             var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
@@ -27,6 +27,29 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             result.Should().NotBeNull();
             httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(GH_PAT);
             httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
+            
+            environmentVariableProviderMock.Verify(m => m.GithubPersonalAccessToken());
+        }
+
+        [Fact]
+        public void Create_Should_Create_Github_Api_With_Provided_Github_Pat()
+        {
+            // Arrange
+            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
+            environmentVariableProviderMock.Setup(m => m.GithubPersonalAccessToken()).Returns(GH_PAT);
+
+            using var httpClient = new HttpClient();
+
+            // Act
+            var factory = new GithubApiFactory(null, httpClient, environmentVariableProviderMock.Object);
+            var result = factory.Create(personalAccessToken: GH_PAT);
+
+            // Assert
+            result.Should().NotBeNull();
+            httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(GH_PAT);
+            httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
+
+            environmentVariableProviderMock.Verify(m => m.GithubPersonalAccessToken(), Times.Never);
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/AdoApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/AdoApiFactoryTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using FluentAssertions;
+using Moq;
+using OctoshiftCLI.GithubEnterpriseImporter;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands;
+
+public class AdoApiFactoryTests
+{
+    private const string ADO_PAT = "ADO_PAT";
+
+    [Fact]
+    public void AdoApiFactory_Should_Create_Ado_Api_With_Ado_Pat_From_Environment_If_Not_Provided()
+    {
+        // Arrange
+        var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
+        environmentVariableProviderMock.Setup(m => m.AdoPersonalAccessToken()).Returns(ADO_PAT);
+
+        using var httpClient = new HttpClient();
+
+        // Act
+        var factory = new AdoApiFactory(null, httpClient, environmentVariableProviderMock.Object);
+        var result = factory.Create();
+
+        // Assert
+        result.Should().NotBeNull();
+        var authToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{ADO_PAT}"));
+        httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(authToken);
+        httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Basic");
+
+        environmentVariableProviderMock.Verify(m => m.AdoPersonalAccessToken());
+    }
+
+    [Fact]
+    public void AdoApiFactory_Should_Create_Ado_Api_With_Provided_Ado_Pat()
+    {
+        // Arrange
+        var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
+        environmentVariableProviderMock.Setup(m => m.AdoPersonalAccessToken()).Returns(ADO_PAT);
+
+        using var httpClient = new HttpClient();
+
+        // Act
+        var factory = new AdoApiFactory(null, httpClient, environmentVariableProviderMock.Object);
+        var result = factory.Create(ADO_PAT);
+
+        // Assert
+        result.Should().NotBeNull();
+        var authToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{ADO_PAT}"));
+        httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(authToken);
+        httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Basic");
+
+        environmentVariableProviderMock.Verify(m => m.AdoPersonalAccessToken(), Times.Never);
+    }
+}

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -492,7 +492,7 @@ if ($Failed -ne 0) {
             // Arrange
             const string githubSourcePat = "github-source-pat";
 
-            var mockSourceGithubApi = new Mock<GithubApi>(null, null); 
+            var mockSourceGithubApi = new Mock<GithubApi>(null, null);
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
             mockSourceGithubApiFactory
                 .Setup(m => m.Create(It.IsAny<string>(), githubSourcePat))
@@ -500,12 +500,12 @@ if ($Failed -ne 0) {
 
             var mockEnvironmentVariableProvider = new Mock<EnvironmentVariableProvider>(null);
             var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
-           
+
             // Act
             var command = new GenerateScriptCommand(
-                new Mock<OctoLogger>().Object, 
+                new Mock<OctoLogger>().Object,
                 mockSourceGithubApiFactory.Object,
-                mockAdoApiFactory.Object, 
+                mockAdoApiFactory.Object,
                 mockEnvironmentVariableProvider.Object);
             await command.Invoke("githubSourceOrg", null, "githubTargetOrg", null, githubSourcePat: githubSourcePat);
 
@@ -520,23 +520,23 @@ if ($Failed -ne 0) {
             // Arrange
             const string adoPat = "ado-pat";
 
-            var mockAdoApi = new Mock<AdoApi>(null); 
+            var mockAdoApi = new Mock<AdoApi>(null);
             var mockAdoApiFactory = new Mock<AdoApiFactory>(null, null, null);
             mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(mockAdoApi.Object);
-            
-            var mockSourceGithubApi = new Mock<GithubApi>(null, null); 
+
+            var mockSourceGithubApi = new Mock<GithubApi>(null, null);
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
             mockSourceGithubApiFactory
                 .Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(mockSourceGithubApi.Object);
 
             var mockEnvironmentVariableProvider = new Mock<EnvironmentVariableProvider>(null);
-           
+
             // Act
             var command = new GenerateScriptCommand(
-                new Mock<OctoLogger>().Object, 
+                new Mock<OctoLogger>().Object,
                 mockSourceGithubApiFactory.Object,
-                mockAdoApiFactory.Object, 
+                mockAdoApiFactory.Object,
                 mockEnvironmentVariableProvider.Object);
             await command.Invoke(null, "adoSourceOrg", "githubTargetOrg", null, adoPat: adoPat);
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -510,7 +510,7 @@ if ($Failed -ne 0) {
             await command.Invoke("githubSourceOrg", null, "githubTargetOrg", null, githubSourcePat: githubSourcePat);
 
             // Assert
-            mockSourceGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubSourcePat));
+            mockSourceGithubApiFactory.Verify(m => m.Create(null, githubSourcePat));
             mockEnvironmentVariableProvider.VerifyNoOtherCalls();
         }
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -582,7 +582,7 @@ if ($Failed -ne 0) {
                 mockSourceGithubApiFactory.Object,
                 mockAdoApiFactory.Object,
                 mockEnvironmentVariableProvider.Object);
-            await command.Invoke("githubSourceOrg", null, "githubTargetOrg", null, githubSourcePat: githubSourcePat);
+            await command.Invoke("githubSourceOrg", null, null, "githubTargetOrg", null, githubSourcePat: githubSourcePat);
 
             // Assert
             mockSourceGithubApiFactory.Verify(m => m.Create(null, githubSourcePat));
@@ -613,7 +613,7 @@ if ($Failed -ne 0) {
                 mockSourceGithubApiFactory.Object,
                 mockAdoApiFactory.Object,
                 mockEnvironmentVariableProvider.Object);
-            await command.Invoke(null, "adoSourceOrg", "githubTargetOrg", null, adoPat: adoPat);
+            await command.Invoke(null, "adoSourceOrg", null, "githubTargetOrg", null, adoPat: adoPat);
 
             // Assert
             mockAdoApiFactory.Verify(m => m.Create(adoPat));

--- a/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Moq;
-using Moq.Protected;
 using OctoshiftCLI.AdoToGithub;
 using OctoshiftCLI.AdoToGithub.Commands;
 using Xunit;

--- a/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
@@ -64,7 +64,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var command = new GrantMigratorRoleCommand(new Mock<OctoLogger>().Object, mockTargetGithubApiFactory.Object);
             await command.Invoke("githubOrg", "actor", "TEAM", githubPat);
 
-            mockTargetGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
+            mockTargetGithubApiFactory.Verify(m => m.Create(null, githubPat));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Moq;
+using Moq.Protected;
 using OctoshiftCLI.AdoToGithub;
 using OctoshiftCLI.AdoToGithub.Commands;
 using Xunit;
@@ -35,7 +36,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
 
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new GrantMigratorRoleCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, actor, actorType);

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -65,7 +65,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL)).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
 
             var actualLogOutput = new List<string>();
             var mockLogger = new Mock<OctoLogger>();
@@ -129,7 +129,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL)).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, mockGithubApiFactory.Object, environmentVariableProviderMock.Object, null);
             await command.Invoke(SOURCE_ORG, null, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, TARGET_API_URL, wait: true);
@@ -170,7 +170,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL)).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, mockGithubApiFactory.Object, environmentVariableProviderMock.Object, null);
             await command.Invoke(null, SOURCE_ORG, adoTeamProject, SOURCE_REPO, TARGET_ORG, TARGET_REPO, TARGET_API_URL, wait: true);
@@ -232,10 +232,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
-            mockSourceGithubApiFactory.Setup(m => m.Create(GHES_API_URL)).Returns(mockGhesGithubApi.Object);
+            mockSourceGithubApiFactory.Setup(m => m.Create(GHES_API_URL, It.IsAny<string>())).Returns(mockGhesGithubApi.Object);
 
             var mockTargetGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockTargetGithubApiFactory.Setup(m => m.Create(TARGET_API_URL)).Returns(mockGithub.Object);
+            mockTargetGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
 
             var mockAzureApiFactory = new Mock<IAzureApiFactory>();
             mockAzureApiFactory.Setup(m => m.Create(AZURE_CONNECTION_STRING)).Returns(mockAzureApi.Object);
@@ -280,7 +280,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL)).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, mockGithubApiFactory.Object, environmentVariableProviderMock.Object, null);
             await command.Invoke(SOURCE_ORG, null, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, TARGET_API_URL, "", "", false, gitArchiveUrl, metadataArchiveUrl, wait: true);
@@ -348,7 +348,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL)).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, mockGithubApiFactory.Object, environmentVariableProviderMock.Object, null);
             await command.Invoke(SOURCE_ORG, null, null, SOURCE_REPO, TARGET_ORG, null, "", wait: true);
@@ -422,10 +422,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             environmentVariableProviderMock.Setup(m => m.AzureStorageConnectionString()).Returns(azureConnectionStringEnv);
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
-            mockSourceGithubApiFactory.Setup(m => m.Create(GHES_API_URL)).Returns(mockGhesGithubApi.Object);
+            mockSourceGithubApiFactory.Setup(m => m.Create(GHES_API_URL, It.IsAny<string>())).Returns(mockGhesGithubApi.Object);
 
             var mockTargetGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockTargetGithubApiFactory.Setup(m => m.Create(TARGET_API_URL)).Returns(mockGithub.Object);
+            mockTargetGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
 
             var mockAzureApiFactory = new Mock<IAzureApiFactory>();
             mockAzureApiFactory.Setup(m => m.Create(azureConnectionStringEnv)).Returns(mockAzureApi.Object);
@@ -491,10 +491,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
-            mockSourceGithubApiFactory.Setup(m => m.CreateClientNoSsl(GHES_API_URL)).Returns(mockGhesGithubApi.Object);
+            mockSourceGithubApiFactory.Setup(m => m.CreateClientNoSsl(GHES_API_URL, It.IsAny<string>())).Returns(mockGhesGithubApi.Object);
 
             var mockTargetGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockTargetGithubApiFactory.Setup(m => m.Create(TARGET_API_URL)).Returns(mockGithub.Object);
+            mockTargetGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
 
             var mockAzureApiFactory = new Mock<IAzureApiFactory>();
             mockAzureApiFactory.Setup(m => m.CreateClientNoSsl(AZURE_CONNECTION_STRING)).Returns(mockAzureApi.Object);
@@ -520,7 +520,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var mockAzureApi = new Mock<AzureApi>(null, null);
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
-            mockSourceGithubApiFactory.Setup(m => m.Create(GHES_API_URL)).Returns(mockGhesGithubApi.Object);
+            mockSourceGithubApiFactory.Setup(m => m.Create(GHES_API_URL, It.IsAny<string>())).Returns(mockGhesGithubApi.Object);
 
             var mockAzureApiFactory = new Mock<IAzureApiFactory>();
             mockAzureApiFactory.Setup(m => m.Create(AZURE_CONNECTION_STRING)).Returns(mockAzureApi.Object);

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -84,7 +84,16 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Act
             var command = new MigrateRepoCommand(mockLogger.Object, null, mockGithubApiFactory.Object, environmentVariableProviderMock.Object, null);
-            await command.Invoke(SOURCE_ORG, null, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, TARGET_API_URL, wait: false);
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                TargetApiUrl = TARGET_API_URL,
+                Wait = false
+            };
+            await command.Invoke(args);
 
             // Assert
             mockGithub.Verify(m => m.GetOrganizationId(TARGET_ORG));
@@ -132,7 +141,16 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, mockGithubApiFactory.Object, environmentVariableProviderMock.Object, null);
-            await command.Invoke(SOURCE_ORG, null, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, TARGET_API_URL, wait: true);
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                TargetApiUrl = TARGET_API_URL,
+                Wait = true
+            };
+            await command.Invoke(args);
 
             mockGithub.Verify(x => x.GetMigrationState(migrationId));
         }
@@ -173,7 +191,17 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, mockGithubApiFactory.Object, environmentVariableProviderMock.Object, null);
-            await command.Invoke(null, SOURCE_ORG, adoTeamProject, SOURCE_REPO, TARGET_ORG, TARGET_REPO, TARGET_API_URL, wait: true);
+            var args = new MigrateRepoCommandArgs
+            {
+                AdoSourceOrg = SOURCE_ORG,
+                AdoTeamProject = adoTeamProject,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                TargetApiUrl = TARGET_API_URL,
+                Wait = true
+            };
+            await command.Invoke(args);
 
             mockGithub.Verify(x => x.GetMigrationState(migrationId));
         }
@@ -241,7 +269,18 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockAzureApiFactory.Setup(m => m.Create(AZURE_CONNECTION_STRING)).Returns(mockAzureApi.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockSourceGithubApiFactory.Object, mockTargetGithubApiFactory.Object, environmentVariableProviderMock.Object, mockAzureApiFactory.Object);
-            await command.Invoke(SOURCE_ORG, null, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, TARGET_API_URL, GHES_API_URL, AZURE_CONNECTION_STRING, wait: true);
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                TargetApiUrl = TARGET_API_URL,
+                GhesApiUrl = GHES_API_URL,
+                AzureStorageConnectionString = AZURE_CONNECTION_STRING,
+                Wait = true
+            };
+            await command.Invoke(args);
 
             mockGithub.Verify(x => x.GetMigrationState(migrationId));
         }
@@ -283,7 +322,18 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, mockGithubApiFactory.Object, environmentVariableProviderMock.Object, null);
-            await command.Invoke(SOURCE_ORG, null, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, TARGET_API_URL, "", "", false, gitArchiveUrl, metadataArchiveUrl, wait: true);
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                TargetApiUrl = TARGET_API_URL,
+                GitArchiveUrl = gitArchiveUrl,
+                MetadataArchiveUrl = metadataArchiveUrl,
+                Wait = true
+            };
+            await command.Invoke(args);
 
             mockGithub.Verify(x => x.GetMigrationState(migrationId));
         }
@@ -295,7 +345,16 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, null, null, null);
             await FluentActions
-                .Invoking(async () => await command.Invoke(SOURCE_ORG, null, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, TARGET_API_URL, "", "", false, gitArchiveUrl, wait: true))
+                .Invoking(async () => await command.Invoke(new MigrateRepoCommandArgs
+                {
+                    GithubSourceOrg = SOURCE_ORG,
+                    SourceRepo = SOURCE_REPO,
+                    GithubTargetOrg = TARGET_ORG,
+                    TargetRepo = TARGET_REPO,
+                    TargetApiUrl = TARGET_API_URL,
+                    GitArchiveUrl = gitArchiveUrl,
+                    Wait = true
+                }))
                 .Should().ThrowAsync<OctoshiftCliException>();
         }
 
@@ -304,7 +363,13 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         {
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, null, null, null);
             await FluentActions
-                .Invoking(async () => await command.Invoke(null, null, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, ""))
+                .Invoking(async () => await command.Invoke(new MigrateRepoCommandArgs
+                {
+                    SourceRepo = SOURCE_REPO,
+                    GithubTargetOrg = TARGET_ORG,
+                    TargetRepo = TARGET_REPO,
+                    TargetApiUrl = ""
+                }))
                 .Should().ThrowAsync<OctoshiftCliException>();
         }
 
@@ -313,7 +378,14 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         {
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, null, null, null);
             await FluentActions
-                .Invoking(async () => await command.Invoke(null, SOURCE_ORG, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, ""))
+                .Invoking(async () => await command.Invoke(new MigrateRepoCommandArgs
+                {
+                    AdoSourceOrg = SOURCE_ORG,
+                    SourceRepo = SOURCE_REPO,
+                    GithubTargetOrg = TARGET_ORG,
+                    TargetRepo = TARGET_REPO,
+                    TargetApiUrl = ""
+                }))
                 .Should().ThrowAsync<OctoshiftCliException>();
         }
 
@@ -351,7 +423,15 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, mockGithubApiFactory.Object, environmentVariableProviderMock.Object, null);
-            await command.Invoke(SOURCE_ORG, null, null, SOURCE_REPO, TARGET_ORG, null, "", wait: true);
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetApiUrl = "",
+                Wait = true
+            };
+            await command.Invoke(args);
 
             mockGithub.Verify(x => x.GetMigrationState(migrationId));
         }
@@ -361,7 +441,14 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         {
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, null, null, null);
             await FluentActions
-                .Invoking(async () => await command.Invoke(null, null, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, GHES_API_URL, ""))
+                .Invoking(async () => await command.Invoke(new MigrateRepoCommandArgs
+                    {
+                        SourceRepo = SOURCE_REPO,
+                        GithubTargetOrg = TARGET_ORG,
+                        TargetRepo = TARGET_REPO,
+                        GhesApiUrl = GHES_API_URL
+                    }
+                ))
                 .Should().ThrowAsync<OctoshiftCliException>();
         }
 
@@ -431,7 +518,17 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockAzureApiFactory.Setup(m => m.Create(azureConnectionStringEnv)).Returns(mockAzureApi.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockSourceGithubApiFactory.Object, mockTargetGithubApiFactory.Object, environmentVariableProviderMock.Object, mockAzureApiFactory.Object);
-            await command.Invoke(SOURCE_ORG, null, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, TARGET_API_URL, GHES_API_URL, wait: true);
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                TargetApiUrl = TARGET_API_URL,
+                GhesApiUrl = GHES_API_URL,
+                Wait = true
+            };
+            await command.Invoke(args);
 
             mockAzureApiFactory.Verify(x => x.Create(azureConnectionStringEnv));
             mockGithub.Verify(x => x.GetMigrationState(migrationId));
@@ -500,7 +597,19 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockAzureApiFactory.Setup(m => m.CreateClientNoSsl(AZURE_CONNECTION_STRING)).Returns(mockAzureApi.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockSourceGithubApiFactory.Object, mockTargetGithubApiFactory.Object, environmentVariableProviderMock.Object, mockAzureApiFactory.Object);
-            await command.Invoke(SOURCE_ORG, null, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, TARGET_API_URL, GHES_API_URL, AZURE_CONNECTION_STRING, true, wait: true);
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                TargetApiUrl = TARGET_API_URL,
+                GhesApiUrl = GHES_API_URL,
+                AzureStorageConnectionString = AZURE_CONNECTION_STRING,
+                NoSslVerify = true,
+                Wait = true
+            };
+            await command.Invoke(args);
 
             mockAzureApiFactory.Verify(x => x.CreateClientNoSsl(AZURE_CONNECTION_STRING));
             mockGithub.Verify(x => x.GetMigrationState(migrationId));
@@ -527,7 +636,17 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockSourceGithubApiFactory.Object, null, null, mockAzureApiFactory.Object);
             await FluentActions
-                .Invoking(async () => await command.Invoke(SOURCE_ORG, null, null, SOURCE_REPO, TARGET_ORG, TARGET_REPO, TARGET_API_URL, GHES_API_URL, AZURE_CONNECTION_STRING))
+                .Invoking(async () => await command.Invoke(new MigrateRepoCommandArgs
+                    {
+                        GithubSourceOrg = SOURCE_ORG,
+                        SourceRepo = SOURCE_REPO,
+                        GithubTargetOrg = TARGET_ORG,
+                        TargetRepo = TARGET_REPO,
+                        TargetApiUrl = TARGET_API_URL,
+                        GhesApiUrl = GHES_API_URL,
+                        AzureStorageConnectionString = AZURE_CONNECTION_STRING
+                    }
+                ))
                 .Should().ThrowAsync<OctoshiftCliException>();
         }
     }

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -25,7 +25,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var command = new MigrateRepoCommand(null, null, null, null, null);
             command.Should().NotBeNull();
             command.Name.Should().Be("migrate-repo");
-            command.Options.Count.Should().Be(15);
+            command.Options.Count.Should().Be(18);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-source-org", false);
             TestHelpers.VerifyCommandOption(command.Options, "ado-source-org", false);
@@ -41,6 +41,9 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(command.Options, "metadata-archive-url", false, true);
             TestHelpers.VerifyCommandOption(command.Options, "ssh", false, true);
             TestHelpers.VerifyCommandOption(command.Options, "wait", false);
+            TestHelpers.VerifyCommandOption(command.Options, "github-source-pat", false);
+            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
+            TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -65,7 +68,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var actualLogOutput = new List<string>();
             var mockLogger = new Mock<OctoLogger>();
@@ -78,7 +81,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 $"SOURCE REPO: {SOURCE_REPO}",
                 $"GITHUB TARGET ORG: {TARGET_ORG}",
                 $"TARGET REPO: {TARGET_REPO}",
-                $"Target API URL: {TARGET_API_URL}",
+                $"TARGET API URL: {TARGET_API_URL}",
                 $"A repository migration (ID: {migrationId}) was successfully queued."
             };
 
@@ -420,7 +423,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, mockGithubApiFactory.Object, environmentVariableProviderMock.Object, null);
             var args = new MigrateRepoCommandArgs
@@ -428,7 +431,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 GithubSourceOrg = SOURCE_ORG,
                 SourceRepo = SOURCE_REPO,
                 GithubTargetOrg = TARGET_ORG,
-                TargetApiUrl = "",
                 Wait = true
             };
             await command.Invoke(args);

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -442,12 +442,12 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, null, null, null, null);
             await FluentActions
                 .Invoking(async () => await command.Invoke(new MigrateRepoCommandArgs
-                    {
-                        SourceRepo = SOURCE_REPO,
-                        GithubTargetOrg = TARGET_ORG,
-                        TargetRepo = TARGET_REPO,
-                        GhesApiUrl = GHES_API_URL
-                    }
+                {
+                    SourceRepo = SOURCE_REPO,
+                    GithubTargetOrg = TARGET_ORG,
+                    TargetRepo = TARGET_REPO,
+                    GhesApiUrl = GHES_API_URL
+                }
                 ))
                 .Should().ThrowAsync<OctoshiftCliException>();
         }
@@ -637,15 +637,15 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var command = new MigrateRepoCommand(new Mock<OctoLogger>().Object, mockSourceGithubApiFactory.Object, null, null, mockAzureApiFactory.Object);
             await FluentActions
                 .Invoking(async () => await command.Invoke(new MigrateRepoCommandArgs
-                    {
-                        GithubSourceOrg = SOURCE_ORG,
-                        SourceRepo = SOURCE_REPO,
-                        GithubTargetOrg = TARGET_ORG,
-                        TargetRepo = TARGET_REPO,
-                        TargetApiUrl = TARGET_API_URL,
-                        GhesApiUrl = GHES_API_URL,
-                        AzureStorageConnectionString = AZURE_CONNECTION_STRING
-                    }
+                {
+                    GithubSourceOrg = SOURCE_ORG,
+                    SourceRepo = SOURCE_REPO,
+                    GithubTargetOrg = TARGET_ORG,
+                    TargetRepo = TARGET_REPO,
+                    TargetApiUrl = TARGET_API_URL,
+                    GhesApiUrl = GHES_API_URL,
+                    AzureStorageConnectionString = AZURE_CONNECTION_STRING
+                }
                 ))
                 .Should().ThrowAsync<OctoshiftCliException>();
         }

--- a/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Moq;
-using Moq.Protected;
 using OctoshiftCLI.AdoToGithub;
 using OctoshiftCLI.AdoToGithub.Commands;
 using Xunit;

--- a/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
@@ -64,7 +64,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var command = new RevokeMigratorRoleCommand(new Mock<OctoLogger>().Object, mockTargetGithubApiFactory.Object);
             await command.Invoke("githubOrg", "actor", "TEAM", githubPat);
 
-            mockTargetGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
+            mockTargetGithubApiFactory.Verify(m => m.Create(null, githubPat));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using OctoshiftCLI.GithubEnterpriseImporter;
 using OctoshiftCLI.GithubEnterpriseImporter.Commands;
@@ -20,7 +22,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "actor", true);
             TestHelpers.VerifyCommandOption(command.Options, "actor-type", true);
-            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
+            TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -53,18 +55,26 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         }
 
         [Fact]
-        public async Task It_Uses_Github_Pat_When_Provided()
+        public async Task It_Uses_Github_Target_Pat_When_Provided()
         {
-            const string githubPat = "github-pat";
+            // Arrange
+            const string githubTargetPat = "github-target-pat";
 
             var mockGithub = new Mock<GithubApi>(null, null);
             var mockTargetGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(mockGithub.Object);
+            mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubTargetPat)).Returns(mockGithub.Object);
 
-            var command = new RevokeMigratorRoleCommand(new Mock<OctoLogger>().Object, mockTargetGithubApiFactory.Object);
-            await command.Invoke("githubOrg", "actor", "TEAM", githubPat);
+            var actualLogOutput = new List<string>();
+            var mockLogger = new Mock<OctoLogger>();
+            mockLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
 
-            mockTargetGithubApiFactory.Verify(m => m.Create(null, githubPat));
+            // Act
+            var command = new RevokeMigratorRoleCommand(mockLogger.Object, mockTargetGithubApiFactory.Object);
+            await command.Invoke("githubOrg", "actor", "TEAM", githubTargetPat);
+
+            // Assert
+            actualLogOutput.Should().Contain("GITHUB TARGET PAT: ***");
+            mockTargetGithubApiFactory.Verify(m => m.Create(null, githubTargetPat));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Threading.Tasks;
 using Moq;
-using OctoshiftCLI.AdoToGithub;
-using OctoshiftCLI.AdoToGithub.Commands;
+using OctoshiftCLI.GithubEnterpriseImporter;
+using OctoshiftCLI.GithubEnterpriseImporter.Commands;
 using Xunit;
 
 namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
@@ -15,11 +15,12 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var command = new RevokeMigratorRoleCommand(null, null);
             Assert.NotNull(command);
             Assert.Equal("revoke-migrator-role", command.Name);
-            Assert.Equal(4, command.Options.Count);
+            Assert.Equal(5, command.Options.Count);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "actor", true);
             TestHelpers.VerifyCommandOption(command.Options, "actor-type", true);
+            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -34,7 +35,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var mockGithub = new Mock<GithubApi>(null, null);
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
 
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new RevokeMigratorRoleCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
@@ -49,6 +50,21 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var command = new RevokeMigratorRoleCommand(new Mock<OctoLogger>().Object, null);
 
             await command.Invoke("foo", "foo", "foo");
+        }
+
+        [Fact]
+        public async Task It_Uses_Github_Pat_When_Provided()
+        {
+            const string githubPat = "github-pat";
+
+            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockTargetGithubApiFactory = new Mock<ITargetGithubApiFactory>();
+            mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(mockGithub.Object);
+
+            var command = new RevokeMigratorRoleCommand(new Mock<OctoLogger>().Object, mockTargetGithubApiFactory.Object);
+            await command.Invoke("githubOrg", "actor", "TEAM", githubPat);
+
+            mockTargetGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Moq;
+using Moq.Protected;
 using OctoshiftCLI.AdoToGithub;
 using OctoshiftCLI.AdoToGithub.Commands;
 using Xunit;
@@ -35,7 +36,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
 
             var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new RevokeMigratorRoleCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, actor, actorType);

--- a/src/OctoshiftCLI.Tests/gei/Commands/WaitForMigrationCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/WaitForMigrationCommandTests.cs
@@ -155,7 +155,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await command.Invoke(specifiedMigrationId, githubPat);
 
             // Assert
-            mockTargetGithubApiFactory.Verify(m => m.Create("https://api.github.com", githubPat));
+            mockTargetGithubApiFactory.Verify(m => m.Create(null, githubPat));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/WaitForMigrationTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/WaitForMigrationTests.cs
@@ -36,7 +36,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Returns(RepositoryMigrationStatus.Succeeded);
 
             var mockTargetGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockTargetGithubApiFactory.Setup(m => m.Create()).Returns(mockGithubApi.Object);
+            mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithubApi.Object);
 
             var actualLogOutput = new List<string>();
             var mockLogger = new Mock<OctoLogger>();
@@ -88,7 +88,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Returns(RepositoryMigrationStatus.Failed);
 
             var mockTargetGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockTargetGithubApiFactory.Setup(m => m.Create()).Returns(mockGithubApi.Object);
+            mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithubApi.Object);
 
             var actualLogOutput = new List<string>();
             var mockLogger = new Mock<OctoLogger>();

--- a/src/OctoshiftCLI.Tests/gei/GithubApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/GithubApiFactoryTests.cs
@@ -29,26 +29,55 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             using var httpClient = new HttpClient();
 
-            var _mockHttpClientFactory = new Mock<IHttpClientFactory>();
-            _mockHttpClientFactory
+            var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+            mockHttpClientFactory
                 .Setup(x => x.CreateClient("NoSSL"))
                 .Returns(httpClient);
 
-            var apiUrl = $"https://api.github.com";
-
             // Act
             ISourceGithubApiFactory factory =
-                new GithubApiFactory(_logger, _mockHttpClientFactory.Object, environmentVariableProviderMock.Object);
-            var githubApi = factory.CreateClientNoSsl(apiUrl);
+                new GithubApiFactory(_logger, mockHttpClientFactory.Object, environmentVariableProviderMock.Object);
+            var githubApi = factory.CreateClientNoSsl();
 
             // Assert
             githubApi.Should().NotBeNull();
             httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(SOURCE_GH_PAT);
             httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
+
+            environmentVariableProviderMock.Verify(m => m.SourceGithubPersonalAccessToken());
         }
 
         [Fact]
         public void GithubApiFactory_Should_Create_GithubApi_For_Source_Github_Api()
+        {
+            // Arrange
+            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(_logger);
+            environmentVariableProviderMock
+                .Setup(m => m.SourceGithubPersonalAccessToken())
+                .Returns(SOURCE_GH_PAT);
+
+            using var httpClient = new HttpClient();
+
+            var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+            mockHttpClientFactory
+                .Setup(x => x.CreateClient("Default"))
+                .Returns(httpClient);
+
+            // Act
+            ISourceGithubApiFactory factory =
+                new GithubApiFactory(_logger, mockHttpClientFactory.Object, environmentVariableProviderMock.Object);
+            var githubApi = factory.Create();
+
+            // Assert
+            githubApi.Should().NotBeNull();
+            httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(SOURCE_GH_PAT);
+            httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
+
+            environmentVariableProviderMock.Verify(m => m.SourceGithubPersonalAccessToken());
+        }
+
+        [Fact]
+        public void GithubApiFactory_Should_Create_GithubApi_For_Source_Github_Api_When_Source_Pat_Is_Provided()
         {
             // Arrange
             var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(_logger);
@@ -66,12 +95,43 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             // Act
             ISourceGithubApiFactory factory =
                 new GithubApiFactory(_logger, _mockHttpClientFactory.Object, environmentVariableProviderMock.Object);
-            var githubApi = factory.Create();
+            var githubApi = factory.Create(sourcePersonalAccessToken: SOURCE_GH_PAT);
 
             // Assert
             githubApi.Should().NotBeNull();
             httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(SOURCE_GH_PAT);
             httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
+
+            environmentVariableProviderMock.Verify(m => m.SourceGithubPersonalAccessToken(), Times.Never);
+        }
+
+        [Fact]
+        public void GithubApiFactory_Should_Create_GithubApi_For_Source_Github_Api_When_Source_Pat_Is_Provided_With_NoSSL()
+        {
+            // Arrange
+            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(_logger);
+            environmentVariableProviderMock
+                .Setup(m => m.SourceGithubPersonalAccessToken())
+                .Returns(SOURCE_GH_PAT);
+
+            using var httpClient = new HttpClient();
+
+            var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+            mockHttpClientFactory
+                .Setup(x => x.CreateClient("NoSSL"))
+                .Returns(httpClient);
+
+            // Act
+            ISourceGithubApiFactory factory =
+                new GithubApiFactory(_logger, mockHttpClientFactory.Object, environmentVariableProviderMock.Object);
+            var githubApi = factory.CreateClientNoSsl(sourcePersonalAccessToken: SOURCE_GH_PAT);
+
+            // Assert
+            githubApi.Should().NotBeNull();
+            httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(SOURCE_GH_PAT);
+            httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
+
+            environmentVariableProviderMock.Verify(m => m.SourceGithubPersonalAccessToken(), Times.Never);
         }
 
         [Fact]
@@ -99,6 +159,37 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             githubApi.Should().NotBeNull();
             httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(TARGET_GH_PAT);
             httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
+
+            environmentVariableProviderMock.Verify(m => m.TargetGithubPersonalAccessToken());
+        }
+
+        [Fact]
+        public void GithubApiFactory_Should_Create_GithubApi_For_Target_Github_Api_When_Target_Pat_Is_Provided()
+        {
+            // Arrange
+            var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(_logger);
+            environmentVariableProviderMock
+                .Setup(m => m.TargetGithubPersonalAccessToken())
+                .Returns(TARGET_GH_PAT);
+
+            using var httpClient = new HttpClient();
+
+            var _mockHttpClientFactory = new Mock<IHttpClientFactory>();
+            _mockHttpClientFactory
+                .Setup(x => x.CreateClient("Default"))
+                .Returns(httpClient);
+
+            // Act
+            ITargetGithubApiFactory factory =
+                new GithubApiFactory(_logger, _mockHttpClientFactory.Object, environmentVariableProviderMock.Object);
+            var githubApi = factory.Create(targetPersonalAccessToken: TARGET_GH_PAT);
+
+            // Assert
+            githubApi.Should().NotBeNull();
+            httpClient.DefaultRequestHeaders.Authorization.Parameter.Should().Be(TARGET_GH_PAT);
+            httpClient.DefaultRequestHeaders.Authorization.Scheme.Should().Be("Bearer");
+
+            environmentVariableProviderMock.Verify(m => m.TargetGithubPersonalAccessToken(), Times.Never);
         }
     }
 }

--- a/src/ado2gh/AdoApiFactory.cs
+++ b/src/ado2gh/AdoApiFactory.cs
@@ -15,10 +15,10 @@ namespace OctoshiftCLI.AdoToGithub
             _environmentVariableProvider = environmentVariableProvider;
         }
 
-        public virtual AdoApi Create()
+        public virtual AdoApi Create(string personalAccessToken = null)
         {
-            var adoPat = _environmentVariableProvider.AdoPersonalAccessToken();
-            var adoClient = new AdoClient(_octoLogger, _client, adoPat);
+            personalAccessToken ??= _environmentVariableProvider.AdoPersonalAccessToken();
+            var adoClient = new AdoClient(_octoLogger, _client, personalAccessToken);
             return new AdoApi(adoClient);
         }
     }

--- a/src/ado2gh/Commands/AddTeamToRepoCommand.cs
+++ b/src/ado2gh/Commands/AddTeamToRepoCommand.cs
@@ -36,6 +36,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                 IsRequired = true,
                 Description = "The only valid values are: pull, push, admin, maintain, triage. For more details see https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions, custom repository roles are not currently supported."
             };
+            var githubPat = new Option<string>("--github-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -45,12 +49,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(githubRepo);
             AddOption(team);
             AddOption(role.FromAmong("pull", "push", "admin", "maintain", "triage"));
+            AddOption(githubPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubOrg, string githubRepo, string team, string role, bool verbose = false)
+        public async Task Invoke(string githubOrg, string githubRepo, string team, string role, string githubPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -59,8 +64,12 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log.LogInformation($"GITHUB REPO: {githubRepo}");
             _log.LogInformation($"TEAM: {team}");
             _log.LogInformation($"ROLE: {role}");
+            if (githubPat is not null)
+            {
+                _log.LogInformation("GITHUB PAT: ***");
+            }
 
-            await _githubApiFactory.Create().AddTeamToRepo(githubOrg, githubRepo, team, role);
+            await _githubApiFactory.Create(personalAccessToken: githubPat).AddTeamToRepo(githubOrg, githubRepo, team, role);
 
             _log.LogSuccess("Successfully added team to repo");
         }

--- a/src/ado2gh/Commands/AddTeamToRepoCommand.cs
+++ b/src/ado2gh/Commands/AddTeamToRepoCommand.cs
@@ -17,7 +17,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             Description = "Adds a team to a repo with a specific role/permission";
             Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variable to be set.";
+            Description += "Note: Expects GH_PAT env variable or --github-pat option to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/ConfigureAutoLinkCommand.cs
+++ b/src/ado2gh/Commands/ConfigureAutoLinkCommand.cs
@@ -36,6 +36,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = true
             };
+            var githubPat = new Option<string>("--github-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -45,12 +49,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(githubRepo);
             AddOption(adoOrg);
             AddOption(adoTeamProject);
+            AddOption(githubPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubOrg, string githubRepo, string adoOrg, string adoTeamProject, bool verbose = false)
+        public async Task Invoke(string githubOrg, string githubRepo, string adoOrg, string adoTeamProject, string githubPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -59,11 +64,15 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log.LogInformation($"GITHUB REPO: {githubRepo}");
             _log.LogInformation($"ADO ORG: {adoOrg}");
             _log.LogInformation($"ADO TEAM PROJECT: {adoTeamProject}");
+            if (githubPat is not null)
+            {
+                _log.LogInformation("GITHUB PAT: ***");
+            }
 
             var keyPrefix = "AB#";
             var urlTemplate = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/";
 
-            var githubApi = _githubApiFactory.Create();
+            var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
 
             var autoLinks = await githubApi.GetAutoLinks(githubOrg, githubRepo);
             if (autoLinks.Any(al => al.KeyPrefix == keyPrefix && al.UrlTemplate == urlTemplate))

--- a/src/ado2gh/Commands/ConfigureAutoLinkCommand.cs
+++ b/src/ado2gh/Commands/ConfigureAutoLinkCommand.cs
@@ -18,7 +18,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             Description = "Configures Autolink References in GitHub so that references to Azure Boards work items become hyperlinks in GitHub";
             Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variable to be set.";
+            Description += "Note: Expects GH_PAT env variable or --github-pat option to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/CreateTeamCommand.cs
+++ b/src/ado2gh/Commands/CreateTeamCommand.cs
@@ -18,7 +18,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             Description = "Creates a GitHub team and optionally links it to an IdP group.";
             Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variable to be set.";
+            Description += "Note: Expects GH_PAT env variable or --github-pat option to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/CreateTeamCommand.cs
+++ b/src/ado2gh/Commands/CreateTeamCommand.cs
@@ -32,6 +32,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = false
             };
+            var githubPat = new Option<string>("--github-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -40,12 +44,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(githubOrg);
             AddOption(teamName);
             AddOption(idpGroup);
+            AddOption(githubPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubOrg, string teamName, string idpGroup, bool verbose = false)
+        public async Task Invoke(string githubOrg, string teamName, string idpGroup, string githubPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -53,8 +58,12 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log.LogInformation($"GITHUB ORG: {githubOrg}");
             _log.LogInformation($"TEAM NAME: {teamName}");
             _log.LogInformation($"IDP GROUP: {idpGroup}");
+            if (githubPat is not null)
+            {
+                _log.LogInformation("GITHUB PAT: ***");
+            }
 
-            var githubApi = _githubApiFactory.Create();
+            var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
 
             var teams = await githubApi.GetTeams(githubOrg);
             if (teams.Contains(teamName))

--- a/src/ado2gh/Commands/DisableRepoCommand.cs
+++ b/src/ado2gh/Commands/DisableRepoCommand.cs
@@ -18,7 +18,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             Description = "Disables the repo in Azure DevOps. This makes the repo non-readable for all.";
             Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT env variable to be set.";
+            Description += "Note: Expects ADO_PAT env variable or --ado-pat option to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/DisableRepoCommand.cs
+++ b/src/ado2gh/Commands/DisableRepoCommand.cs
@@ -31,6 +31,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = true
             };
+            var adoPat = new Option<string>("--ado-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -39,12 +43,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(adoOrg);
             AddOption(adoTeamProject);
             AddOption(adoRepo);
+            AddOption(adoPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string adoOrg, string adoTeamProject, string adoRepo, bool verbose = false)
+        public async Task Invoke(string adoOrg, string adoTeamProject, string adoRepo, string adoPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -52,8 +57,12 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log.LogInformation($"ADO ORG: {adoOrg}");
             _log.LogInformation($"ADO TEAM PROJECT: {adoTeamProject}");
             _log.LogInformation($"ADO REPO: {adoRepo}");
+            if (adoPat is not null)
+            {
+                _log.LogInformation("ADO PAT: ***");
+            }
 
-            var ado = _adoApiFactory.Create();
+            var ado = _adoApiFactory.Create(adoPat);
 
             var repoId = await ado.GetRepoId(adoOrg, adoTeamProject, adoRepo);
             await ado.DisableRepo(adoOrg, adoTeamProject, repoId);

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -57,6 +57,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                 IsRequired = false,
                 Description = "Waits for each migration to finish before moving on to the next one."
             };
+            var adoPat = new Option<string>("--ado-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -69,12 +73,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(skipIdpOption);
             AddOption(sshOption);
             AddOption(sequential);
+            AddOption(adoPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, FileInfo, bool, bool, bool, bool, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, FileInfo, bool, bool, bool, bool, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubOrg, string adoOrg, FileInfo output, bool reposOnly, bool skipIdp, bool ssh = false, bool sequential = false, bool verbose = false)
+        public async Task Invoke(string githubOrg, string adoOrg, FileInfo output, bool reposOnly, bool skipIdp, bool ssh = false, bool sequential = false, string adoPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -90,10 +95,14 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 _log.LogInformation("SEQUENTIAL: true");
             }
+            if (adoPat is not null)
+            {
+                _log.LogInformation("ADO PAT: ***");
+            }
 
             _reposOnly = reposOnly;
 
-            var ado = _adoApiFactory.Create();
+            var ado = _adoApiFactory.Create(adoPat);
 
             var orgs = await GetOrgs(ado, adoOrg);
             var repos = await GetRepos(ado, orgs);

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -23,7 +23,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             Description = "Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it.";
             Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT env variable to be set.";
+            Description += "Note: Expects ADO_PAT env variable or --ado-pat option to be set.";
 
             var githubOrgOption = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/GrantMigratorRoleCommand.cs
+++ b/src/ado2gh/Commands/GrantMigratorRoleCommand.cs
@@ -31,6 +31,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = true
             };
+            var githubPat = new Option<string>("--github-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -39,12 +43,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(githubOrg);
             AddOption(actor);
             AddOption(actorType);
+            AddOption(githubPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubOrg, string actor, string actorType, bool verbose = false)
+        public async Task Invoke(string githubOrg, string actor, string actorType, string githubPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -65,7 +70,12 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                 return;
             }
 
-            var githubApi = _githubApiFactory.Create();
+            if (githubPat is not null)
+            {
+                _log.LogInformation("GITHUB PAT: ***");
+            }
+
+            var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
             var success = await githubApi.GrantMigratorRole(githubOrgId, actor, actorType);
 

--- a/src/ado2gh/Commands/GrantMigratorRoleCommand.cs
+++ b/src/ado2gh/Commands/GrantMigratorRoleCommand.cs
@@ -17,7 +17,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             Description = "Allows an organization admin to grant a USER or TEAM the migrator role for a single GitHub organization. The migrator role allows the role assignee to perform migrations into the target organization.";
             Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variable to be set.";
+            Description += "Note: Expects GH_PAT env variable or --github-pat option to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/IntegrateBoardsCommand.cs
+++ b/src/ado2gh/Commands/IntegrateBoardsCommand.cs
@@ -42,6 +42,14 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = true
             };
+            var adoPat = new Option<string>("--ado-pat")
+            {
+                IsRequired = false
+            };
+            var githubPat = new Option<string>("--github-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -51,12 +59,14 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(adoTeamProject);
             AddOption(githubOrg);
             AddOption(githubRepo);
+            AddOption(adoPat);
+            AddOption(githubPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string adoOrg, string adoTeamProject, string githubOrg, string githubRepo, bool verbose = false)
+        public async Task Invoke(string adoOrg, string adoTeamProject, string githubOrg, string githubRepo, string adoPat = null, string githubPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -65,20 +75,28 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log.LogInformation($"ADO TEAM PROJECT: {adoTeamProject}");
             _log.LogInformation($"GITHUB ORG: {githubOrg}");
             _log.LogInformation($"GITHUB REPO: {githubRepo}");
+            if (adoPat is not null)
+            {
+                _log.LogInformation("ADO PAT: ***");
+            }
+            if (githubPat is not null)
+            {
+                _log.LogInformation("GITHUB PAT: ***");
+            }
 
-            var ado = _adoApiFactory.Create();
-            var githubToken = _environmentVariableProvider.GithubPersonalAccessToken();
+            var ado = _adoApiFactory.Create(adoPat);
+            githubPat ??= _environmentVariableProvider.GithubPersonalAccessToken();
 
             var userId = await ado.GetUserId();
             var adoOrgId = await ado.GetOrganizationId(userId, adoOrg);
             var adoTeamProjectId = await ado.GetTeamProjectId(adoOrg, adoTeamProject);
-            var githubHandle = await ado.GetGithubHandle(adoOrg, adoOrgId, adoTeamProject, githubToken);
+            var githubHandle = await ado.GetGithubHandle(adoOrg, adoOrgId, adoTeamProject, githubPat);
 
             var boardsConnection = await ado.GetBoardsGithubConnection(adoOrg, adoOrgId, adoTeamProject);
 
             if (boardsConnection == default)
             {
-                var endpointId = await ado.CreateBoardsGithubEndpoint(adoOrg, adoTeamProjectId, githubToken, githubHandle, Guid.NewGuid().ToString());
+                var endpointId = await ado.CreateBoardsGithubEndpoint(adoOrg, adoTeamProjectId, githubPat, githubHandle, Guid.NewGuid().ToString());
                 var repoId = await ado.GetBoardsGithubRepoId(adoOrg, adoOrgId, adoTeamProject, adoTeamProjectId, endpointId, githubOrg, githubRepo);
                 await ado.CreateBoardsGithubConnection(adoOrg, adoOrgId, adoTeamProject, endpointId, repoId);
                 _log.LogSuccess("Successfully configured Boards<->GitHub integration");

--- a/src/ado2gh/Commands/IntegrateBoardsCommand.cs
+++ b/src/ado2gh/Commands/IntegrateBoardsCommand.cs
@@ -24,7 +24,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             Description = "Configures the Azure Boards<->GitHub integration in Azure DevOps.";
             Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT and GH_PAT env variables to be set.";
+            Description += "Note: Expects ADO_PAT and GH_PAT env variables or --ado-pat and --github-pat options to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/LockRepoCommand.cs
+++ b/src/ado2gh/Commands/LockRepoCommand.cs
@@ -31,6 +31,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = true
             };
+            var adoPat = new Option<string>("--ado-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -39,12 +43,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(adoOrg);
             AddOption(adoTeamProject);
             AddOption(adoRepo);
+            AddOption(adoPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string adoOrg, string adoTeamProject, string adoRepo, bool verbose = false)
+        public async Task Invoke(string adoOrg, string adoTeamProject, string adoRepo, string adoPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -52,8 +57,12 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log.LogInformation($"ADO ORG: {adoOrg}");
             _log.LogInformation($"ADO TEAM PROJECT: {adoTeamProject}");
             _log.LogInformation($"ADO REPO: {adoRepo}");
+            if (adoPat is not null)
+            {
+                _log.LogInformation("ADO PAT: ***");
+            }
 
-            var ado = _adoApiFactory.Create();
+            var ado = _adoApiFactory.Create(adoPat);
 
             var teamProjectId = await ado.GetTeamProjectId(adoOrg, adoTeamProject);
             var repoId = await ado.GetRepoId(adoOrg, adoTeamProject, adoRepo);

--- a/src/ado2gh/Commands/LockRepoCommand.cs
+++ b/src/ado2gh/Commands/LockRepoCommand.cs
@@ -17,7 +17,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             Description = "Makes the ADO repo read-only for all users. It does this by adding Deny permissions for the Project Valid Users group on the repo.";
             Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT env variable to be set.";
+            Description += "Note: Expects ADO_PAT env variable or --ado-pat option to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/MigrateRepoCommand.cs
+++ b/src/ado2gh/Commands/MigrateRepoCommand.cs
@@ -22,7 +22,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             Description = "Invokes the GitHub API's to migrate the repo and all PR data";
             Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT and GH_PAT env variables to be set.";
+            Description += "Note: Expects ADO_PAT and GH_PAT env variables or --ado-pat and --github-pat options to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/MigrateRepoCommand.cs
+++ b/src/ado2gh/Commands/MigrateRepoCommand.cs
@@ -55,6 +55,14 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                 IsRequired = false,
                 Description = "Synchronously waits for the repo migration to finish."
             };
+            var adoPat = new Option<string>("--ado-pat")
+            {
+                IsRequired = false
+            };
+            var githubPat = new Option<string>("--github-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -67,12 +75,14 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(githubRepo);
             AddOption(ssh);
             AddOption(wait);
+            AddOption(adoPat);
+            AddOption(githubPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, string, bool, bool, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, string, bool, bool, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string adoOrg, string adoTeamProject, string adoRepo, string githubOrg, string githubRepo, bool ssh = false, bool wait = false, bool verbose = false)
+        public async Task Invoke(string adoOrg, string adoTeamProject, string adoRepo, string githubOrg, string githubRepo, bool ssh = false, bool wait = false, string adoPat = null, string githubPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -90,15 +100,23 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 _log.LogInformation("WAIT: true");
             }
+            if (adoPat is not null)
+            {
+                _log.LogInformation("ADO PAT: ***");
+            }
+            if (githubPat is not null)
+            {
+                _log.LogInformation("GITHUB PAT: ***");
+            }
 
             var adoRepoUrl = GetAdoRepoUrl(adoOrg, adoTeamProject, adoRepo);
 
-            var adoToken = _environmentVariableProvider.AdoPersonalAccessToken();
-            var githubPat = _environmentVariableProvider.GithubPersonalAccessToken();
-            var githubApi = _githubApiFactory.Create();
+            adoPat ??= _environmentVariableProvider.AdoPersonalAccessToken();
+            githubPat ??= _environmentVariableProvider.GithubPersonalAccessToken();
+            var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
-            var migrationSourceId = await githubApi.CreateAdoMigrationSource(githubOrgId, adoToken, githubPat);
-            var migrationId = await githubApi.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, adoToken, githubPat);
+            var migrationSourceId = await githubApi.CreateAdoMigrationSource(githubOrgId, adoPat, githubPat);
+            var migrationId = await githubApi.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, adoPat, githubPat);
 
             if (!wait)
             {

--- a/src/ado2gh/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/ado2gh/Commands/RevokeMigratorRoleCommand.cs
@@ -30,6 +30,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = true
             };
+            var githubPat = new Option<string>("--github-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -38,18 +42,23 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(githubOrg);
             AddOption(actor);
             AddOption(actorType);
+            AddOption(githubPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubOrg, string actor, string actorType, bool verbose = false)
+        public async Task Invoke(string githubOrg, string actor, string actorType, string githubPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
             _log.LogInformation("Granting migrator role ...");
             _log.LogInformation($"GITHUB ORG: {githubOrg}");
             _log.LogInformation($"ACTOR: {actor}");
+            if (githubPat is not null)
+            {
+                _log.LogInformation("GITHUB PAT: ***");
+            }
 
             actorType = actorType?.ToUpper();
             _log.LogInformation($"ACTOR TYPE: {actorType}");
@@ -66,7 +75,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                 return;
             }
 
-            var githubApi = _githubApiFactory.Create();
+            var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
             var success = await githubApi.RevokeMigratorRole(githubOrgId, actor, actorType);
 

--- a/src/ado2gh/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/ado2gh/Commands/RevokeMigratorRoleCommand.cs
@@ -16,7 +16,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _githubApiFactory = githubApiFactory;
             Description = "Allows an organization admin to revoke the migrator role for a USER or TEAM for a single GitHub organization. This will remove their ability to run a migration into the target organization.";
             Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variable to be set.";
+            Description += "Note: Expects GH_PAT env variable or --github-pat option to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/RewirePipelineCommand.cs
+++ b/src/ado2gh/Commands/RewirePipelineCommand.cs
@@ -17,7 +17,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             Description = "Updates an Azure Pipeline to point to a GitHub repo instead of an Azure Repo.";
             Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT env variable to be set.";
+            Description += "Note: Expects ADO_PAT env variable or --ado-pat option to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/RewirePipelineCommand.cs
+++ b/src/ado2gh/Commands/RewirePipelineCommand.cs
@@ -43,6 +43,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = true
             };
+            var adoPat = new Option<string>("--ado-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -54,12 +58,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(githubOrg);
             AddOption(githubRepo);
             AddOption(serviceConnectionId);
+            AddOption(adoPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string adoOrg, string adoTeamProject, string adoPipeline, string githubOrg, string githubRepo, string serviceConnectionId, bool verbose = false)
+        public async Task Invoke(string adoOrg, string adoTeamProject, string adoPipeline, string githubOrg, string githubRepo, string serviceConnectionId, string adoPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -70,8 +75,12 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log.LogInformation($"GITHUB ORG: {githubOrg}");
             _log.LogInformation($"GITHUB REPO: {githubRepo}");
             _log.LogInformation($"SERVICE CONNECTION ID: {serviceConnectionId}");
+            if (adoPat is not null)
+            {
+                _log.LogInformation("ADO PAT: ***");
+            }
 
-            var ado = _adoApiFactory.Create();
+            var ado = _adoApiFactory.Create(adoPat);
 
             var adoPipelineId = await ado.GetPipelineId(adoOrg, adoTeamProject, adoPipeline);
             var (defaultBranch, clean, checkoutSubmodules) = await ado.GetPipeline(adoOrg, adoTeamProject, adoPipelineId);

--- a/src/ado2gh/Commands/ShareServiceConnectionCommand.cs
+++ b/src/ado2gh/Commands/ShareServiceConnectionCommand.cs
@@ -17,7 +17,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             Description = "Makes an existing GitHub Pipelines App service connection available in another team project. This is required before you can rewire pipelines.";
             Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT env variable to be set.";
+            Description += "Note: Expects ADO_PAT env variable or --ado-pat option to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/ShareServiceConnectionCommand.cs
+++ b/src/ado2gh/Commands/ShareServiceConnectionCommand.cs
@@ -31,6 +31,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = true
             };
+            var adoPat = new Option<string>("--ado-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -39,12 +43,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(adoOrg);
             AddOption(adoTeamProject);
             AddOption(serviceConnectionId);
+            AddOption(adoPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string adoOrg, string adoTeamProject, string serviceConnectionId, bool verbose = false)
+        public async Task Invoke(string adoOrg, string adoTeamProject, string serviceConnectionId, string adoPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -52,8 +57,12 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log.LogInformation($"ADO ORG: {adoOrg}");
             _log.LogInformation($"ADO TEAM PROJECT: {adoTeamProject}");
             _log.LogInformation($"SERVICE CONNECTION ID: {serviceConnectionId}");
+            if (adoPat is not null)
+            {
+                _log.LogInformation("ADO PAT: ***");
+            }
 
-            var ado = _adoApiFactory.Create();
+            var ado = _adoApiFactory.Create(adoPat);
 
             var adoTeamProjectId = await ado.GetTeamProjectId(adoOrg, adoTeamProject);
             // TODO: If the service connection is already shared with this team project this will crash

--- a/src/ado2gh/Commands/WaitForMigrationCommand.cs
+++ b/src/ado2gh/Commands/WaitForMigrationCommand.cs
@@ -28,21 +28,30 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                 IsRequired = true,
                 Description = "Waits for the specified migration to finish."
             };
+            var githubPat = new Option<string>("--github-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose") { IsRequired = false };
 
             AddOption(migrationId);
+            AddOption(githubPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string migrationId, bool verbose = false)
+        public async Task Invoke(string migrationId, string githubPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
             _log.LogInformation($"Waiting for migration {migrationId} to finish...");
+            if (githubPat is not null)
+            {
+                _log.LogInformation("GITHUB PAT: ***");
+            }
 
-            var githubApi = _githubApiFactory.Create();
+            var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
 
             while (true)
             {

--- a/src/ado2gh/Commands/WaitForMigrationCommand.cs
+++ b/src/ado2gh/Commands/WaitForMigrationCommand.cs
@@ -21,7 +21,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             Description = "Waits for migration(s) to finish and reports all in progress and queued ones.";
             Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variables to be set.";
+            Description += "Note: Expects GH_PAT env variable or --github-pat option to be set.";
 
             var migrationId = new Option<string>("--migration-id")
             {

--- a/src/ado2gh/GithubApiFactory.cs
+++ b/src/ado2gh/GithubApiFactory.cs
@@ -5,7 +5,7 @@ namespace OctoshiftCLI.AdoToGithub
     public class GithubApiFactory
     {
         private const string DEFAULT_API_URL = "https://api.github.com";
-        
+
         private readonly OctoLogger _octoLogger;
         private readonly HttpClient _client;
         private readonly EnvironmentVariableProvider _environmentVariableProvider;

--- a/src/ado2gh/GithubApiFactory.cs
+++ b/src/ado2gh/GithubApiFactory.cs
@@ -4,6 +4,8 @@ namespace OctoshiftCLI.AdoToGithub
 {
     public class GithubApiFactory
     {
+        private const string DEFAULT_API_URL = "https://api.github.com";
+        
         private readonly OctoLogger _octoLogger;
         private readonly HttpClient _client;
         private readonly EnvironmentVariableProvider _environmentVariableProvider;
@@ -15,15 +17,10 @@ namespace OctoshiftCLI.AdoToGithub
             _environmentVariableProvider = environmentVariableProvider;
         }
 
-        public virtual GithubApi Create()
+        public virtual GithubApi Create(string apiUrl = DEFAULT_API_URL, string personalAccessToken = null)
         {
-            return Create("https://api.github.com");
-        }
-
-        public virtual GithubApi Create(string apiUrl)
-        {
-            var githubPat = _environmentVariableProvider.GithubPersonalAccessToken();
-            var githubClient = new GithubClient(_octoLogger, _client, githubPat);
+            personalAccessToken ??= _environmentVariableProvider.GithubPersonalAccessToken();
+            var githubClient = new GithubClient(_octoLogger, _client, personalAccessToken);
             return new GithubApi(githubClient, apiUrl);
         }
     }

--- a/src/ado2gh/GithubApiFactory.cs
+++ b/src/ado2gh/GithubApiFactory.cs
@@ -17,8 +17,9 @@ namespace OctoshiftCLI.AdoToGithub
             _environmentVariableProvider = environmentVariableProvider;
         }
 
-        public virtual GithubApi Create(string apiUrl = DEFAULT_API_URL, string personalAccessToken = null)
+        public virtual GithubApi Create(string apiUrl = null, string personalAccessToken = null)
         {
+            apiUrl ??= DEFAULT_API_URL;
             personalAccessToken ??= _environmentVariableProvider.GithubPersonalAccessToken();
             var githubClient = new GithubClient(_octoLogger, _client, personalAccessToken);
             return new GithubApi(githubClient, apiUrl);

--- a/src/gei/AdoApiFactory.cs
+++ b/src/gei/AdoApiFactory.cs
@@ -15,10 +15,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
             _environmentVariableProvider = environmentVariableProvider;
         }
 
-        public virtual AdoApi Create()
+        public virtual AdoApi Create(string personalAccessToken = null)
         {
-            var adoPat = _environmentVariableProvider.AdoPersonalAccessToken();
-            var adoClient = new AdoClient(_octoLogger, _client, adoPat);
+            personalAccessToken ??= _environmentVariableProvider.AdoPersonalAccessToken();
+            var adoClient = new AdoClient(_octoLogger, _client, personalAccessToken);
             return new AdoApi(adoClient);
         }
     }

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -29,12 +29,12 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var githubSourceOrgOption = new Option<string>("--github-source-org")
             {
                 IsRequired = false,
-                Description = "Uses GH_SOURCE_PAT env variable. Will fall back to GH_PAT if not set."
+                Description = "Uses GH_SOURCE_PAT env variable or --github-source-pat option. Will fall back to GH_PAT if not set."
             };
             var adoSourceOrgOption = new Option<string>("--ado-source-org")
             {
                 IsRequired = false,
-                Description = "Uses ADO_PAT env variable."
+                Description = "Uses ADO_PAT env variable or --ado-pat option."
             };
             var adoTeamProject = new Option<string>("--ado-team-project")
             {
@@ -42,8 +42,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             };
             var githubTargetOrgOption = new Option<string>("--github-target-org")
             {
-                IsRequired = true,
-                Description = "Uses GH_PAT env variable."
+                IsRequired = true
             };
 
             // GHES migration path

--- a/src/gei/Commands/GrantMigratorRoleCommand.cs
+++ b/src/gei/Commands/GrantMigratorRoleCommand.cs
@@ -31,6 +31,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 IsRequired = true
             };
+            var githubPat = new Option<string>("--github-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -39,18 +43,23 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(githubOrg);
             AddOption(actor);
             AddOption(actorType);
+            AddOption(githubPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubOrg, string actor, string actorType, bool verbose = false)
+        public async Task Invoke(string githubOrg, string actor, string actorType, string githubPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
             _log.LogInformation("Granting migrator role ...");
             _log.LogInformation($"GITHUB ORG: {githubOrg}");
             _log.LogInformation($"ACTOR: {actor}");
+            if (githubPat is not null)
+            {
+                _log.LogInformation("GITHUB PAT: ***");
+            }
 
             actorType = actorType?.ToUpper();
             _log.LogInformation($"ACTOR TYPE: {actorType}");
@@ -65,7 +74,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 return;
             }
 
-            var githubApi = _githubApiFactory.Create();
+            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubPat);
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
             var success = await githubApi.GrantMigratorRole(githubOrgId, actor, actorType);
 

--- a/src/gei/Commands/GrantMigratorRoleCommand.cs
+++ b/src/gei/Commands/GrantMigratorRoleCommand.cs
@@ -31,7 +31,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 IsRequired = true
             };
-            var githubPat = new Option<string>("--github-pat")
+            var githubTargetPat = new Option<string>("--github-target-pat")
             {
                 IsRequired = false
             };
@@ -43,22 +43,22 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(githubOrg);
             AddOption(actor);
             AddOption(actorType);
-            AddOption(githubPat);
+            AddOption(githubTargetPat);
             AddOption(verbose);
 
             Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubOrg, string actor, string actorType, string githubPat = null, bool verbose = false)
+        public async Task Invoke(string githubOrg, string actor, string actorType, string githubTargetPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
             _log.LogInformation("Granting migrator role ...");
             _log.LogInformation($"GITHUB ORG: {githubOrg}");
             _log.LogInformation($"ACTOR: {actor}");
-            if (githubPat is not null)
+            if (githubTargetPat is not null)
             {
-                _log.LogInformation("GITHUB PAT: ***");
+                _log.LogInformation("GITHUB TARGET PAT: ***");
             }
 
             actorType = actorType?.ToUpper();
@@ -74,7 +74,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 return;
             }
 
-            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubPat);
+            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubTargetPat);
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
             var success = await githubApi.GrantMigratorRole(githubOrgId, actor, actorType);
 

--- a/src/gei/Commands/GrantMigratorRoleCommand.cs
+++ b/src/gei/Commands/GrantMigratorRoleCommand.cs
@@ -17,7 +17,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             Description = "Allows an organization admin to grant a USER or TEAM the migrator role for a single GitHub organization. The migrator role allows the role assignee to perform migrations into the target organization.";
             Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variable to be set.";
+            Description += "Note: Expects GH_PAT env variable or --github-target-pat option to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -136,7 +136,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 throw new ArgumentNullException(nameof(args));
             }
-            
+
             _log.Verbose = args.Verbose;
 
             _log.LogInformation("Migrating Repo...");
@@ -347,7 +347,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         private string GetAdoRepoUrl(string org, string project, string repo) => $"https://dev.azure.com/{org}/{project}/_git/{repo}".Replace(" ", "%20");
     }
 
-    public class MigrateRepoCommandArgs 
+    public class MigrateRepoCommandArgs
     {
         public string GithubSourceOrg { get; set; }
         public string AdoSourceOrg { get; set; }

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -31,12 +31,12 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var githubSourceOrg = new Option<string>("--github-source-org")
             {
                 IsRequired = false,
-                Description = "Uses GH_SOURCE_PAT env variable. Will fall back to GH_PAT if not set."
+                Description = "Uses GH_SOURCE_PAT env variable or --github-source-pat option. Will fall back to GH_PAT or --github-target-pat if not set."
             };
             var adoSourceOrg = new Option<string>("--ado-source-org")
             {
                 IsRequired = false,
-                Description = "Uses ADO_PAT env variable."
+                Description = "Uses ADO_PAT env variable or --ado-pat option."
             };
             var adoTeamProject = new Option<string>("--ado-team-project")
             {
@@ -49,7 +49,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var githubTargetOrg = new Option<string>("--github-target-org")
             {
                 IsRequired = true,
-                Description = "Uses GH_PAT env variable."
+                Description = "Uses GH_PAT env variable or --github-target-pat option."
             };
             var targetRepo = new Option<string>("--target-repo")
             {

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -108,7 +108,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 IsRequired = false
             };
-            var githubPat = new Option<string>("--github-pat")
+            var githubTargetPat = new Option<string>("--github-target-pat")
             {
                 IsRequired = false
             };
@@ -139,7 +139,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(ssh);
             AddOption(wait);
             AddOption(githubSourcePat);
-            AddOption(githubPat);
+            AddOption(githubTargetPat);
             AddOption(adoPat);
             AddOption(verbose);
 
@@ -189,14 +189,14 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 _log.LogInformation("GITHUB SOURCE PAT: ***");
             }
 
-            if (args.GithubPat is not null)
+            if (args.GithubTargetPat is not null)
             {
-                _log.LogInformation("GITHUB PAT: ***");
+                _log.LogInformation("GITHUB TARGET PAT: ***");
 
                 if (args.GithubSourcePat is null)
                 {
-                    args.GithubSourcePat = args.GithubPat;
-                    _log.LogInformation("Since github-pat is provided, github-source-pat will also use its value.");
+                    args.GithubSourcePat = args.GithubTargetPat;
+                    _log.LogInformation("Since github-target-pat is provided, github-source-pat will also use its value.");
                 }
             }
 
@@ -247,14 +247,14 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 _log.LogInformation("Archives uploaded to Azure Blob Storage, now starting migration...");
             }
 
-            var githubApi = _targetGithubApiFactory.Create(args.TargetApiUrl, args.GithubPat);
+            var githubApi = _targetGithubApiFactory.Create(args.TargetApiUrl, args.GithubTargetPat);
             var githubOrgId = await githubApi.GetOrganizationId(args.GithubTargetOrg);
-            var targetGithubPat = args.GithubPat ?? _environmentVariableProvider.TargetGithubPersonalAccessToken();
             var sourceRepoUrl = GetSourceRepoUrl(args);
             var sourceToken = GetSourceToken(args);
+            var targetToken = args.GithubTargetPat ?? _environmentVariableProvider.TargetGithubPersonalAccessToken();
             var migrationSourceId = args.GithubSourceOrg.HasValue()
-                ? await githubApi.CreateGhecMigrationSource(githubOrgId, sourceToken, targetGithubPat)
-                : await githubApi.CreateAdoMigrationSource(githubOrgId, sourceToken, targetGithubPat);
+                ? await githubApi.CreateGhecMigrationSource(githubOrgId, sourceToken, targetToken)
+                : await githubApi.CreateAdoMigrationSource(githubOrgId, sourceToken, targetToken);
 
             var migrationId = await githubApi.StartMigration(
                 migrationSourceId,
@@ -262,7 +262,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 githubOrgId,
                 args.TargetRepo,
                 sourceToken,
-                targetGithubPat,
+                targetToken,
                 args.GitArchiveUrl,
                 args.MetadataArchiveUrl);
 
@@ -402,7 +402,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         public bool Wait { get; set; }
         public bool Verbose { get; set; }
         public string GithubSourcePat { get; set; }
-        public string GithubPat { get; set; }
+        public string GithubTargetPat { get; set; }
         public string AdoPat { get; set; }
     }
 }

--- a/src/gei/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/gei/Commands/RevokeMigratorRoleCommand.cs
@@ -30,6 +30,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 IsRequired = true
             };
+            var githubPat = new Option<string>("--github-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -38,18 +42,23 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(githubOrg);
             AddOption(actor);
             AddOption(actorType);
+            AddOption(githubPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubOrg, string actor, string actorType, bool verbose = false)
+        public async Task Invoke(string githubOrg, string actor, string actorType, string githubPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
             _log.LogInformation("Granting migrator role ...");
             _log.LogInformation($"GITHUB ORG: {githubOrg}");
             _log.LogInformation($"ACTOR: {actor}");
+            if (githubPat is not null)
+            {
+                _log.LogInformation("GITHUB PAT: ***");
+            }
 
             actorType = actorType?.ToUpper();
             _log.LogInformation($"ACTOR TYPE: {actorType}");
@@ -66,8 +75,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 return;
             }
 
-            var targetApiUrl = "https://api.github.com";
-            var githubApi = _githubApiFactory.Create(targetApiUrl);
+            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubPat);
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
             var success = await githubApi.RevokeMigratorRole(githubOrgId, actor, actorType);
 

--- a/src/gei/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/gei/Commands/RevokeMigratorRoleCommand.cs
@@ -30,7 +30,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 IsRequired = true
             };
-            var githubPat = new Option<string>("--github-pat")
+            var githubTargetPat = new Option<string>("--github-target-pat")
             {
                 IsRequired = false
             };
@@ -42,22 +42,22 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(githubOrg);
             AddOption(actor);
             AddOption(actorType);
-            AddOption(githubPat);
+            AddOption(githubTargetPat);
             AddOption(verbose);
 
             Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubOrg, string actor, string actorType, string githubPat = null, bool verbose = false)
+        public async Task Invoke(string githubOrg, string actor, string actorType, string githubTargetPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
             _log.LogInformation("Granting migrator role ...");
             _log.LogInformation($"GITHUB ORG: {githubOrg}");
             _log.LogInformation($"ACTOR: {actor}");
-            if (githubPat is not null)
+            if (githubTargetPat is not null)
             {
-                _log.LogInformation("GITHUB PAT: ***");
+                _log.LogInformation("GITHUB TARGET PAT: ***");
             }
 
             actorType = actorType?.ToUpper();
@@ -75,7 +75,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 return;
             }
 
-            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubPat);
+            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubTargetPat);
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
             var success = await githubApi.RevokeMigratorRole(githubOrgId, actor, actorType);
 

--- a/src/gei/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/gei/Commands/RevokeMigratorRoleCommand.cs
@@ -16,7 +16,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             _githubApiFactory = githubApiFactory;
             Description = "Allows an organization admin to revoke the migrator role for a USER or TEAM for a single GitHub organization. This will remove their ability to run a migration into the target organization.";
             Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variable to be set.";
+            Description += "Note: Expects GH_PAT env variable or --github-target-pat option to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/gei/Commands/WaitForMigrationCommand.cs
+++ b/src/gei/Commands/WaitForMigrationCommand.cs
@@ -28,21 +28,26 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 IsRequired = true,
                 Description = "Waits for the specified migration to finish."
             };
+            var githubPat = new Option<string>("--github-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose") { IsRequired = false };
 
             AddOption(migrationId);
+            AddOption(githubPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string migrationId, bool verbose = false)
+        public async Task Invoke(string migrationId, string githubPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
             _log.LogInformation($"Waiting for migration {migrationId} to finish...");
 
-            var githubApi = _targetGithubApiFactory.Create();
+            var githubApi = _targetGithubApiFactory.Create(targetPersonalAccessToken: githubPat);
 
             while (true)
             {

--- a/src/gei/Commands/WaitForMigrationCommand.cs
+++ b/src/gei/Commands/WaitForMigrationCommand.cs
@@ -28,26 +28,31 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 IsRequired = true,
                 Description = "Waits for the specified migration to finish."
             };
-            var githubPat = new Option<string>("--github-pat")
+            var githubTargetPat = new Option<string>("--github-target-pat")
             {
                 IsRequired = false
             };
             var verbose = new Option("--verbose") { IsRequired = false };
 
             AddOption(migrationId);
-            AddOption(githubPat);
+            AddOption(githubTargetPat);
             AddOption(verbose);
 
             Handler = CommandHandler.Create<string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string migrationId, string githubPat = null, bool verbose = false)
+        public async Task Invoke(string migrationId, string githubTargetPat = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
             _log.LogInformation($"Waiting for migration {migrationId} to finish...");
 
-            var githubApi = _targetGithubApiFactory.Create(targetPersonalAccessToken: githubPat);
+            if (githubTargetPat is not null)
+            {
+                _log.LogInformation("GITHUB TARGET PAT: ***");
+            }
+
+            var githubApi = _targetGithubApiFactory.Create(targetPersonalAccessToken: githubTargetPat);
 
             while (true)
             {

--- a/src/gei/Commands/WaitForMigrationCommand.cs
+++ b/src/gei/Commands/WaitForMigrationCommand.cs
@@ -21,7 +21,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             Description = "Waits for migration(s) to finish and reports all in progress and queued ones.";
             Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variables to be set.";
+            Description += "Note: Expects GH_PAT env variable or --github-target-pat option to be set.";
 
             var migrationId = new Option<string>("--migration-id")
             {

--- a/src/gei/Defaults.cs
+++ b/src/gei/Defaults.cs
@@ -1,0 +1,7 @@
+namespace OctoshiftCLI.GithubEnterpriseImporter
+{
+    public static class Defaults
+    {
+        public const string GithubApiUrl = "https://api.github.com";
+    }
+}

--- a/src/gei/Defaults.cs
+++ b/src/gei/Defaults.cs
@@ -1,7 +1,0 @@
-namespace OctoshiftCLI.GithubEnterpriseImporter
-{
-    public static class Defaults
-    {
-        public const string GithubApiUrl = "https://api.github.com";
-    }
-}

--- a/src/gei/GithubApiFactory.cs
+++ b/src/gei/GithubApiFactory.cs
@@ -5,7 +5,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
     public sealed class GithubApiFactory : ISourceGithubApiFactory, ITargetGithubApiFactory
     {
         private const string DEFAULT_API_URL = "https://api.github.com";
-        
+
         private readonly OctoLogger _octoLogger;
         private readonly IHttpClientFactory _clientFactory;
         private readonly EnvironmentVariableProvider _environmentVariableProvider;

--- a/src/gei/GithubApiFactory.cs
+++ b/src/gei/GithubApiFactory.cs
@@ -15,28 +15,24 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
             _environmentVariableProvider = environmentVariableProvider;
         }
 
-        GithubApi ISourceGithubApiFactory.Create() => (this as ISourceGithubApiFactory).Create("https://api.github.com");
-
-        GithubApi ISourceGithubApiFactory.Create(string apiUrl)
+        GithubApi ISourceGithubApiFactory.Create(string apiUrl, string sourcePersonalAccessToken)
         {
-            var githubPat = _environmentVariableProvider.SourceGithubPersonalAccessToken();
-            var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), githubPat);
+            sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
+            var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), sourcePersonalAccessToken);
             return new GithubApi(githubClient, apiUrl);
         }
 
-        GithubApi ISourceGithubApiFactory.CreateClientNoSsl(string apiUrl)
+        GithubApi ISourceGithubApiFactory.CreateClientNoSsl(string apiUrl, string sourcePersonalAccessToken)
         {
-            var githubPat = _environmentVariableProvider.SourceGithubPersonalAccessToken();
-            var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("NoSSL"), githubPat);
+            sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
+            var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("NoSSL"), sourcePersonalAccessToken);
             return new GithubApi(githubClient, apiUrl);
         }
 
-        GithubApi ITargetGithubApiFactory.Create() => (this as ITargetGithubApiFactory).Create("https://api.github.com");
-
-        GithubApi ITargetGithubApiFactory.Create(string apiUrl)
+        GithubApi ITargetGithubApiFactory.Create(string apiUrl, string targetPersonalAccessToken)
         {
-            var githubPat = _environmentVariableProvider.TargetGithubPersonalAccessToken();
-            var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), githubPat);
+            targetPersonalAccessToken ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
+            var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), targetPersonalAccessToken);
             return new GithubApi(githubClient, apiUrl);
         }
     }

--- a/src/gei/GithubApiFactory.cs
+++ b/src/gei/GithubApiFactory.cs
@@ -17,6 +17,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
         GithubApi ISourceGithubApiFactory.Create(string apiUrl, string sourcePersonalAccessToken)
         {
+            apiUrl ??= Defaults.GithubApiUrl;
             sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
             var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), sourcePersonalAccessToken);
             return new GithubApi(githubClient, apiUrl);
@@ -24,6 +25,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
         GithubApi ISourceGithubApiFactory.CreateClientNoSsl(string apiUrl, string sourcePersonalAccessToken)
         {
+            apiUrl ??= Defaults.GithubApiUrl;
             sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
             var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("NoSSL"), sourcePersonalAccessToken);
             return new GithubApi(githubClient, apiUrl);
@@ -31,6 +33,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
         GithubApi ITargetGithubApiFactory.Create(string apiUrl, string targetPersonalAccessToken)
         {
+            apiUrl ??= Defaults.GithubApiUrl;
             targetPersonalAccessToken ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
             var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), targetPersonalAccessToken);
             return new GithubApi(githubClient, apiUrl);

--- a/src/gei/GithubApiFactory.cs
+++ b/src/gei/GithubApiFactory.cs
@@ -4,6 +4,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 {
     public sealed class GithubApiFactory : ISourceGithubApiFactory, ITargetGithubApiFactory
     {
+        private const string DEFAULT_API_URL = "https://api.github.com";
+        
         private readonly OctoLogger _octoLogger;
         private readonly IHttpClientFactory _clientFactory;
         private readonly EnvironmentVariableProvider _environmentVariableProvider;
@@ -17,7 +19,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
         GithubApi ISourceGithubApiFactory.Create(string apiUrl, string sourcePersonalAccessToken)
         {
-            apiUrl ??= Defaults.GithubApiUrl;
+            apiUrl ??= DEFAULT_API_URL;
             sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
             var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), sourcePersonalAccessToken);
             return new GithubApi(githubClient, apiUrl);
@@ -25,7 +27,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
         GithubApi ISourceGithubApiFactory.CreateClientNoSsl(string apiUrl, string sourcePersonalAccessToken)
         {
-            apiUrl ??= Defaults.GithubApiUrl;
+            apiUrl ??= DEFAULT_API_URL;
             sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
             var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("NoSSL"), sourcePersonalAccessToken);
             return new GithubApi(githubClient, apiUrl);
@@ -33,7 +35,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
         GithubApi ITargetGithubApiFactory.Create(string apiUrl, string targetPersonalAccessToken)
         {
-            apiUrl ??= Defaults.GithubApiUrl;
+            apiUrl ??= DEFAULT_API_URL;
             targetPersonalAccessToken ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
             var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), targetPersonalAccessToken);
             return new GithubApi(githubClient, apiUrl);

--- a/src/gei/ISourceGithubApiFactory.cs
+++ b/src/gei/ISourceGithubApiFactory.cs
@@ -2,8 +2,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 {
     public interface ISourceGithubApiFactory
     {
-        private const string DEFAULT_API_URL = "https://api.github.com";
-        GithubApi Create(string apiUrl = DEFAULT_API_URL, string sourcePersonalAccessToken = null);
-        GithubApi CreateClientNoSsl(string apiUrl = DEFAULT_API_URL, string sourcePersonalAccessToken = null);
+        GithubApi Create(string apiUrl = Defaults.GithubApiUrl, string sourcePersonalAccessToken = null);
+        GithubApi CreateClientNoSsl(string apiUrl = Defaults.GithubApiUrl, string sourcePersonalAccessToken = null);
     }
 }

--- a/src/gei/ISourceGithubApiFactory.cs
+++ b/src/gei/ISourceGithubApiFactory.cs
@@ -2,7 +2,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 {
     public interface ISourceGithubApiFactory
     {
-        GithubApi Create(string apiUrl = Defaults.GithubApiUrl, string sourcePersonalAccessToken = null);
-        GithubApi CreateClientNoSsl(string apiUrl = Defaults.GithubApiUrl, string sourcePersonalAccessToken = null);
+        GithubApi Create(string apiUrl = null, string sourcePersonalAccessToken = null);
+        GithubApi CreateClientNoSsl(string apiUrl = null, string sourcePersonalAccessToken = null);
     }
 }

--- a/src/gei/ISourceGithubApiFactory.cs
+++ b/src/gei/ISourceGithubApiFactory.cs
@@ -2,8 +2,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 {
     public interface ISourceGithubApiFactory
     {
-        GithubApi Create();
-        GithubApi Create(string apiUrl);
-        GithubApi CreateClientNoSsl(string apiUrl);
+        private const string DEFAULT_API_URL = "https://api.github.com";
+        GithubApi Create(string apiUrl = DEFAULT_API_URL, string sourcePersonalAccessToken = null);
+        GithubApi CreateClientNoSsl(string apiUrl = DEFAULT_API_URL, string sourcePersonalAccessToken = null);
     }
 }

--- a/src/gei/ITargetGithubApiFactory.cs
+++ b/src/gei/ITargetGithubApiFactory.cs
@@ -2,6 +2,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 {
     public interface ITargetGithubApiFactory
     {
-        GithubApi Create(string apiUrl = Defaults.GithubApiUrl, string targetPersonalAccessToken = null);
+        GithubApi Create(string apiUrl = null, string targetPersonalAccessToken = null);
     }
 }

--- a/src/gei/ITargetGithubApiFactory.cs
+++ b/src/gei/ITargetGithubApiFactory.cs
@@ -2,7 +2,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 {
     public interface ITargetGithubApiFactory
     {
-        GithubApi Create();
-        GithubApi Create(string apiUrl);
+        private const string DEFAULT_API_URL = "https://api.github.com";
+        GithubApi Create(string apiUrl = DEFAULT_API_URL, string targetPersonalAccessToken = null);
     }
 }

--- a/src/gei/ITargetGithubApiFactory.cs
+++ b/src/gei/ITargetGithubApiFactory.cs
@@ -2,7 +2,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 {
     public interface ITargetGithubApiFactory
     {
-        private const string DEFAULT_API_URL = "https://api.github.com";
-        GithubApi Create(string apiUrl = DEFAULT_API_URL, string targetPersonalAccessToken = null);
+        GithubApi Create(string apiUrl = Defaults.GithubApiUrl, string targetPersonalAccessToken = null);
     }
 }


### PR DESCRIPTION
Closes #4 

### Description

1. Refactored API factories in both `ado2gh` and `gei` projects to support passing in the PATs as args. 
2. For simplicity and ease of use, I unified the `Create` methods in API factories into a single one with `null` default values. 
3. In the `gh gei` project, I had to refactor the `migrate-repo` command in order to:
a) make it possible to have more than 16 command args. For more that 16 args we cannot use the `Func` invoke anymore and we need to switch to a container class that has all the command line args.  See [this](https://github.com/dotnet/command-line-api/issues/458) issue as reference.
b) simplify the method a bit to reduce the [cyclomatic complexity](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1502). I did the bare minimum and while I could go even further, I thought it would be better to do them in a separate `tech-debt` issue if need be.

### Sample command output
```
./ado2gh add-team-to-repo --github-org "org" --github-repo "repo" --team "team" --role "maintain" --github-pat "gh-pat"
[11:17 AM] [INFO] Adding team to repo...
[11:17 AM] [INFO] GITHUB ORG: org
[11:17 AM] [INFO] GITHUB REPO: repo
[11:17 AM] [INFO] TEAM: team
[11:17 AM] [INFO] ROLE: maintain
[11:17 AM] [INFO] GITHUB PAT: ***
[11:17 AM] [INFO] Successfully added team to repo
```

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked