### PR TITLE
added osx-arm64 to publish script

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -222,9 +222,11 @@ jobs:
           ./dist/ado2gh.*.win-x64.zip
           ./dist/ado2gh.*.linux-x64.tar.gz
           ./dist/ado2gh.*.osx-x64.tar.gz
+          ./dist/ado2gh.*.osx-arm64.tar.gz
           ./dist/win-x64/gei-windows-amd64.exe
           ./dist/linux-x64/gei-linux-amd64
           ./dist/osx-x64/gei-darwin-amd64
+          ./dist/osx-arm64/gei-darwin-arm64
 
     - name: Archive Release Notes
       shell: pwsh

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - Add ado-team-project parameter to `ado2gh generate-script` command
 - Add ado-team-project parameter to `gh gei generate-script` command
+- Publishing ARM64 binaries for those users on M1 macs

--- a/publish.ps1
+++ b/publish.ps1
@@ -44,6 +44,15 @@ else {
     }
 
     tar -cvzf ./dist/ado2gh.$AssemblyVersion.osx-x64.tar.gz -C ./dist/osx-x64 ado2gh
+
+    # arm64 version for M1 macs
+    dotnet publish src/ado2gh/ado2gh.csproj -c Release -o dist/osx-arm64/ -r osx-arm64 -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    tar -cvzf ./dist/ado2gh.$AssemblyVersion.osx-arm64.tar.gz -C ./dist/osx-arm64 ado2gh
 }  
 
 
@@ -97,6 +106,19 @@ else {
     }
 
     Rename-Item ./dist/osx-x64/gei gei-darwin-amd64
+
+    # arm64 version for M1 macs
+    dotnet publish src/gei/gei.csproj -c Release -o dist/osx-arm64/ -r osx-arm64 -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    if (Test-Path -Path ./dist/osx-arm64/gei-darwin-arm64) {
+        Remove-Item ./dist/osx-arm64/gei-darwin-arm64
+    }
+
+    Rename-Item ./dist/osx-arm64/gei gei-darwin-arm64
 }
 
 


### PR DESCRIPTION
Issue #302 

Builds an arm64 binary for macos, this is for the new M1 macs.

Can't really test this (via automated tests) because GH Actions doesn't have M1 macs yet in the hosted pools.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked