### PR TITLE
Rolling back the +x bit change in v0.10

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,3 @@
-- Updates most commands to be idempotent. They will check if there is anything to do, and if not they will print a message to that effect and complete successfully. E.g. create-team will check if the team already exists and if so exit as success (compared to previously where it would crash). The following commands have been updated:
-  - configure-autolink
-  - create-team
+- Updating commands to be idempotent. They will check if there is anything to do, and if not they will print a message to that effect and complete successfully. E.g. create-team will check if the team already exists and if so exit as success (compared to previously where it would crash). The following commands have been updated:
   - disable-ado-repo
+- The change to automatically set the +x bit on the generated migration script has been rolled back (introduced in v0.10). We discovered a bug with this that caused `generate-script` to crash on MacOS. We're temporarily rolling this back to unblock customers while we investigate and fix the problem.

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -4,10 +4,8 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
-using Mono.Unix;
 using OctoshiftCLI.Extensions;
 
 namespace OctoshiftCLI.AdoToGithub.Commands
@@ -109,12 +107,6 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             if (output != null)
             {
                 await File.WriteAllTextAsync(output.FullName, script);
-                // +x so script can be executed on macos and linux
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    var unixFileInfo = new UnixFileInfo(output.FullName);
-                    unixFileInfo.FileAccessPermissions |= FileAccessPermissions.UserExecute | FileAccessPermissions.GroupExecute | FileAccessPermissions.OtherExecute;
-                }
             }
         }
 

--- a/src/ado2gh/ado2gh.csproj
+++ b/src/ado2gh/ado2gh.csproj
@@ -10,8 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />    
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />    
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.21216.1" />
   </ItemGroup>

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -4,10 +4,8 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
-using Mono.Unix;
 using OctoshiftCLI.Extensions;
 
 namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
@@ -165,13 +163,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             if (output != null)
             {
                 await File.WriteAllTextAsync(output.FullName, script);
-
-                // +x so script can be executed on macos and linux
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    var unixFileInfo = new UnixFileInfo(output.FullName);
-                    unixFileInfo.FileAccessPermissions |= FileAccessPermissions.UserExecute | FileAccessPermissions.GroupExecute | FileAccessPermissions.OtherExecute;
-                }
             }
         }
 

--- a/src/gei/gei.csproj
+++ b/src/gei/gei.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.21216.1" />
   </ItemGroup>


### PR DESCRIPTION
`generate-script` is broken on MacOS apparantly. Rolling back to fix customers and buy us time to roll out a real fix.

Issue #279 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked