### PR TITLE
Removing All Orgs scope requirement on PAT for integrate-boards

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - Updates most commands to be idempotent. They will check if there is anything to do, and if not they will print a message to that effect and complete successfully. E.g. create-team will check if the team already exists and if so exit as success (compared to previously where it would crash). The following commands have been updated:
   - migrate-repo
+- `integrate-boards` no longer requires a PAT with the `All Accessible Organizations` setting

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -103,7 +103,7 @@ namespace OctoshiftCLI
             return endpoint != null ? (string)endpoint["id"] : null;
         }
 
-        public virtual async Task<string> GetGithubHandle(string org, string orgId, string teamProject, string githubToken)
+        public virtual async Task<string> GetGithubHandle(string org, string teamProject, string githubToken)
         {
             var url = $"https://dev.azure.com/{org}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
@@ -120,15 +120,9 @@ namespace OctoshiftCLI
                         accessToken = githubToken,
                         sourcePage = new
                         {
-                            url = $"https://dev.azure.com/{org}/{teamProject}/_settings/boards-external-integration#",
-                            routeId = "ms.vss-admin-web.project-admin-hub-route",
                             routeValues = new
                             {
-                                project = teamProject,
-                                adminPivot = "boards-external-integration",
-                                controller = "ContributedPage",
-                                action = "Execute",
-                                serviceHost = $"{orgId} ({org})"
+                                project = teamProject
                             }
                         }
                     }
@@ -141,7 +135,7 @@ namespace OctoshiftCLI
             return (string)data["dataProviders"]["ms.vss-work-web.github-user-data-provider"]["login"];
         }
 
-        public virtual async Task<(string connectionId, string endpointId, string connectionName, IEnumerable<string> repoIds)> GetBoardsGithubConnection(string org, string orgId, string teamProject)
+        public virtual async Task<(string connectionId, string endpointId, string connectionName, IEnumerable<string> repoIds)> GetBoardsGithubConnection(string org, string teamProject)
         {
             var url = $"https://dev.azure.com/{org}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
@@ -158,15 +152,9 @@ namespace OctoshiftCLI
                         includeInvalidConnections = false,
                         sourcePage = new
                         {
-                            url = $"https://dev.azure.com/{org}/{teamProject}/_settings/work-team",
-                            routeId = "ms.vss-admin-web.project-admin-hub-route",
                             routeValues = new
                             {
-                                project = teamProject,
-                                adminPivot = "work-team",
-                                controller = "ContributedPage",
-                                action = "Execute",
-                                serviceHost = $"{orgId} ({org})"
+                                project = teamProject
                             }
                         }
                     }
@@ -217,7 +205,7 @@ namespace OctoshiftCLI
             return (string)data["id"];
         }
 
-        public virtual async Task AddRepoToBoardsGithubConnection(string org, string orgId, string teamProject, string connectionId, string connectionName, string endpointId, IEnumerable<string> repoIds)
+        public virtual async Task AddRepoToBoardsGithubConnection(string org, string teamProject, string connectionId, string connectionName, string endpointId, IEnumerable<string> repoIds)
         {
             var url = $"https://dev.azure.com/{org}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
@@ -243,15 +231,9 @@ namespace OctoshiftCLI
                         },
                         sourcePage = new
                         {
-                            url = $"https://dev.azure.com/{org}/{teamProject}/_settings/boards-external-integration",
-                            routeId = "ms.vss-admin-web.project-admin-hub-route",
                             routeValues = new
                             {
-                                project = teamProject,
-                                adminPivot = "boards-external-integration",
-                                controller = "ContributedPage",
-                                action = "Execute",
-                                serviceHost = $"{orgId} ({org})"
+                                project = teamProject
                             }
                         }
                     }
@@ -394,7 +376,7 @@ namespace OctoshiftCLI
             await _client.PutAsync(url, payload.ToObject(typeof(object)));
         }
 
-        public virtual async Task<string> GetBoardsGithubRepoId(string org, string orgId, string teamProject, string teamProjectId, string endpointId, string githubOrg, string githubRepo)
+        public virtual async Task<string> GetBoardsGithubRepoId(string org, string teamProject, string teamProjectId, string endpointId, string githubOrg, string githubRepo)
         {
             var url = $"https://dev.azure.com/{org}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
@@ -413,15 +395,9 @@ namespace OctoshiftCLI
                         serviceEndpointId = endpointId,
                         sourcePage = new
                         {
-                            url = $"https://dev.azure.com/{org}/{teamProject}/_settings/boards-external-integration#",
-                            routeId = "ms.vss-admin-web.project-admin-hub-route",
                             routeValues = new
                             {
-                                project = teamProject,
-                                adminPivot = "boards-external-integration",
-                                controller = "ContributedPage",
-                                action = "Execute",
-                                serviceHost = $"{orgId} ({org})"
+                                project = teamProject
                             }
                         }
                     }
@@ -434,7 +410,7 @@ namespace OctoshiftCLI
             return (string)data["dataProviders"]["ms.vss-work-web.github-user-repository-data-provider"]["additionalProperties"]["nodeId"];
         }
 
-        public virtual async Task CreateBoardsGithubConnection(string org, string orgId, string teamProject, string endpointId, string repoId)
+        public virtual async Task CreateBoardsGithubConnection(string org, string teamProject, string endpointId, string repoId)
         {
             var url = $"https://dev.azure.com/{org}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
@@ -461,15 +437,9 @@ namespace OctoshiftCLI
                         },
                         sourcePage = new
                         {
-                            url = $"https://dev.azure.com/{org}/{teamProject}/_settings/boards-external-integration#",
-                            routeId = "ms.vss-admin-web.project-admin-hub-route",
                             routeValues = new
                             {
-                                project = teamProject,
-                                adminPivot = "boards-external-integration",
-                                controller = "ContributedPage",
-                                action = "Execute",
-                                serviceHost = $"{orgId} ({org})"
+                                project = teamProject
                             }
                         }
                     }

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -580,9 +580,7 @@ steps:
         {
             _output.WriteLine("Checking that the boards integration is configured...");
 
-            var userId = await _adoApi.GetUserId();
-            var adoOrgId = await _adoApi.GetOrganizationId(userId, adoOrg);
-            var boardsConnection = await _adoApi.GetBoardsGithubConnection(adoOrg, adoOrgId, teamProject);
+            var boardsConnection = await _adoApi.GetBoardsGithubConnection(adoOrg, teamProject);
 
             boardsConnection.Should().NotBeNull();
             boardsConnection.repoIds.Count().Should().Be(1);

--- a/src/OctoshiftCLI.Tests/AdoApiTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoApiTests.cs
@@ -267,7 +267,6 @@ namespace OctoshiftCLI.Tests
         public async Task GetGithubHandle_Should_Return_Handle()
         {
             var adoOrg = "FOO-ORG";
-            var adoOrgId = "FOO-ORG-ID";
             var teamProject = "FOO-TEAMPROJECT";
             var githubToken = Guid.NewGuid().ToString();
 
@@ -286,15 +285,9 @@ namespace OctoshiftCLI.Tests
                         accessToken = githubToken,
                         sourcePage = new
                         {
-                            url = $"https://dev.azure.com/{adoOrg}/{teamProject}/_settings/boards-external-integration#",
-                            routeId = "ms.vss-admin-web.project-admin-hub-route",
                             routeValues = new
                             {
-                                project = teamProject,
-                                adminPivot = "boards-external-integration",
-                                controller = "ContributedPage",
-                                action = "Execute",
-                                serviceHost = $"{adoOrgId} ({adoOrg})"
+                                project = teamProject
                             }
                         }
                     }
@@ -308,7 +301,7 @@ namespace OctoshiftCLI.Tests
             mockClient.Setup(x => x.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result).Returns(json);
 
             var sut = new AdoApi(mockClient.Object);
-            var result = await sut.GetGithubHandle(adoOrg, adoOrgId, teamProject, githubToken);
+            var result = await sut.GetGithubHandle(adoOrg, teamProject, githubToken);
 
             result.Should().Be(handle);
         }
@@ -317,7 +310,6 @@ namespace OctoshiftCLI.Tests
         public async Task GetBoardsGithubConnection_Should_Return_Connection_With_All_Repos()
         {
             var teamProject = "FOO-TEAMPROJECT";
-            var orgId = "FOO-ORGID";
             var orgName = "FOO-ORG";
             var endpoint = $"https://dev.azure.com/{orgName}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
 
@@ -334,15 +326,9 @@ namespace OctoshiftCLI.Tests
                         includeInvalidConnections = false,
                         sourcePage = new
                         {
-                            url = $"https://dev.azure.com/{orgName}/{teamProject}/_settings/work-team",
-                            routeId = "ms.vss-admin-web.project-admin-hub-route",
                             routeValues = new
                             {
-                                project = teamProject,
-                                adminPivot = "work-team",
-                                controller = "ContributedPage",
-                                action = "Execute",
-                                serviceHost = $"{orgId} ({orgName})"
+                                project = teamProject
                             }
                         }
                     }
@@ -362,7 +348,7 @@ namespace OctoshiftCLI.Tests
             mockClient.Setup(x => x.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result).Returns(json);
 
             var sut = new AdoApi(mockClient.Object);
-            var result = await sut.GetBoardsGithubConnection("FOO-ORG", "FOO-ORGID", "FOO-TEAMPROJECT");
+            var result = await sut.GetBoardsGithubConnection("FOO-ORG", "FOO-TEAMPROJECT");
 
             result.connectionId.Should().Be(connectionId);
             result.endpointId.Should().Be(endpointId);
@@ -421,7 +407,6 @@ namespace OctoshiftCLI.Tests
         public async Task AddRepoToBoardsGithubConnection_Should_Send_Correct_Payload()
         {
             var orgName = "FOO-ORG";
-            var orgId = Guid.NewGuid().ToString();
             var teamProject = "FOO-TEAMPROJECT";
             var connectionId = Guid.NewGuid().ToString();
             var connectionName = "FOO-CONNECTION";
@@ -457,15 +442,9 @@ namespace OctoshiftCLI.Tests
                         },
                         sourcePage = new
                         {
-                            url = $"https://dev.azure.com/{orgName}/{teamProject}/_settings/boards-external-integration",
-                            routeId = "ms.vss-admin-web.project-admin-hub-route",
                             routeValues = new
                             {
-                                project = teamProject,
-                                adminPivot = "boards-external-integration",
-                                controller = "ContributedPage",
-                                action = "Execute",
-                                serviceHost = $"{orgId} ({orgName})"
+                                project = teamProject
                             }
                         }
                     }
@@ -474,7 +453,7 @@ namespace OctoshiftCLI.Tests
 
             var mockClient = TestHelpers.CreateMock<AdoClient>();
             var sut = new AdoApi(mockClient.Object);
-            await sut.AddRepoToBoardsGithubConnection(orgName, orgId, teamProject, connectionId, connectionName, endpointId, new List<string>() { repo1, repo2 });
+            await sut.AddRepoToBoardsGithubConnection(orgName, teamProject, connectionId, connectionName, endpointId, new List<string>() { repo1, repo2 });
 
             mockClient.Verify(m => m.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result);
         }
@@ -749,7 +728,6 @@ namespace OctoshiftCLI.Tests
         public async Task GetBoardsGithubRepoId_Should_Return_RepoId()
         {
             var orgName = "FOO-ORG";
-            var orgId = Guid.NewGuid().ToString();
             var teamProject = "foo-tp";
             var teamProjectId = Guid.NewGuid().ToString();
             var endpointId = Guid.NewGuid().ToString();
@@ -773,15 +751,9 @@ namespace OctoshiftCLI.Tests
                         serviceEndpointId = endpointId,
                         sourcePage = new
                         {
-                            url = $"https://dev.azure.com/{orgName}/{teamProject}/_settings/boards-external-integration#",
-                            routeId = "ms.vss-admin-web.project-admin-hub-route",
                             routeValues = new
                             {
-                                project = teamProject,
-                                adminPivot = "boards-external-integration",
-                                controller = "ContributedPage",
-                                action = "Execute",
-                                serviceHost = $"{orgId} ({orgName})"
+                                project = teamProject
                             }
                         }
                     }
@@ -795,7 +767,7 @@ namespace OctoshiftCLI.Tests
             mockClient.Setup(x => x.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result).Returns(json);
 
             var sut = new AdoApi(mockClient.Object);
-            var result = await sut.GetBoardsGithubRepoId(orgName, orgId, teamProject, teamProjectId, endpointId, githubOrg, githubRepo);
+            var result = await sut.GetBoardsGithubRepoId(orgName, teamProject, teamProjectId, endpointId, githubOrg, githubRepo);
 
             result.Should().Be(repoId);
         }
@@ -804,7 +776,6 @@ namespace OctoshiftCLI.Tests
         public async Task CreateBoardsGithubConnection_Should_Send_Correct_Payload()
         {
             var orgName = "FOO-ORG";
-            var orgId = Guid.NewGuid().ToString();
             var teamProject = "foo-tp";
             var endpointId = Guid.NewGuid().ToString();
             var repoId = Guid.NewGuid().ToString();
@@ -834,15 +805,9 @@ namespace OctoshiftCLI.Tests
                         },
                         sourcePage = new
                         {
-                            url = $"https://dev.azure.com/{orgName}/{teamProject}/_settings/boards-external-integration#",
-                            routeId = "ms.vss-admin-web.project-admin-hub-route",
                             routeValues = new
                             {
-                                project = teamProject,
-                                adminPivot = "boards-external-integration",
-                                controller = "ContributedPage",
-                                action = "Execute",
-                                serviceHost = $"{orgId} ({orgName})"
+                                project = teamProject
                             }
                         }
                     }
@@ -852,7 +817,7 @@ namespace OctoshiftCLI.Tests
             var mockClient = TestHelpers.CreateMock<AdoClient>();
 
             var sut = new AdoApi(mockClient.Object);
-            await sut.CreateBoardsGithubConnection(orgName, orgId, teamProject, endpointId, repoId);
+            await sut.CreateBoardsGithubConnection(orgName, teamProject, endpointId, repoId);
 
             mockClient.Verify(m => m.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result);
         }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/IntegrateBoardsCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/IntegrateBoardsCommandTests.cs
@@ -35,8 +35,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var adoTeamProject = "BlahTeamProject";
             var githubOrg = "foo-gh-org";
             var githubRepo = "foo-repo";
-            var userId = Guid.NewGuid().ToString();
-            var orgId = Guid.NewGuid().ToString();
             var teamProjectId = Guid.NewGuid().ToString();
             var githubHandle = "foo-handle";
             var endpointId = Guid.NewGuid().ToString();
@@ -44,13 +42,11 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var githubToken = Guid.NewGuid().ToString();
 
             var mockAdo = TestHelpers.CreateMock<AdoApi>();
-            mockAdo.Setup(x => x.GetUserId().Result).Returns(userId);
-            mockAdo.Setup(x => x.GetOrganizationId(userId, adoOrg).Result).Returns(orgId);
             mockAdo.Setup(x => x.GetTeamProjectId(adoOrg, adoTeamProject).Result).Returns(teamProjectId);
-            mockAdo.Setup(x => x.GetGithubHandle(adoOrg, orgId, adoTeamProject, githubToken).Result).Returns(githubHandle);
-            mockAdo.Setup(x => x.GetBoardsGithubConnection(adoOrg, orgId, adoTeamProject).Result).Returns(() => default);
+            mockAdo.Setup(x => x.GetGithubHandle(adoOrg, adoTeamProject, githubToken).Result).Returns(githubHandle);
+            mockAdo.Setup(x => x.GetBoardsGithubConnection(adoOrg, adoTeamProject).Result).Returns(() => default);
             mockAdo.Setup(x => x.CreateBoardsGithubEndpoint(adoOrg, teamProjectId, githubToken, githubHandle, It.IsAny<string>()).Result).Returns(endpointId);
-            mockAdo.Setup(x => x.GetBoardsGithubRepoId(adoOrg, orgId, adoTeamProject, teamProjectId, endpointId, githubOrg, githubRepo).Result).Returns(newRepoId);
+            mockAdo.Setup(x => x.GetBoardsGithubRepoId(adoOrg, adoTeamProject, teamProjectId, endpointId, githubOrg, githubRepo).Result).Returns(newRepoId);
 
             var environmentVariableProviderMock = TestHelpers.CreateMock<OctoshiftCLI.AdoToGithub.EnvironmentVariableProvider>();
             environmentVariableProviderMock
@@ -64,7 +60,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 environmentVariableProviderMock.Object);
             await command.Invoke(adoOrg, adoTeamProject, githubOrg, githubRepo);
 
-            mockAdo.Verify(x => x.CreateBoardsGithubConnection(adoOrg, orgId, adoTeamProject, endpointId, newRepoId));
+            mockAdo.Verify(x => x.CreateBoardsGithubConnection(adoOrg, adoTeamProject, endpointId, newRepoId));
         }
 
         [Fact]
@@ -74,8 +70,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var adoTeamProject = "BlahTeamProject";
             var githubOrg = "foo-gh-org";
             var githubRepo = "foo-repo";
-            var userId = Guid.NewGuid().ToString();
-            var orgId = Guid.NewGuid().ToString();
             var teamProjectId = Guid.NewGuid().ToString();
             var githubHandle = "foo-handle";
             var connectionId = Guid.NewGuid().ToString();
@@ -86,12 +80,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var githubToken = Guid.NewGuid().ToString();
 
             var mockAdo = TestHelpers.CreateMock<AdoApi>();
-            mockAdo.Setup(x => x.GetUserId().Result).Returns(userId);
-            mockAdo.Setup(x => x.GetOrganizationId(userId, adoOrg).Result).Returns(orgId);
             mockAdo.Setup(x => x.GetTeamProjectId(adoOrg, adoTeamProject).Result).Returns(teamProjectId);
-            mockAdo.Setup(x => x.GetGithubHandle(adoOrg, orgId, adoTeamProject, githubToken).Result).Returns(githubHandle);
-            mockAdo.Setup(x => x.GetBoardsGithubConnection(adoOrg, orgId, adoTeamProject).Result).Returns((connectionId, endpointId, connectionName, repoIds));
-            mockAdo.Setup(x => x.GetBoardsGithubRepoId(adoOrg, orgId, adoTeamProject, teamProjectId, endpointId, githubOrg, githubRepo).Result).Returns(newRepoId);
+            mockAdo.Setup(x => x.GetGithubHandle(adoOrg, adoTeamProject, githubToken).Result).Returns(githubHandle);
+            mockAdo.Setup(x => x.GetBoardsGithubConnection(adoOrg, adoTeamProject).Result).Returns((connectionId, endpointId, connectionName, repoIds));
+            mockAdo.Setup(x => x.GetBoardsGithubRepoId(adoOrg, adoTeamProject, teamProjectId, endpointId, githubOrg, githubRepo).Result).Returns(newRepoId);
 
             var environmentVariableProviderMock = TestHelpers.CreateMock<OctoshiftCLI.AdoToGithub.EnvironmentVariableProvider>();
             environmentVariableProviderMock
@@ -106,7 +98,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await command.Invoke(adoOrg, adoTeamProject, githubOrg, githubRepo);
 
             mockAdo.Verify(x => x.CreateBoardsGithubEndpoint(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            mockAdo.Verify(x => x.AddRepoToBoardsGithubConnection(adoOrg, orgId, adoTeamProject, connectionId, connectionName, endpointId, Moq.It.Is<IEnumerable<string>>(x => x.Contains(repoIds[0]) &&
+            mockAdo.Verify(x => x.AddRepoToBoardsGithubConnection(adoOrg, adoTeamProject, connectionId, connectionName, endpointId, Moq.It.Is<IEnumerable<string>>(x => x.Contains(repoIds[0]) &&
                                                                                                                                                                                x.Contains(repoIds[1]) &&
                                                                                                                                                                                x.Contains(newRepoId))));
         }
@@ -118,8 +110,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var adoTeamProject = "BlahTeamProject";
             var githubOrg = "foo-gh-org";
             var githubRepo = "foo-repo";
-            var userId = Guid.NewGuid().ToString();
-            var orgId = Guid.NewGuid().ToString();
             var teamProjectId = Guid.NewGuid().ToString();
             var githubHandle = "foo-handle";
             var connectionId = Guid.NewGuid().ToString();
@@ -130,12 +120,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var githubToken = Guid.NewGuid().ToString();
 
             var mockAdo = TestHelpers.CreateMock<AdoApi>();
-            mockAdo.Setup(x => x.GetUserId().Result).Returns(userId);
-            mockAdo.Setup(x => x.GetOrganizationId(userId, adoOrg).Result).Returns(orgId);
             mockAdo.Setup(x => x.GetTeamProjectId(adoOrg, adoTeamProject).Result).Returns(teamProjectId);
-            mockAdo.Setup(x => x.GetGithubHandle(adoOrg, orgId, adoTeamProject, githubToken).Result).Returns(githubHandle);
-            mockAdo.Setup(x => x.GetBoardsGithubConnection(adoOrg, orgId, adoTeamProject).Result).Returns((connectionId, endpointId, connectionName, repoIds));
-            mockAdo.Setup(x => x.GetBoardsGithubRepoId(adoOrg, orgId, adoTeamProject, teamProjectId, endpointId, githubOrg, githubRepo).Result).Returns(newRepoId);
+            mockAdo.Setup(x => x.GetGithubHandle(adoOrg, adoTeamProject, githubToken).Result).Returns(githubHandle);
+            mockAdo.Setup(x => x.GetBoardsGithubConnection(adoOrg, adoTeamProject).Result).Returns((connectionId, endpointId, connectionName, repoIds));
+            mockAdo.Setup(x => x.GetBoardsGithubRepoId(adoOrg, adoTeamProject, teamProjectId, endpointId, githubOrg, githubRepo).Result).Returns(newRepoId);
 
             var environmentVariableProviderMock = TestHelpers.CreateMock<OctoshiftCLI.AdoToGithub.EnvironmentVariableProvider>();
             environmentVariableProviderMock
@@ -150,7 +138,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await command.Invoke(adoOrg, adoTeamProject, githubOrg, githubRepo);
 
             mockAdo.Verify(x => x.CreateBoardsGithubEndpoint(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            mockAdo.Verify(x => x.AddRepoToBoardsGithubConnection(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()), Times.Never);
+            mockAdo.Verify(x => x.AddRepoToBoardsGithubConnection(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()), Times.Never);
         }
 
         [Fact]

--- a/src/ado2gh/Commands/IntegrateBoardsCommand.cs
+++ b/src/ado2gh/Commands/IntegrateBoardsCommand.cs
@@ -87,23 +87,21 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             var ado = _adoApiFactory.Create(adoPat);
             githubPat ??= _environmentVariableProvider.GithubPersonalAccessToken();
 
-            var userId = await ado.GetUserId();
-            var adoOrgId = await ado.GetOrganizationId(userId, adoOrg);
             var adoTeamProjectId = await ado.GetTeamProjectId(adoOrg, adoTeamProject);
-            var githubHandle = await ado.GetGithubHandle(adoOrg, adoOrgId, adoTeamProject, githubPat);
+            var githubHandle = await ado.GetGithubHandle(adoOrg, adoTeamProject, githubPat);
 
-            var boardsConnection = await ado.GetBoardsGithubConnection(adoOrg, adoOrgId, adoTeamProject);
+            var boardsConnection = await ado.GetBoardsGithubConnection(adoOrg, adoTeamProject);
 
             if (boardsConnection == default)
             {
                 var endpointId = await ado.CreateBoardsGithubEndpoint(adoOrg, adoTeamProjectId, githubPat, githubHandle, Guid.NewGuid().ToString());
-                var repoId = await ado.GetBoardsGithubRepoId(adoOrg, adoOrgId, adoTeamProject, adoTeamProjectId, endpointId, githubOrg, githubRepo);
-                await ado.CreateBoardsGithubConnection(adoOrg, adoOrgId, adoTeamProject, endpointId, repoId);
+                var repoId = await ado.GetBoardsGithubRepoId(adoOrg, adoTeamProject, adoTeamProjectId, endpointId, githubOrg, githubRepo);
+                await ado.CreateBoardsGithubConnection(adoOrg, adoTeamProject, endpointId, repoId);
                 _log.LogSuccess("Successfully configured Boards<->GitHub integration");
             }
             else
             {
-                var repoId = await ado.GetBoardsGithubRepoId(adoOrg, adoOrgId, adoTeamProject, adoTeamProjectId, boardsConnection.endpointId, githubOrg, githubRepo);
+                var repoId = await ado.GetBoardsGithubRepoId(adoOrg, adoTeamProject, adoTeamProjectId, boardsConnection.endpointId, githubOrg, githubRepo);
 
                 if (boardsConnection.repoIds.Any(x => x == repoId))
                 {
@@ -116,7 +114,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                         repoId
                     };
 
-                    await ado.AddRepoToBoardsGithubConnection(adoOrg, adoOrgId, adoTeamProject, boardsConnection.connectionId, boardsConnection.connectionName, boardsConnection.endpointId, repos);
+                    await ado.AddRepoToBoardsGithubConnection(adoOrg, adoTeamProject, boardsConnection.connectionId, boardsConnection.connectionName, boardsConnection.endpointId, repos);
                     _log.LogSuccess("Successfully configured Boards<->GitHub integration");
                 }
             }


### PR DESCRIPTION
Issue #216 

`integrate-boards` used to require the ADO PAT to have the `All Accessible Organizations` setting, which some customers (e.g. any MSFT org) cannot choose due to security policies.

The reason this was required was the way we were calling the boards integration API's required us to pass in an Org ID, and the API's to retrieve an Org ID required that PAT permission.

Now we have a simplified way to call the boards integration API's that do not require the Org ID to be passed in.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked