### PR TITLE
removing mac M1 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -222,11 +222,9 @@ jobs:
           ./dist/ado2gh.*.win-x64.zip
           ./dist/ado2gh.*.linux-x64.tar.gz
           ./dist/ado2gh.*.osx-x64.tar.gz
-          ./dist/ado2gh.*.osx-arm64.tar.gz
           ./dist/win-x64/gei-windows-amd64.exe
           ./dist/linux-x64/gei-linux-amd64
           ./dist/osx-x64/gei-darwin-amd64
-          ./dist/osx-arm64/gei-darwin-arm64
 
     - name: Archive Release Notes
       shell: pwsh

--- a/publish.ps1
+++ b/publish.ps1
@@ -44,15 +44,6 @@ else {
     }
 
     tar -cvzf ./dist/ado2gh.$AssemblyVersion.osx-x64.tar.gz -C ./dist/osx-x64 ado2gh
-
-    # arm64 version for M1 macs
-    dotnet publish src/ado2gh/ado2gh.csproj -c Release -o dist/osx-arm64/ -r osx-arm64 -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
-
-    if ($LASTEXITCODE -ne 0) {
-        exit $LASTEXITCODE
-    }
-
-    tar -cvzf ./dist/ado2gh.$AssemblyVersion.osx-arm64.tar.gz -C ./dist/osx-arm64 ado2gh
 }  
 
 
@@ -106,24 +97,4 @@ else {
     }
 
     Rename-Item ./dist/osx-x64/gei gei-darwin-amd64
-
-    # arm64 version for M1 macs
-    dotnet publish src/gei/gei.csproj -c Release -o dist/osx-arm64/ -r osx-arm64 -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
-
-    if ($LASTEXITCODE -ne 0) {
-        exit $LASTEXITCODE
-    }
-
-    if (Test-Path -Path ./dist/osx-arm64/gei-darwin-arm64) {
-        Remove-Item ./dist/osx-arm64/gei-darwin-arm64
-    }
-
-    Rename-Item ./dist/osx-arm64/gei gei-darwin-arm64
 }
-
-
-
-
-
-
-


### PR DESCRIPTION
Undoing the changes from #304 because it doesn't actually work due to a change in signing requirements for M1 binaries. See issue for more details (#302)

Will leave the issue #302 open


- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked