### PR TITLE
Extract base GHES url from GHES api url

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 - `integrate-boards` no longer requires a PAT with the `All Accessible Organizations` setting
+- Fixed incorrect repo url in migration logs when migrating from GHES

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -205,8 +205,8 @@ namespace OctoshiftCLI
                     $sourceRepositoryUrl: URI!,
                     $repositoryName: String!,
                     $continueOnError: Boolean!,
-                    $gitArchiveUrl: String!,
-                    $metadataArchiveUrl: String!,
+                    $gitArchiveUrl: String,
+                    $metadataArchiveUrl: String,
                     $accessToken: String!,
                     $githubPat: String,
                     $skipReleases: Boolean)";

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -194,7 +194,7 @@ namespace OctoshiftCLI
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
 
-        public virtual async Task<string> StartMigration(string migrationSourceId, string sourceRepoUrl, string orgId, string repo, string sourceToken, string targetToken, string gitArchiveUrl = "", string metadataArchiveUrl = "", bool skipReleases = false)
+        public virtual async Task<string> StartMigration(string migrationSourceId, string sourceRepoUrl, string orgId, string repo, string sourceToken, string targetToken, string gitArchiveUrl = null, string metadataArchiveUrl = null, bool skipReleases = false)
         {
             var url = $"{_apiUrl}/graphql";
 

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -533,8 +533,8 @@ namespace OctoshiftCLI.Tests
                     $sourceRepositoryUrl: URI!,
                     $repositoryName: String!,
                     $continueOnError: Boolean!,
-                    $gitArchiveUrl: String!,
-                    $metadataArchiveUrl: String!,
+                    $gitArchiveUrl: String,
+                    $metadataArchiveUrl: String,
                     $accessToken: String!,
                     $githubPat: String,
                     $skipReleases: Boolean)";

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
@@ -59,8 +59,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                     githubRepo,
                     adoToken,
                     githubPat,
-                    "",
-                    "",
+                    null,
+                    null,
                     false).Result)
                 .Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
@@ -100,7 +100,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Verify(m => m.GetRepos(githubOrg));
             mockGithub.Verify(m => m.GetOrganizationId(githubOrg));
             mockGithub.Verify(m => m.CreateAdoMigrationSource(githubOrgId));
-            mockGithub.Verify(m => m.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, adoToken, githubPat, "", "", false));
+            mockGithub.Verify(m => m.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, adoToken, githubPat, null, null, false));
 
             mockLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
             actualLogOutput.Should().Equal(expectedLogOutput);
@@ -183,8 +183,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                         githubRepo,
                         adoToken,
                         githubPat,
-                        "",
-                        "",
+                        null,
+                        null,
                         false).Result)
                 .Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -66,7 +66,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithub.Setup(x => x.GetRepos(TARGET_ORG).Result).Returns(new List<string>());
             mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
-            mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, "", "", false).Result).Returns(migrationId);
+            mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false).Result).Returns(migrationId);
 
             var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
             environmentVariableProviderMock.Setup(m => m.SourceGithubPersonalAccessToken()).Returns(sourceGithubPat);
@@ -107,7 +107,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithub.Verify(m => m.GetRepos(TARGET_ORG));
             mockGithub.Verify(m => m.GetOrganizationId(TARGET_ORG));
             mockGithub.Verify(m => m.CreateGhecMigrationSource(githubOrgId));
-            mockGithub.Verify(m => m.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, "", "", false));
+            mockGithub.Verify(m => m.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false));
 
             mockLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
             actualLogOutput.Should().Equal(expectedLogOutput);
@@ -189,8 +189,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     TARGET_REPO,
                     sourceGithubPat,
                     targetGithubPat,
-                    "",
-                    "",
+                    null,
+                    null,
                     false).Result)
                 .Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
@@ -240,8 +240,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     TARGET_REPO,
                     sourceAdoPat,
                     targetGithubPat,
-                    "",
-                    "",
+                    null,
+                    null,
                     false).Result)
                 .Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
@@ -475,8 +475,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     SOURCE_REPO,
                     sourceGithubPat,
                     targetGithubPat,
-                    "",
-                    "",
+                    null,
+                    null,
                     false).Result)
                 .Returns(migrationId);
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -12,7 +12,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
     public class MigrateRepoCommandTests
     {
         private const string TARGET_API_URL = "https://api.github.com";
-        private const string GHES_API_URL = "https://api.ghes.com";
+        private const string GHES_API_URL = "https://myghes/api/v3";
         private const string AZURE_CONNECTION_STRING = "DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net";
         private const string SOURCE_ORG = "foo-source-org";
         private const string SOURCE_REPO = "foo-repo-source";
@@ -276,7 +276,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var migrationSourceId = Guid.NewGuid().ToString();
             var sourceGithubPat = Guid.NewGuid().ToString();
             var targetGithubPat = Guid.NewGuid().ToString();
-            var githubRepoUrl = $"https://github.com/{SOURCE_ORG}/{SOURCE_REPO}";
+            var githubRepoUrl = $"https://myghes/{SOURCE_ORG}/{SOURCE_REPO}";
             var migrationId = Guid.NewGuid().ToString();
             var gitArchiveId = 1;
             var metadataArchiveId = 2;
@@ -526,7 +526,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var migrationSourceId = Guid.NewGuid().ToString();
             var sourceGithubPat = Guid.NewGuid().ToString();
             var targetGithubPat = Guid.NewGuid().ToString();
-            var githubRepoUrl = $"https://github.com/{SOURCE_ORG}/{SOURCE_REPO}";
+            var githubRepoUrl = $"https://myghes/{SOURCE_ORG}/{SOURCE_REPO}";
             var migrationId = Guid.NewGuid().ToString();
             var gitArchiveId = 1;
             var metadataArchiveId = 2;
@@ -607,7 +607,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var migrationSourceId = Guid.NewGuid().ToString();
             var sourceGithubPat = Guid.NewGuid().ToString();
             var targetGithubPat = Guid.NewGuid().ToString();
-            var githubRepoUrl = $"https://github.com/{SOURCE_ORG}/{SOURCE_REPO}";
+            var githubRepoUrl = $"https://myghes/{SOURCE_ORG}/{SOURCE_REPO}";
             var migrationId = Guid.NewGuid().ToString();
             var gitArchiveId = 1;
             var metadataArchiveId = 2;

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -165,7 +165,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             LogAndValidateOptions(args);
 
-            if (!string.IsNullOrWhiteSpace(args.GhesApiUrl))
+            if (args.GhesApiUrl.HasValue())
             {
                 (args.GitArchiveUrl, args.MetadataArchiveUrl) = await GenerateAndUploadArchive(
                   args.GhesApiUrl,
@@ -180,11 +180,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             }
 
             var githubApi = _targetGithubApiFactory.Create(args.TargetApiUrl, args.GithubTargetPat);
+
             if (await RepoExists(githubApi, args.GithubTargetOrg, args.TargetRepo))
             {
                 _log.LogWarning($"The Org '{args.GithubTargetOrg}' already contains a repository with the name '{args.TargetRepo}'. No operation will be performed");
                 return;
             }
+
             var githubOrgId = await githubApi.GetOrganizationId(args.GithubTargetOrg);
             var sourceRepoUrl = GetSourceRepoUrl(args);
             var sourceToken = GetSourceToken(args);
@@ -423,11 +425,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         public string GithubTargetOrg { get; set; }
         public string TargetRepo { get; set; }
         public string TargetApiUrl { get; set; }
-        public string GhesApiUrl { get; set; } = "";
-        public string AzureStorageConnectionString { get; set; } = "";
+        public string GhesApiUrl { get; set; }
+        public string AzureStorageConnectionString { get; set; }
         public bool NoSslVerify { get; set; }
-        public string GitArchiveUrl { get; set; } = "";
-        public string MetadataArchiveUrl { get; set; } = "";
+        public string GitArchiveUrl { get; set; }
+        public string MetadataArchiveUrl { get; set; }
         public bool SkipReleases { get; set; }
         public bool Ssh { get; set; }
         public bool Wait { get; set; }

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -69,7 +69,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var ghesApiUrl = new Option<string>("--ghes-api-url")
             {
                 IsRequired = false,
-                Description = "Required if migrating from GHES. The API endpoint for the hostname of your GHES instance. For example: http(s)://myghes.com/api/v3"
+                Description = "Required if migrating from GHES. The API endpoint for your GHES instance. For example: http(s)://ghes.contoso.com/api/v3"
             };
             var azureStorageConnectionString = new Option<string>("--azure-storage-connection-string")
             {


### PR DESCRIPTION
Fixes https://github.com/github/octoshift/issues/4352

### Description
The CLI was calling the `startRepositoryMigration` mutation with a hardcoded base url in `sourceRepositoryUrl`. It works for most scenarios but when migrating from GHES to GitHub, the base url needs to be the actual GHES base url not `github.com`. Functionality wise, since the CLI expects a `--ghes-api-url` to be passed for GHES migrations, the migration was working fine. The only problem was that in the final migration log, instead of pointing to the correct GHES source it was always pointing to `github.com`. 

### Solution
Since we didn't want to introduce yet another command line arg for the base url, we are going to extract the base url from the provided `ghesApiUrl`. We expect the url format to be either `http(s)://hostname/api/v3` or `http(s)://api.hostname.com` so we can extract the base url. In case of failure, we will always fallback to the `ghesApiUrl` and use it as the base url. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)