### PR TITLE
re-enable e2e tests on PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
       if: matrix.runner-os == 'ubuntu-latest'
 
   integration-test:
-    if: false
+    if: true
     strategy:
       matrix:
         runner-os: [windows-latest, ubuntu-latest, macos-latest]

--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -34,7 +34,7 @@ namespace OctoshiftCLI.IntegrationTests
 
             _helper = new TestHelper(_output, adoApi, githubApi, adoClient, githubClient);
         }
-        
+
         [Fact]
         public async Task Basic()
         {

--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -34,7 +34,7 @@ namespace OctoshiftCLI.IntegrationTests
 
             _helper = new TestHelper(_output, adoApi, githubApi, adoClient, githubClient);
         }
-
+        // foo
         [Fact]
         public async Task Basic()
         {

--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -35,6 +35,7 @@ namespace OctoshiftCLI.IntegrationTests
             _helper = new TestHelper(_output, adoApi, githubApi, adoClient, githubClient);
         }
 
+        [Fact]
         public async Task Basic()
         {
             var adoOrg = $"gei-e2e-testing-{_helper.GetOsName()}";

--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -35,8 +35,6 @@ namespace OctoshiftCLI.IntegrationTests
             _helper = new TestHelper(_output, adoApi, githubApi, adoClient, githubClient);
         }
 
-        // Tracking Issue: https://github.com/github/octoshift/issues/3606
-        [Fact(Skip = "random 404 errors")]
         public async Task Basic()
         {
             var adoOrg = $"gei-e2e-testing-{_helper.GetOsName()}";
@@ -60,61 +58,6 @@ namespace OctoshiftCLI.IntegrationTests
             await _helper.CreatePipeline(adoOrg, teamProject2, adoRepo2, pipeline2, commitId);
 
             await _helper.RunAdoToGithubCliMigration($"generate-script --github-org {githubOrg} --ado-org {adoOrg}");
-
-            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject1}-{teamProject1}", $"https://dev.azure.com/{adoOrg}/{teamProject1}/_workitems/edit/<num>/");
-            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject2}-{teamProject2}", $"https://dev.azure.com/{adoOrg}/{teamProject2}/_workitems/edit/<num>/");
-            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject1, adoRepo1);
-            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject2, adoRepo2);
-            await _helper.AssertAdoRepoLocked(adoOrg, teamProject1, adoRepo1);
-            await _helper.AssertAdoRepoLocked(adoOrg, teamProject2, adoRepo2);
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-maintainers");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-admins");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-maintainers");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-admins");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-maintainers", $"{teamProject1}-maintainers");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-admins", $"{teamProject1}-admins");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-maintainers", $"{teamProject2}-maintainers");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-admins", $"{teamProject2}-admins");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-maintainers", $"{teamProject1}-{teamProject1}", "maintain");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-admins", $"{teamProject1}-{teamProject1}", "admin");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-maintainers", $"{teamProject2}-{teamProject2}", "maintain");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-admins", $"{teamProject2}-{teamProject2}", "admin");
-            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject1);
-            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject2);
-            await _helper.AssertPipelineRewired(adoOrg, teamProject1, pipeline1, githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertPipelineRewired(adoOrg, teamProject2, pipeline2, githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject1);
-            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject2);
-        }
-
-        [Fact]
-        public async Task BasicWithSsh()
-        {
-            var adoOrg = $"gei-e2e-testing-{_helper.GetOsName()}";
-            var githubOrg = $"e2e-testing-{_helper.GetOsName()}";
-            var teamProject1 = "gei-e2e-1";
-            var teamProject2 = "gei-e2e-2";
-            var adoRepo1 = teamProject1;
-            var adoRepo2 = teamProject2;
-            var pipeline1 = "pipeline1";
-            var pipeline2 = "pipeline2";
-
-            await _helper.ResetAdoTestEnvironment(adoOrg);
-            await _helper.ResetGithubTestEnvironment(githubOrg);
-
-            await _helper.CreateTeamProject(adoOrg, teamProject1);
-            var commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject1, adoRepo1);
-            await _helper.CreatePipeline(adoOrg, teamProject1, adoRepo1, pipeline1, commitId);
-
-            await _helper.CreateTeamProject(adoOrg, teamProject2);
-            commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject2, adoRepo2);
-            await _helper.CreatePipeline(adoOrg, teamProject2, adoRepo2, pipeline2, commitId);
-
-            await _helper.RunAdoToGithubCliMigration($"generate-script --github-org {githubOrg} --ado-org {adoOrg} --ssh");
 
             await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject1}-{teamProject1}");
             await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject2}-{teamProject2}");

--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -34,7 +34,7 @@ namespace OctoshiftCLI.IntegrationTests
 
             _helper = new TestHelper(_output, adoApi, githubApi, adoClient, githubClient);
         }
-        // foo
+        
         [Fact]
         public async Task Basic()
         {

--- a/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
@@ -31,6 +31,7 @@ namespace OctoshiftCLI.IntegrationTests
             _helper = new TestHelper(_output, _githubApi, _githubClient);
         }
 
+        [Fact]
         public async Task Basic()
         {
             var githubSourceOrg = $"e2e-testing-source-{_helper.GetOsName()}";

--- a/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
@@ -31,8 +31,6 @@ namespace OctoshiftCLI.IntegrationTests
             _helper = new TestHelper(_output, _githubApi, _githubClient);
         }
 
-        // Tracking Issue: https://github.com/github/octoshift/issues/3606
-        [Fact(Skip = "random 404 errors")]
         public async Task Basic()
         {
             var githubSourceOrg = $"e2e-testing-source-{_helper.GetOsName()}";
@@ -47,28 +45,6 @@ namespace OctoshiftCLI.IntegrationTests
             await _helper.CreateGithubRepo(githubSourceOrg, repo2);
 
             await _helper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg}");
-
-            await _helper.AssertGithubRepoExists(githubTargetOrg, repo1);
-            await _helper.AssertGithubRepoExists(githubTargetOrg, repo2);
-            await _helper.AssertGithubRepoInitialized(githubTargetOrg, repo1);
-            await _helper.AssertGithubRepoInitialized(githubTargetOrg, repo2);
-        }
-
-        [Fact]
-        public async Task BasicWithSsh()
-        {
-            var githubSourceOrg = $"e2e-testing-source-{_helper.GetOsName()}";
-            var githubTargetOrg = $"e2e-testing-{_helper.GetOsName()}";
-            var repo1 = "repo-1";
-            var repo2 = "repo-2";
-
-            await _helper.ResetGithubTestEnvironment(githubSourceOrg);
-            await _helper.ResetGithubTestEnvironment(githubTargetOrg);
-
-            await _helper.CreateGithubRepo(githubSourceOrg, repo1);
-            await _helper.CreateGithubRepo(githubSourceOrg, repo2);
-
-            await _helper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --ssh");
 
             await _helper.AssertGithubRepoExists(githubTargetOrg, repo1);
             await _helper.AssertGithubRepoExists(githubTargetOrg, repo2);


### PR DESCRIPTION
Issue #303 

Turning back on e2e tests on PR commits. The underlying issues causing the flakiness should be solved now.

Also removed the SSH versions and we're using only the HTTPS versions of the e2e tests now.

I'm not going to turn on the branch protection rule that requires these to pass to merge. Lets just let them run for a week or two and make sure they are solid before we start requiring them again. I suspect there may still be some retry logic we have to implement in create-team command to solve one last flakiness holdout.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked