### PR TITLE
Retry when wait-for-migration encounters 502 errors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -222,9 +222,11 @@ jobs:
           ./dist/ado2gh.*.win-x64.zip
           ./dist/ado2gh.*.linux-x64.tar.gz
           ./dist/ado2gh.*.osx-x64.tar.gz
+          ./dist/ado2gh.*.osx-arm64.tar.gz
           ./dist/win-x64/gei-windows-amd64.exe
           ./dist/linux-x64/gei-linux-amd64
           ./dist/osx-x64/gei-darwin-amd64
+          ./dist/osx-arm64/gei-darwin-arm64
 
     - name: Archive Release Notes
       shell: pwsh

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - Add ado-team-project parameter to `ado2gh generate-script` command
 - Add ado-team-project parameter to `gh gei generate-script` command
+- Publishing ARM64 binaries for those users on M1 macs

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
 - Add ado-team-project parameter to `ado2gh generate-script` command
 - Add ado-team-project parameter to `gh gei generate-script` command
 - Publishing ARM64 binaries for those users on M1 macs
+- Sometimes `wait-for-migration` would error with a 502 error, now it will retry automatically when this happens

--- a/publish.ps1
+++ b/publish.ps1
@@ -44,6 +44,15 @@ else {
     }
 
     tar -cvzf ./dist/ado2gh.$AssemblyVersion.osx-x64.tar.gz -C ./dist/osx-x64 ado2gh
+
+    # arm64 version for M1 macs
+    dotnet publish src/ado2gh/ado2gh.csproj -c Release -o dist/osx-arm64/ -r osx-arm64 -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    tar -cvzf ./dist/ado2gh.$AssemblyVersion.osx-arm64.tar.gz -C ./dist/osx-arm64 ado2gh
 }  
 
 
@@ -97,6 +106,19 @@ else {
     }
 
     Rename-Item ./dist/osx-x64/gei gei-darwin-amd64
+
+    # arm64 version for M1 macs
+    dotnet publish src/gei/gei.csproj -c Release -o dist/osx-arm64/ -r osx-arm64 -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    if (Test-Path -Path ./dist/osx-arm64/gei-darwin-arm64) {
+        Remove-Item ./dist/osx-arm64/gei-darwin-arm64
+    }
+
+    Rename-Item ./dist/osx-arm64/gei gei-darwin-arm64
 }
 
 

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -267,7 +267,7 @@ namespace OctoshiftCLI
             var payload = new { query = $"{query} {{ {gql} }}", variables = new { id = migrationId } };
 
             var response = await _retryPolicy.Retry(async () => await _client.PostAsync(url, payload),
-                                                   ex => ex.StatusCode == HttpStatusCode.BadGateway);
+                                                    ex => ex.StatusCode == HttpStatusCode.BadGateway);
             var data = JObject.Parse(response);
 
             return (string)data["data"]["node"]["state"];
@@ -326,7 +326,7 @@ namespace OctoshiftCLI
             var payload = new { query = $"{query} {{ {gql} }}", variables = new { id = migrationId } };
 
             var response = await _retryPolicy.Retry(async () => await _client.PostAsync(url, payload),
-                                                   ex => ex.StatusCode == HttpStatusCode.BadGateway);
+                                                    ex => ex.StatusCode == HttpStatusCode.BadGateway);
             var data = JObject.Parse(response);
 
             return (string)data["data"]["node"]["failureReason"];

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -325,7 +325,8 @@ namespace OctoshiftCLI
 
             var payload = new { query = $"{query} {{ {gql} }}", variables = new { id = migrationId } };
 
-            var response = await _client.PostAsync(url, payload);
+            var response = await _retryPolicy.Retry(async () => await _client.PostAsync(url, payload),
+                                                   ex => ex.StatusCode == HttpStatusCode.BadGateway);
             var data = JObject.Parse(response);
 
             return (string)data["data"]["node"]["failureReason"];

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -12,11 +12,13 @@ namespace OctoshiftCLI
     {
         private readonly GithubClient _client;
         private readonly string _apiUrl;
+        private readonly RetryPolicy _retryPolicy;
 
-        public GithubApi(GithubClient client, string apiUrl)
+        public GithubApi(GithubClient client, string apiUrl, RetryPolicy retryPolicy)
         {
             _client = client;
             _apiUrl = apiUrl;
+            _retryPolicy = retryPolicy;
         }
 
         public virtual async Task AddAutoLink(string org, string repo, string keyPrefix, string urlTemplate)
@@ -264,7 +266,8 @@ namespace OctoshiftCLI
 
             var payload = new { query = $"{query} {{ {gql} }}", variables = new { id = migrationId } };
 
-            var response = await _client.PostAsync(url, payload);
+            var response = await _retryPolicy.Retry(async () => await _client.PostAsync(url, payload),
+                                                   ex => ex.StatusCode == HttpStatusCode.BadGateway);
             var data = JObject.Parse(response);
 
             return (string)data["data"]["node"]["state"];

--- a/src/Octoshift/Octoshift.csproj
+++ b/src/Octoshift/Octoshift.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="System.Linq.Async" Version="5.1.0" />
   </ItemGroup>
 

--- a/src/Octoshift/Octoshift.csproj
+++ b/src/Octoshift/Octoshift.csproj
@@ -8,6 +8,8 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="System.Linq.Async" Version="5.1.0" />
   </ItemGroup>
 

--- a/src/Octoshift/RetryPolicy.cs
+++ b/src/Octoshift/RetryPolicy.cs
@@ -2,7 +2,6 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Polly;
-using Polly.Contrib.WaitAndRetry;
 
 namespace OctoshiftCLI
 {
@@ -17,9 +16,8 @@ namespace OctoshiftCLI
 
         public async Task<T> Retry<T>(Func<Task<T>> func, Func<HttpRequestException, bool> filter)
         {
-            var delay = Backoff.LinearBackoff(TimeSpan.FromMilliseconds(200), retryCount: 5, fastFirst: true);
-            var policy = Policy.Handle<HttpRequestException>(filter)
-                               .WaitAndRetryAsync(delay, (ex, _) =>
+            var policy = Policy.Handle(filter)
+                               .WaitAndRetryAsync(5, retry => retry * TimeSpan.FromMilliseconds(1000), (ex, _) =>
                                {
                                    _log.LogVerbose($"Call failed with HTTP {((HttpRequestException)ex).StatusCode}, retrying...");
                                });

--- a/src/Octoshift/RetryPolicy.cs
+++ b/src/Octoshift/RetryPolicy.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Polly;
+using Polly.Contrib.WaitAndRetry;
+
+namespace OctoshiftCLI
+{
+    public class RetryPolicy
+    {
+        private readonly OctoLogger _log;
+
+        public RetryPolicy(OctoLogger log)
+        {
+            _log = log;
+        }
+
+        public async Task<T> Retry<T>(Func<Task<T>> func, Func<HttpRequestException, bool> filter)
+        {
+            var delay = Backoff.LinearBackoff(TimeSpan.FromMilliseconds(200), retryCount: 5, fastFirst: true);
+            var policy = Policy.Handle<HttpRequestException>(filter)
+                               .WaitAndRetryAsync(delay, (ex, _) =>
+                               {
+                                   _log.LogVerbose($"Call failed with HTTP {((HttpRequestException)ex).StatusCode}, retrying...");
+                               });
+
+            return await policy.ExecuteAsync(func);
+        }
+    }
+}

--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -30,7 +30,7 @@ namespace OctoshiftCLI.IntegrationTests
             var githubToken = Environment.GetEnvironmentVariable("GH_PAT");
             _githubHttpClient = new HttpClient();
             var githubClient = new GithubClient(logger, _githubHttpClient, githubToken);
-            var githubApi = new GithubApi(githubClient, "https://api.github.com");
+            var githubApi = new GithubApi(githubClient, "https://api.github.com", new RetryPolicy(logger));
 
             _helper = new TestHelper(_output, adoApi, githubApi, adoClient, githubClient);
         }

--- a/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
@@ -26,7 +26,7 @@ namespace OctoshiftCLI.IntegrationTests
 
             _githubHttpClient = new HttpClient();
             _githubClient = new GithubClient(logger, _githubHttpClient, githubToken);
-            _githubApi = new GithubApi(_githubClient, "https://api.github.com");
+            _githubApi = new GithubApi(_githubClient, "https://api.github.com", new RetryPolicy(logger));
 
             _helper = new TestHelper(_output, _githubApi, _githubClient);
         }

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -14,6 +14,7 @@ namespace OctoshiftCLI.Tests
     public class GithubApiTests
     {
         private const string Api_Url = $"https://api.github.com";
+        private readonly RetryPolicy _retryPolicy = new RetryPolicy(new Mock<OctoLogger>().Object);
 
         [Fact]
         public async Task AddAutoLink_Calls_The_Right_Endpoint_With_Payload()
@@ -38,7 +39,7 @@ namespace OctoshiftCLI.Tests
             var githubClientMock = new Mock<GithubClient>(null, null, null);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.AddAutoLink(org, repo, keyPrefix, urlTemplate);
 
             // Assert
@@ -68,7 +69,7 @@ namespace OctoshiftCLI.Tests
             var githubClientMock = new Mock<GithubClient>(null, null, null);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.AddAutoLink(org, repo, keyPrefix, urlTemplate);
 
             // Assert
@@ -87,7 +88,7 @@ namespace OctoshiftCLI.Tests
             var githubClientMock = new Mock<GithubClient>(null, null, null);
             githubClientMock.Setup(x => x.GetAllAsync(It.IsAny<string>())).Returns(AsyncEnumerable.Empty<JToken>());
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.GetAutoLinks(org, repo);
 
             // Assert
@@ -106,7 +107,7 @@ namespace OctoshiftCLI.Tests
 
             var githubClientMock = new Mock<GithubClient>(null, null, null);
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.DeleteAutoLink(org, repo, autoLinkId);
 
             // Assert
@@ -132,7 +133,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var result = await githubApi.CreateTeam(org, teamName);
 
             // Assert
@@ -166,7 +167,7 @@ namespace OctoshiftCLI.Tests
                 .Returns(teamsResult);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var result = (await githubApi.GetTeams(org)).ToArray();
 
             // Assert
@@ -230,7 +231,7 @@ namespace OctoshiftCLI.Tests
                 .Returns(GetAllPages);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var result = (await githubApi.GetTeamMembers(org, teamName)).ToArray();
 
             // Assert
@@ -292,7 +293,7 @@ namespace OctoshiftCLI.Tests
                 .Returns(GetAllPages);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var result = (await githubApi.GetRepos(org)).ToArray();
 
             // Assert
@@ -314,7 +315,7 @@ namespace OctoshiftCLI.Tests
             githubClientMock.Setup(m => m.DeleteAsync(url));
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.RemoveTeamMember(org, teamName, member);
 
             // Assert
@@ -340,7 +341,7 @@ namespace OctoshiftCLI.Tests
             var githubClientMock = new Mock<GithubClient>(null, null, null);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.AddTeamSync(org, teamName, groupId, groupName, groupDesc);
 
             // Assert
@@ -362,7 +363,7 @@ namespace OctoshiftCLI.Tests
             var githubClientMock = new Mock<GithubClient>(null, null, null);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.AddTeamToRepo(org, repo, teamName, role);
 
             // Assert
@@ -398,7 +399,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var result = await githubApi.GetOrganizationId(org);
 
             // Assert
@@ -436,7 +437,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var expectedMigrationSourceId = await githubApi.CreateAdoMigrationSource(orgId);
 
             // Assert
@@ -474,7 +475,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var expectedMigrationSourceId = await githubApi.CreateGhecMigrationSource(orgId);
 
             // Assert
@@ -575,7 +576,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var expectedRepositoryMigrationId = await githubApi.StartMigration(migrationSourceId, adoRepoUrl, orgId, repo, sourceToken, targetToken, gitArchiveUrl, metadataArchiveUrl);
 
             // Assert
@@ -614,7 +615,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var expectedMigrationState = await githubApi.GetMigrationState(migrationId);
 
             // Assert
@@ -653,7 +654,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var expectedFailureReason = await githubApi.GetMigrationFailureReason(migrationId);
 
             // Assert
@@ -691,7 +692,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var actualGroupId = await githubApi.GetIdpGroupId(org, groupName);
 
             // Assert
@@ -731,7 +732,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var actualTeamSlug = await githubApi.GetTeamSlug(org, teamName);
 
             // Assert
@@ -752,7 +753,7 @@ namespace OctoshiftCLI.Tests
             var githubClientMock = new Mock<GithubClient>(null, null, null);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.AddEmuGroupToTeam(org, teamSlug, groupId);
 
             // Assert
@@ -789,7 +790,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var actualSuccessState = await githubApi.GrantMigratorRole(org, actor, actorType);
 
             // Assert
@@ -817,7 +818,7 @@ namespace OctoshiftCLI.Tests
                 .Throws<HttpRequestException>();
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var actualSuccessState = await githubApi.GrantMigratorRole(org, actor, actorType);
 
             // Assert
@@ -854,7 +855,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var actualSuccessState = await githubApi.RevokeMigratorRole(org, actor, actorType);
 
             // Assert
@@ -882,7 +883,7 @@ namespace OctoshiftCLI.Tests
                 .Throws<HttpRequestException>();
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var actualSuccessState = await githubApi.RevokeMigratorRole(org, actor, actorType);
 
             // Assert
@@ -901,7 +902,7 @@ namespace OctoshiftCLI.Tests
             var githubClientMock = new Mock<GithubClient>(null, null, null);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.DeleteRepo(org, repo);
 
             // Assert
@@ -995,7 +996,7 @@ namespace OctoshiftCLI.Tests
                 }.ToAsyncEnumerable());
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url);
+            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
             var migrationStates = (await githubApi.GetMigrationStates(orgId)).ToArray();
 
             // Assert

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
@@ -32,8 +32,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var team = "foo-team";
             var role = "maintain";
 
-            var mockGithub = new Mock<GithubApi>(null, null);
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var command = new AddTeamToRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
@@ -50,8 +50,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var team = "foo-team";
             var role = "read";  // read is not a valid role
 
-            var mockGithub = new Mock<GithubApi>(null, null);
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var command = new AddTeamToRepoCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ConfigureAutoLinkCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ConfigureAutoLinkCommandTests.cs
@@ -35,10 +35,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var keyPrefix = "AB#";
             var urlTemplate = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/".Replace(" ", "%20");
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetAutoLinks(It.IsAny<string>(), It.IsAny<string>()))
                       .ReturnsAsync(new List<(int Id, string KeyPrefix, string UrlTemplate)>());
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var command = new ConfigureAutoLinkCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
@@ -58,13 +58,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var keyPrefix = "AB#";
             var urlTemplate = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/".Replace(" ", "%20");
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetAutoLinks(It.IsAny<string>(), It.IsAny<string>()))
                       .Returns(Task.FromResult(new List<(int Id, string KeyPrefix, string UrlTemplate)>
                       {
                           (1, keyPrefix, urlTemplate),
                       }));
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var actualLogOutput = new List<string>();
@@ -90,13 +90,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var keyPrefix = "AB#";
             var urlTemplate = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/".Replace(" ", "%20");
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetAutoLinks(It.IsAny<string>(), It.IsAny<string>()))
                       .ReturnsAsync(new List<(int Id, string KeyPrefix, string UrlTemplate)>
                       {
                           (1, keyPrefix, "SomethingElse"),
                       });
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var actualLogOutput = new List<string>();

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/CreateTeamCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/CreateTeamCommandTests.cs
@@ -33,13 +33,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var idpGroupId = 42;
             var teamSlug = "foo-slug";
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetTeamMembers(githubOrg, teamName).Result).Returns(teamMembers);
             mockGithub.Setup(x => x.GetIdpGroupId(githubOrg, idpGroup).Result).Returns(idpGroupId);
             mockGithub.Setup(x => x.GetTeamSlug(githubOrg, teamName).Result).Returns(teamSlug);
             mockGithub.Setup(x => x.GetTeams(githubOrg).Result).Returns(new List<string>());
 
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var command = new CreateTeamCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);
@@ -61,13 +61,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var idpGroupId = 42;
             var teamSlug = "foo-slug";
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetTeamMembers(githubOrg, teamName).Result).Returns(teamMembers);
             mockGithub.Setup(x => x.GetIdpGroupId(githubOrg, idpGroup).Result).Returns(idpGroupId);
             mockGithub.Setup(x => x.GetTeamSlug(githubOrg, teamName).Result).Returns(teamSlug);
             mockGithub.Setup(x => x.GetTeams(githubOrg).Result).Returns(new List<string> { teamName });
 
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var actualLogOutput = new List<string>();

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRoleCommandTests.cs
@@ -31,10 +31,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var actorType = "TEAM";
             var githubOrgId = Guid.NewGuid().ToString();
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
 
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var command = new GrantMigratorRoleCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
@@ -45,7 +45,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var migrationId = Guid.NewGuid().ToString();
             var githubPat = Guid.NewGuid().ToString();
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
             mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
@@ -61,7 +61,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 .Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
@@ -119,7 +119,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var migrationId = Guid.NewGuid().ToString();
             var githubPat = Guid.NewGuid().ToString();
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
             mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
@@ -135,7 +135,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 .Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
@@ -31,10 +31,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var actorType = "TEAM";
             var githubOrgId = Guid.NewGuid().ToString();
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
 
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var command = new RevokeMigratorRoleCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/WaitForMigrationTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/WaitForMigrationTests.cs
@@ -29,13 +29,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             const string specifiedMigrationId = "MIGRATION_ID";
             const int waitIntervalInSeconds = 1;
 
-            var mockGithubApi = new Mock<GithubApi>(null, null);
+            var mockGithubApi = new Mock<GithubApi>(null, null, null);
             mockGithubApi.SetupSequence(x => x.GetMigrationState(specifiedMigrationId).Result)
                 .Returns(RepositoryMigrationStatus.InProgress)
                 .Returns(RepositoryMigrationStatus.InProgress)
                 .Returns(RepositoryMigrationStatus.Succeeded);
 
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithubApi.Object);
 
             var actualLogOutput = new List<string>();
@@ -81,14 +81,14 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             const string failureReason = "FAILURE_REASON";
             const int waitIntervalInSeconds = 1;
 
-            var mockGithubApi = new Mock<GithubApi>(null, null);
+            var mockGithubApi = new Mock<GithubApi>(null, null, null);
             mockGithubApi.Setup(m => m.GetMigrationFailureReason(specifiedMigrationId).Result).Returns(failureReason);
             mockGithubApi.SetupSequence(x => x.GetMigrationState(specifiedMigrationId).Result)
                 .Returns(RepositoryMigrationStatus.InProgress)
                 .Returns(RepositoryMigrationStatus.InProgress)
                 .Returns(RepositoryMigrationStatus.Failed);
 
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithubApi.Object);
 
             var actualLogOutput = new List<string>();

--- a/src/OctoshiftCLI.Tests/ado2gh/GithubApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/GithubApiFactoryTests.cs
@@ -20,7 +20,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             using var httpClient = new HttpClient();
 
             // Act
-            var factory = new GithubApiFactory(null, httpClient, environmentVariableProviderMock.Object);
+            var factory = new GithubApiFactory(null, httpClient, environmentVariableProviderMock.Object, null);
             var result = factory.Create();
 
             // Assert

--- a/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
@@ -31,10 +31,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var actorType = "TEAM";
             var githubOrgId = Guid.NewGuid().ToString();
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
 
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var command = new GrantMigratorRoleCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -55,7 +55,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var githubRepoUrl = $"https://github.com/{SOURCE_ORG}/{SOURCE_REPO}";
             var migrationId = Guid.NewGuid().ToString();
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, "", "").Result).Returns(migrationId);
@@ -108,7 +108,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var githubRepoUrl = $"https://github.com/{SOURCE_ORG}/{SOURCE_REPO}";
             var migrationId = Guid.NewGuid().ToString();
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
@@ -149,7 +149,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var adoRepoUrl = $"https://dev.azure.com/{SOURCE_ORG}/{adoTeamProject}/_git/{SOURCE_REPO}";
             var migrationId = Guid.NewGuid().ToString();
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
@@ -197,7 +197,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var authenticatedGitArchiveUrl = new Uri($"https://example.com/{gitArchiveId}/authenticated");
             var authenticatedMetadataArchiveUrl = new Uri($"https://example.com/{metadataArchiveId}/authenticated");
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
@@ -213,7 +213,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
-            var mockGhesGithubApi = new Mock<GithubApi>(null, null);
+            var mockGhesGithubApi = new Mock<GithubApi>(null, null, null);
             mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
             mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
@@ -259,7 +259,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var gitArchiveUrl = "https://example.com/git_archive.tar.gz";
             var metadataArchiveUrl = "https://example.com/metadata_archive.tar.gz";
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
@@ -327,7 +327,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var githubRepoUrl = $"https://github.com/{SOURCE_ORG}/{SOURCE_REPO}";
             var migrationId = Guid.NewGuid().ToString();
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
@@ -386,7 +386,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var authenticatedGitArchiveUrl = new Uri($"https://example.com/{gitArchiveId}/authenticated");
             var authenticatedMetadataArchiveUrl = new Uri($"https://example.com/{metadataArchiveId}/authenticated");
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
@@ -402,7 +402,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
-            var mockGhesGithubApi = new Mock<GithubApi>(null, null);
+            var mockGhesGithubApi = new Mock<GithubApi>(null, null, null);
             mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
             mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
@@ -456,7 +456,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var authenticatedGitArchiveUrl = new Uri($"https://example.com/{gitArchiveId}/authenticated");
             var authenticatedMetadataArchiveUrl = new Uri($"https://example.com/{metadataArchiveId}/authenticated");
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
@@ -472,7 +472,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
-            var mockGhesGithubApi = new Mock<GithubApi>(null, null);
+            var mockGhesGithubApi = new Mock<GithubApi>(null, null, null);
             mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
             mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
@@ -512,7 +512,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var gitArchiveId = 1;
             var metadataArchiveId = 2;
 
-            var mockGhesGithubApi = new Mock<GithubApi>(null, null);
+            var mockGhesGithubApi = new Mock<GithubApi>(null, null, null);
             mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
             mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Failed);

--- a/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
@@ -31,10 +31,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var actorType = "TEAM";
             var githubOrgId = Guid.NewGuid().ToString();
 
-            var mockGithub = new Mock<GithubApi>(null, null);
+            var mockGithub = new Mock<GithubApi>(null, null, null);
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
 
-            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null);
+            var mockGithubApiFactory = new Mock<GithubApiFactory>(null, null, null, null);
             mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
 
             var command = new RevokeMigratorRoleCommand(new Mock<OctoLogger>().Object, mockGithubApiFactory.Object);

--- a/src/OctoshiftCLI.Tests/gei/Commands/WaitForMigrationTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/WaitForMigrationTests.cs
@@ -29,7 +29,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             const string specifiedMigrationId = "MIGRATION_ID";
             const int waitIntervalInSeconds = 1;
 
-            var mockGithubApi = new Mock<GithubApi>(null, null);
+            var mockGithubApi = new Mock<GithubApi>(null, null, null);
             mockGithubApi.SetupSequence(x => x.GetMigrationState(specifiedMigrationId).Result)
                 .Returns(RepositoryMigrationStatus.InProgress)
                 .Returns(RepositoryMigrationStatus.InProgress)
@@ -80,7 +80,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             const string failureReason = "FAILURE_REASON";
             const int waitIntervalInSeconds = 1;
 
-            var mockGithubApi = new Mock<GithubApi>(null, null);
+            var mockGithubApi = new Mock<GithubApi>(null, null, null);
             mockGithubApi.Setup(m => m.GetMigrationFailureReason(specifiedMigrationId).Result).Returns(failureReason);
             mockGithubApi.SetupSequence(x => x.GetMigrationState(specifiedMigrationId).Result)
                 .Returns(RepositoryMigrationStatus.InProgress)

--- a/src/OctoshiftCLI.Tests/gei/GithubApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/GithubApiFactoryTests.cs
@@ -38,7 +38,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Act
             ISourceGithubApiFactory factory =
-                new GithubApiFactory(_logger, _mockHttpClientFactory.Object, environmentVariableProviderMock.Object);
+                new GithubApiFactory(_logger, _mockHttpClientFactory.Object, environmentVariableProviderMock.Object, null);
             var githubApi = factory.CreateClientNoSsl(apiUrl);
 
             // Assert
@@ -65,7 +65,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Act
             ISourceGithubApiFactory factory =
-                new GithubApiFactory(_logger, _mockHttpClientFactory.Object, environmentVariableProviderMock.Object);
+                new GithubApiFactory(_logger, _mockHttpClientFactory.Object, environmentVariableProviderMock.Object, null);
             var githubApi = factory.Create();
 
             // Assert
@@ -92,7 +92,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Act
             ITargetGithubApiFactory factory =
-                new GithubApiFactory(_logger, _mockHttpClientFactory.Object, environmentVariableProviderMock.Object);
+                new GithubApiFactory(_logger, _mockHttpClientFactory.Object, environmentVariableProviderMock.Object, null);
             var githubApi = factory.Create();
 
             // Assert

--- a/src/ado2gh/GithubApiFactory.cs
+++ b/src/ado2gh/GithubApiFactory.cs
@@ -7,12 +7,14 @@ namespace OctoshiftCLI.AdoToGithub
         private readonly OctoLogger _octoLogger;
         private readonly HttpClient _client;
         private readonly EnvironmentVariableProvider _environmentVariableProvider;
+        private readonly RetryPolicy _retryPolicy;
 
-        public GithubApiFactory(OctoLogger octoLogger, HttpClient client, EnvironmentVariableProvider environmentVariableProvider)
+        public GithubApiFactory(OctoLogger octoLogger, HttpClient client, EnvironmentVariableProvider environmentVariableProvider, RetryPolicy retryPolicy)
         {
             _octoLogger = octoLogger;
             _client = client;
             _environmentVariableProvider = environmentVariableProvider;
+            _retryPolicy = retryPolicy;
         }
 
         public virtual GithubApi Create()
@@ -24,7 +26,7 @@ namespace OctoshiftCLI.AdoToGithub
         {
             var githubPat = _environmentVariableProvider.GithubPersonalAccessToken();
             var githubClient = new GithubClient(_octoLogger, _client, githubPat);
-            return new GithubApi(githubClient, apiUrl);
+            return new GithubApi(githubClient, apiUrl, _retryPolicy);
         }
     }
 }

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -22,6 +22,7 @@ namespace OctoshiftCLI.AdoToGithub
                 .AddSingleton<EnvironmentVariableProvider>()
                 .AddSingleton<AdoApiFactory>()
                 .AddSingleton<GithubApiFactory>()
+                .AddSingleton<RetryPolicy>()
                 .AddHttpClient();
 
             var serviceProvider = serviceCollection.BuildServiceProvider();

--- a/src/gei/GithubApiFactory.cs
+++ b/src/gei/GithubApiFactory.cs
@@ -7,12 +7,14 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
         private readonly OctoLogger _octoLogger;
         private readonly IHttpClientFactory _clientFactory;
         private readonly EnvironmentVariableProvider _environmentVariableProvider;
+        private readonly RetryPolicy _retryPolicy;
 
-        public GithubApiFactory(OctoLogger octoLogger, IHttpClientFactory clientFactory, EnvironmentVariableProvider environmentVariableProvider)
+        public GithubApiFactory(OctoLogger octoLogger, IHttpClientFactory clientFactory, EnvironmentVariableProvider environmentVariableProvider, RetryPolicy retryPolicy)
         {
             _octoLogger = octoLogger;
             _clientFactory = clientFactory;
             _environmentVariableProvider = environmentVariableProvider;
+            _retryPolicy = retryPolicy;
         }
 
         GithubApi ISourceGithubApiFactory.Create() => (this as ISourceGithubApiFactory).Create("https://api.github.com");
@@ -21,14 +23,14 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
         {
             var githubPat = _environmentVariableProvider.SourceGithubPersonalAccessToken();
             var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), githubPat);
-            return new GithubApi(githubClient, apiUrl);
+            return new GithubApi(githubClient, apiUrl, _retryPolicy);
         }
 
         GithubApi ISourceGithubApiFactory.CreateClientNoSsl(string apiUrl)
         {
             var githubPat = _environmentVariableProvider.SourceGithubPersonalAccessToken();
             var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("NoSSL"), githubPat);
-            return new GithubApi(githubClient, apiUrl);
+            return new GithubApi(githubClient, apiUrl, _retryPolicy);
         }
 
         GithubApi ITargetGithubApiFactory.Create() => (this as ITargetGithubApiFactory).Create("https://api.github.com");
@@ -37,7 +39,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
         {
             var githubPat = _environmentVariableProvider.TargetGithubPersonalAccessToken();
             var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), githubPat);
-            return new GithubApi(githubClient, apiUrl);
+            return new GithubApi(githubClient, apiUrl, _retryPolicy);
         }
     }
 }

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -25,6 +25,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
                 .AddSingleton<AdoApiFactory>()
                 .AddSingleton<IBlobServiceClientFactory, BlobServiceClientFactory>()
                 .AddSingleton<IAzureApiFactory, AzureApiFactory>()
+                .AddSingleton<RetryPolicy>()
                 .AddTransient<ITargetGithubApiFactory>(sp => sp.GetRequiredService<GithubApiFactory>())
                 .AddTransient<ISourceGithubApiFactory>(sp => sp.GetRequiredService<GithubApiFactory>())
                 .AddHttpClient("NoSSL")


### PR DESCRIPTION
Issue #292 

Implemented this using the Polly library.

In the GithubApi layer, it can decide on a call by call basis whether retries are appropriate, and if so wrap the call to GithubClient in the RetryPolicy:

```
var response = await _retryPolicy.Retry(async () => await _client.PostAsync(url, payload),
                                        ex => ex.StatusCode == HttpStatusCode.BadGateway);
```

The RetryPolicy class is a simple wrapper around Polly to set the retry logic so it's consistent whenever we use it. In this case 5 retries with a 200ms wait between each one.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked