### PR TITLE
Added reclaim-mannequin to ado2gh

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - `integrate-boards` no longer requires a PAT with the `All Accessible Organizations` setting
 - Fixed incorrect repo url in migration logs when migrating from GHES
+- Added `reclaim-mannequin` command to ado2gh (previously it was only available in `gh gei`)

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ReclaimMannequinCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ReclaimMannequinCommandTests.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Octoshift.Models;
+using OctoshiftCLI.AdoToGithub;
+using OctoshiftCLI.AdoToGithub.Commands;
+using OctoshiftCLI.Models;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+{
+    public class ReclaimMannequinCommandTests
+    {
+        private const string TARGET_API_URL = "https://api.github.com";
+
+        [Fact]
+        public void Should_Have_Options()
+        {
+            var command = new ReclaimMannequinCommand(null, null);
+            Assert.NotNull(command);
+            Assert.Equal("reclaim-mannequin", command.Name);
+            Assert.Equal(5, command.Options.Count);
+
+            TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
+            TestHelpers.VerifyCommandOption(command.Options, "mannequin-user", true);
+            TestHelpers.VerifyCommandOption(command.Options, "target-user", true);
+            TestHelpers.VerifyCommandOption(command.Options, "force", false);
+            TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+        }
+
+        [Fact]
+        public async Task Happy_Path()
+        {
+            var githubOrg = "FooOrg";
+            var githubOrgId = Guid.NewGuid().ToString();
+            var mannequinUser = "mona";
+            var mannequinUserId = Guid.NewGuid().ToString();
+            var targetUser = "mona_emu";
+            var targetUserId = Guid.NewGuid().ToString();
+
+            var mannequinResponse = new Mannequin
+            {
+                Id = mannequinUserId,
+                Login = "mona"
+            };
+
+            var reclaimMannequinResponse = new MannequinReclaimResult()
+            {
+                Data = new CreateAttributionInvitationData()
+                {
+                    CreateAttributionInvitation = new CreateAttributionInvitation()
+                    {
+                        Source = new UserInfo()
+                        {
+                            Id = mannequinUserId,
+                            Login = mannequinUser
+                        },
+                        Target = new UserInfo()
+                        {
+                            Id = targetUserId,
+                            Login = targetUser
+                        }
+                    }
+                }
+            };
+
+            var mockGithub = TestHelpers.CreateMock<GithubApi>();
+            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequin(githubOrgId, mannequinUser).Result).Returns(mannequinResponse);
+            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
+            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
+
+            var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
+            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+
+            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
+            await command.Invoke(githubOrg, mannequinUser, targetUser, false);
+
+            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId));
+        }
+
+        [Fact]
+        public async Task AlreadyMapped_No_Reclaim_Throws_OctoshiftCliException()
+        {
+            var githubOrg = "FooOrg";
+            var githubOrgId = Guid.NewGuid().ToString();
+            var mannequinUser = "mona";
+            var mannequinUserId = Guid.NewGuid().ToString();
+            var targetUser = "mona_emu";
+            var targetUserId = Guid.NewGuid().ToString();
+
+            var mannequinResponse = new Mannequin
+            {
+                Id = mannequinUserId,
+                Login = "mona",
+                MappedUser = new Claimant
+                {
+                    Id = "claimantId",
+                    Login = "claimant"
+                }
+            };
+
+            var mockGithub = TestHelpers.CreateMock<GithubApi>();
+            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequin(githubOrgId, mannequinUser).Result).Returns(mannequinResponse);
+
+            var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
+            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+
+            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
+
+
+            await FluentActions
+                .Invoking(async () => await command.Invoke(githubOrg, mannequinUser, targetUser, false))
+                .Should().ThrowAsync<OctoshiftCliException>();
+
+            mockGithub.Verify(x => x.GetUserId(targetUser), Times.Never());
+            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId), Times.Never());
+        }
+
+        [Fact]
+        public async Task AlreadyMapped_Force_Reclaim()
+        {
+            var githubOrg = "FooOrg";
+            var githubOrgId = Guid.NewGuid().ToString();
+            var mannequinUser = "mona";
+            var mannequinUserId = Guid.NewGuid().ToString();
+            var targetUser = "mona_emu";
+            var targetUserId = Guid.NewGuid().ToString();
+
+            var mannequinResponse = new Mannequin
+            {
+                Id = mannequinUserId,
+                Login = mannequinUser,
+                MappedUser = new Claimant
+                {
+                    Id = "claimantId",
+                    Login = "claimant"
+                }
+            };
+
+            var reclaimMannequinResponse = new MannequinReclaimResult()
+            {
+                Data = new CreateAttributionInvitationData()
+                {
+                    CreateAttributionInvitation = new CreateAttributionInvitation()
+                    {
+                        Source = new UserInfo()
+                        {
+                            Id = mannequinUserId,
+                            Login = mannequinUser
+                        },
+                        Target = new UserInfo()
+                        {
+                            Id = targetUserId,
+                            Login = targetUser
+                        }
+                    }
+                }
+            };
+
+            var mockGithub = TestHelpers.CreateMock<GithubApi>();
+            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequin(githubOrgId, mannequinUser).Result).Returns(mannequinResponse);
+            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
+            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
+
+            var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
+            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+
+            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
+            await command.Invoke(githubOrg, mannequinUser, targetUser, true);
+
+            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId));
+        }
+
+        [Fact]
+        public async Task Cant_ReclaimUser_Throws_OctoshiftCliException()
+        {
+            var githubOrg = "FooOrg";
+            var githubOrgId = Guid.NewGuid().ToString();
+            var mannequinUser = "mona";
+            var mannequinUserId = Guid.NewGuid().ToString();
+            var targetUser = "mona_emu";
+            var targetUserId = Guid.NewGuid().ToString();
+
+            var mannequinResponse = new Mannequin
+            {
+                Id = mannequinUserId,
+                Login = "mona",
+                MappedUser = new Claimant
+                {
+                    Id = "claimantId",
+                    Login = "claimant"
+                }
+            };
+
+            var reclaimMannequinResponse = new MannequinReclaimResult()
+            {
+                Data = new CreateAttributionInvitationData()
+                {
+                    CreateAttributionInvitation = null
+                },
+                Errors = new Collection<ErrorData>{new ErrorData
+                {
+                    Type = "UNPROCESSABLE",
+                    Message = "Target must be a member of the octocat organization",
+                    Path = new Collection<string> { "createAttributionInvitation" },
+                    Locations = new Collection<Location> {
+                                new Location()
+                                {
+                                    Line = 2,
+                                    Column = 14
+                                }
+                            }
+                    }
+                }
+            };
+
+            var mockGithub = TestHelpers.CreateMock<GithubApi>();
+            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequin(githubOrgId, mannequinUser).Result).Returns(mannequinResponse);
+            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
+
+            var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
+            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+
+            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
+
+            await FluentActions
+                .Invoking(async () => await command.Invoke(githubOrg, mannequinUser, targetUser, false))
+                .Should().ThrowAsync<OctoshiftCliException>();
+        }
+
+        [Fact]
+        public async Task NoExistantMannequin_No_Reclaim_Throws_OctoshiftCliException()
+        {
+            var githubOrg = "FooOrg";
+            var githubOrgId = Guid.NewGuid().ToString();
+            var mannequinUser = "monadoesnotexist";
+            var mannequinUserId = Guid.NewGuid().ToString();
+            var targetUser = "mona_emu";
+            var targetUserId = Guid.NewGuid().ToString();
+            var mannequinResponse = new Mannequin();
+
+            var mockGithub = TestHelpers.CreateMock<GithubApi>();
+            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequin(githubOrgId, mannequinUser).Result).Returns(mannequinResponse);
+            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
+
+            var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
+            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+
+            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
+
+            await FluentActions
+                .Invoking(async () => await command.Invoke(githubOrg, mannequinUser, targetUser, false))
+                .Should().ThrowAsync<OctoshiftCliException>();
+
+            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId), Times.Never());
+            mockGithub.Verify(x => x.GetUserId(targetUser), Times.Never());
+        }
+
+        [Fact]
+        public async Task NoTargetUser_No_Reclaim_Throws_OctoshiftCliException()
+        {
+            var githubOrg = "FooOrg";
+            var githubOrgId = Guid.NewGuid().ToString();
+            var mannequinUser = "mona";
+            var mannequinUserId = Guid.NewGuid().ToString();
+            var targetUser = "mona_emu";
+            var targetUserId = Guid.NewGuid().ToString();
+            var mannequinResponse = new Mannequin
+            {
+                Id = mannequinUserId,
+                Login = mannequinUser,
+                MappedUser = new Claimant
+                {
+                    Id = "claimantId",
+                    Login = "claimant"
+                }
+            };
+
+            var mockGithub = TestHelpers.CreateMock<GithubApi>();
+            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequin(githubOrgId, mannequinUser).Result).Returns(mannequinResponse);
+
+            var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
+            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+
+            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
+
+            await FluentActions
+                .Invoking(async () => await command.Invoke(githubOrg, mannequinUser, targetUser, false))
+                .Should().ThrowAsync<OctoshiftCliException>();
+
+            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId), Times.Never());
+            mockGithub.Verify(x => x.GetUserId(targetUser), Times.Never());
+        }
+    }
+}

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ReclaimMannequinCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ReclaimMannequinCommandTests.cs
@@ -19,12 +19,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new ReclaimMannequinCommand(null, null);
             Assert.NotNull(command);
             Assert.Equal("reclaim-mannequin", command.Name);
-            Assert.Equal(5, command.Options.Count);
+            Assert.Equal(6, command.Options.Count);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "mannequin-user", true);
             TestHelpers.VerifyCommandOption(command.Options, "target-user", true);
             TestHelpers.VerifyCommandOption(command.Options, "force", false);
+            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 
@@ -71,7 +72,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
 
             var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, mannequinUser, targetUser, false);
@@ -157,7 +158,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Setup(x => x.GetMannequin(githubOrgId, mannequinUser).Result).Returns(mannequinResponse);
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
 
             var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
 
@@ -218,7 +219,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
 
             var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, mannequinUser, targetUser, true);
@@ -275,7 +276,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
 
             var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
 
@@ -301,7 +302,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
 
             var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
 
@@ -338,7 +339,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithub.Setup(x => x.GetMannequin(githubOrgId, mannequinUser).Result).Returns(mannequinResponse);
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create()).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
 
             var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ReclaimMannequinCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ReclaimMannequinCommandTests.cs
@@ -13,8 +13,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 {
     public class ReclaimMannequinCommandTests
     {
-        private const string TARGET_API_URL = "https://api.github.com";
-
         [Fact]
         public void Should_Have_Options()
         {

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ReclaimMannequinCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ReclaimMannequinCommandTests.cs
@@ -80,6 +80,58 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         }
 
         [Fact]
+        public async Task It_Uses_The_Github_Pat_When_Provided()
+        {
+            var githubOrg = "FooOrg";
+            var githubOrgId = Guid.NewGuid().ToString();
+            var mannequinUser = "mona";
+            var mannequinUserId = Guid.NewGuid().ToString();
+            var targetUser = "mona_emu";
+            var targetUserId = Guid.NewGuid().ToString();
+            var githubPat = "PAT";
+
+            var mannequinResponse = new Mannequin
+            {
+                Id = mannequinUserId,
+                Login = "mona"
+            };
+
+            var reclaimMannequinResponse = new MannequinReclaimResult()
+            {
+                Data = new CreateAttributionInvitationData()
+                {
+                    CreateAttributionInvitation = new CreateAttributionInvitation()
+                    {
+                        Source = new UserInfo()
+                        {
+                            Id = mannequinUserId,
+                            Login = mannequinUser
+                        },
+                        Target = new UserInfo()
+                        {
+                            Id = targetUserId,
+                            Login = targetUser
+                        }
+                    }
+                }
+            };
+
+            var mockGithub = TestHelpers.CreateMock<GithubApi>();
+            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequin(githubOrgId, mannequinUser).Result).Returns(mannequinResponse);
+            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
+            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
+
+            var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
+            mockGithubApiFactory.Setup(m => m.Create(null, githubPat)).Returns(mockGithub.Object);
+
+            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
+            await command.Invoke(githubOrg, mannequinUser, targetUser, false, githubPat);
+
+            mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
+        }
+
+        [Fact]
         public async Task AlreadyMapped_No_Reclaim_Throws_OctoshiftCliException()
         {
             var githubOrg = "FooOrg";

--- a/src/OctoshiftCLI.Tests/gei/Commands/ReclaimMannequinCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/ReclaimMannequinCommandTests.cs
@@ -13,12 +13,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 {
     public class ReclaimMannequinCommandTests
     {
-        private const string TARGET_API_URL = "https://api.github.com";
-
         [Fact]
         public void Should_Have_Options()
         {
-            var command = new ReclaimMannequinCommand(null, null, null);
+            var command = new ReclaimMannequinCommand(null, null);
             Assert.NotNull(command);
             Assert.Equal("reclaim-mannequin", command.Name);
             Assert.Equal(5, command.Options.Count);
@@ -39,7 +37,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var mannequinUserId = Guid.NewGuid().ToString();
             var targetUser = "mona_emu";
             var targetUserId = Guid.NewGuid().ToString();
-            var targetGithubPat = Guid.NewGuid().ToString();
 
             var mannequinResponse = new Mannequin
             {
@@ -73,13 +70,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
             mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
 
-            var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
-            environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
-
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
 
-            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
+            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, mannequinUser, targetUser, false);
 
             mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId));
@@ -111,13 +105,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
             mockGithub.Setup(x => x.GetMannequin(githubOrgId, mannequinUser).Result).Returns(mannequinResponse);
 
-            var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
-            environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
-
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
 
-            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
+            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
 
 
             await FluentActions
@@ -137,7 +128,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var mannequinUserId = Guid.NewGuid().ToString();
             var targetUser = "mona_emu";
             var targetUserId = Guid.NewGuid().ToString();
-            var targetGithubPat = Guid.NewGuid().ToString();
 
             var mannequinResponse = new Mannequin
             {
@@ -176,13 +166,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
             mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
 
-            var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
-            environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
-
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
 
-            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
+            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, mannequinUser, targetUser, true);
 
             mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId));
@@ -197,7 +184,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var mannequinUserId = Guid.NewGuid().ToString();
             var targetUser = "mona_emu";
             var targetUserId = Guid.NewGuid().ToString();
-            var targetGithubPat = Guid.NewGuid().ToString();
 
             var mannequinResponse = new Mannequin
             {
@@ -237,13 +223,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithub.Setup(x => x.GetMannequin(githubOrgId, mannequinUser).Result).Returns(mannequinResponse);
             mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
 
-            var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
-            environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
-
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
 
-            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
+            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
 
             await FluentActions
                 .Invoking(async () => await command.Invoke(githubOrg, mannequinUser, targetUser, false))
@@ -259,7 +242,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var mannequinUserId = Guid.NewGuid().ToString();
             var targetUser = "mona_emu";
             var targetUserId = Guid.NewGuid().ToString();
-            var targetGithubPat = Guid.NewGuid().ToString();
             var mannequinResponse = new Mannequin();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
@@ -267,13 +249,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithub.Setup(x => x.GetMannequin(githubOrgId, mannequinUser).Result).Returns(mannequinResponse);
             mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
 
-            var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
-            environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
-
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
 
-            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
+            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
 
             await FluentActions
                 .Invoking(async () => await command.Invoke(githubOrg, mannequinUser, targetUser, false))
@@ -292,7 +271,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var mannequinUserId = Guid.NewGuid().ToString();
             var targetUser = "mona_emu";
             var targetUserId = Guid.NewGuid().ToString();
-            var targetGithubPat = Guid.NewGuid().ToString();
             var mannequinResponse = new Mannequin
             {
                 Id = mannequinUserId,
@@ -308,13 +286,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
             mockGithub.Setup(x => x.GetMannequin(githubOrgId, mannequinUser).Result).Returns(mannequinResponse);
 
-            var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
-            environmentVariableProviderMock.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
-
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-            mockGithubApiFactory.Setup(m => m.Create(TARGET_API_URL, It.IsAny<string>())).Returns(mockGithub.Object);
+            mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
 
-            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object, environmentVariableProviderMock.Object);
+            var command = new ReclaimMannequinCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
 
             await FluentActions
                 .Invoking(async () => await command.Invoke(githubOrg, mannequinUser, targetUser, false))

--- a/src/OctoshiftCLI.Tests/gei/Commands/ReclaimMannequinCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/ReclaimMannequinCommandTests.cs
@@ -88,7 +88,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var mannequinUserId = Guid.NewGuid().ToString();
             var targetUser = "mona_emu";
             var targetUserId = Guid.NewGuid().ToString();
-            var targetGithubPat = Guid.NewGuid().ToString();
 
             var mannequinResponse = new Mannequin
             {

--- a/src/OctoshiftCLI.Tests/gei/Commands/ReclaimMannequinCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/ReclaimMannequinCommandTests.cs
@@ -19,12 +19,13 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var command = new ReclaimMannequinCommand(null, null);
             Assert.NotNull(command);
             Assert.Equal("reclaim-mannequin", command.Name);
-            Assert.Equal(5, command.Options.Count);
+            Assert.Equal(6, command.Options.Count);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-target-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "mannequin-user", true);
             TestHelpers.VerifyCommandOption(command.Options, "target-user", true);
             TestHelpers.VerifyCommandOption(command.Options, "force", false);
+            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         }
 

--- a/src/ado2gh/Commands/ReclaimMannequinCommand.cs
+++ b/src/ado2gh/Commands/ReclaimMannequinCommand.cs
@@ -107,9 +107,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 throw new OctoshiftCliException($"Failed to reclaim {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId})");
             }
-            
+
             _log.LogInformation($"Successfully reclaimed {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId})");
-            
         }
     }
 }

--- a/src/ado2gh/Commands/ReclaimMannequinCommand.cs
+++ b/src/ado2gh/Commands/ReclaimMannequinCommand.cs
@@ -1,0 +1,116 @@
+﻿using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading.Tasks;
+
+namespace OctoshiftCLI.AdoToGithub.Commands
+{
+    public class ReclaimMannequinCommand : Command
+    {
+        private readonly OctoLogger _log;
+        private readonly GithubApiFactory _githubApiFactory;
+
+        public ReclaimMannequinCommand(OctoLogger log, GithubApiFactory githubApiFactory) : base("reclaim-mannequin")
+        {
+            _log = log;
+            _githubApiFactory = githubApiFactory;
+
+            Description = "Reclaims a mannequin user. An invite will be sent and the user will have to accept for the remapping to occur.";
+
+            var githubOrgOption = new Option<string>("--github-org")
+            {
+                IsRequired = true,
+                Description = "Uses GH_PAT env variable."
+            };
+
+            var mannequinUsernameOption = new Option<string>("--mannequin-user")
+            {
+                IsRequired = true,
+                Description = "The login of the mannequin to be remapped."
+            };
+            var targetUsernameOption = new Option<string>("--target-user")
+            {
+                IsRequired = true,
+                Description = "The login of the target user to be mapped."
+            };
+
+            var forceOption = new Option("--force")
+            {
+                IsRequired = false,
+                Description = "Map the user even if it was previously mapped"
+            };
+
+
+            var verbose = new Option("--verbose")
+            {
+                IsRequired = false
+            };
+
+            AddOption(githubOrgOption);
+            AddOption(mannequinUsernameOption);
+            AddOption(targetUsernameOption);
+            AddOption(forceOption);
+            AddOption(verbose);
+
+            Handler = CommandHandler.Create<string, string, string, bool, bool>(Invoke);
+        }
+
+        public async Task Invoke(
+          string githubOrg,
+          string mannequinUser,
+          string targetUser,
+          bool force = false,
+          bool verbose = false)
+        {
+            _log.Verbose = verbose;
+
+            _log.LogInformation("Reclaming Mannequin...");
+
+            _log.LogInformation($"GITHUB ORG: {githubOrg}");
+            _log.LogInformation($"MANNEQUIN: {mannequinUser}");
+            _log.LogInformation($"RECLAIMING USER: {targetUser}");
+
+            var githubApi = _githubApiFactory.Create();
+
+            _log.LogInformation($"GITHUB ORG: {githubOrg}");
+            var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
+            _log.LogInformation($"    Organization Id: {githubOrgId}");
+
+            var mannequin = await githubApi.GetMannequin(githubOrgId, mannequinUser);
+
+            if (mannequin == null || mannequin.Id == null)
+            {
+                throw new OctoshiftCliException($"User {mannequinUser} is not a mannequin.");
+            }
+
+            if (mannequin.MappedUser != null && force == false)
+            {
+                throw new OctoshiftCliException($"User {mannequinUser} has been already mapped to {mannequin.MappedUser.Login}. Use the force option if you want to reclaim the mannequin again.");
+            }
+
+            var targetUserId = await githubApi.GetUserId(targetUser);
+
+            if (targetUserId == null)
+            {
+                throw new OctoshiftCliException($"Target user {targetUser} not found.");
+            }
+
+            var result = await githubApi.ReclaimMannequin(githubOrgId, mannequin.Id, targetUserId);
+
+            if (result.Errors != null)
+            {
+                throw new OctoshiftCliException($"Failed to reclaim {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId}) Reason: {result.Errors[0].Message}");
+            }
+
+            if (result.Data.CreateAttributionInvitation != null &&
+                result.Data.CreateAttributionInvitation.Source.Id == mannequin.Id &&
+                result.Data.CreateAttributionInvitation.Target.Id == targetUserId)
+            {
+                _log.LogInformation($"Successfully reclaimed {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId})");
+            }
+            else
+            {
+                throw new OctoshiftCliException($"Failed to reclaim {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId})");
+            }
+        }
+    }
+}

--- a/src/ado2gh/Commands/ReclaimMannequinCommand.cs
+++ b/src/ado2gh/Commands/ReclaimMannequinCommand.cs
@@ -101,16 +101,15 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                 throw new OctoshiftCliException($"Failed to reclaim {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId}) Reason: {result.Errors[0].Message}");
             }
 
-            if (result.Data.CreateAttributionInvitation != null &&
-                result.Data.CreateAttributionInvitation.Source.Id == mannequin.Id &&
-                result.Data.CreateAttributionInvitation.Target.Id == targetUserId)
-            {
-                _log.LogInformation($"Successfully reclaimed {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId})");
-            }
-            else
+            if (result.Data.CreateAttributionInvitation is null ||
+                result.Data.CreateAttributionInvitation.Source.Id != mannequin.Id ||
+                result.Data.CreateAttributionInvitation.Target.Id != targetUserId)
             {
                 throw new OctoshiftCliException($"Failed to reclaim {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId})");
             }
+            
+            _log.LogInformation($"Successfully reclaimed {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId})");
+            
         }
     }
 }

--- a/src/ado2gh/Commands/ReclaimMannequinCommand.cs
+++ b/src/ado2gh/Commands/ReclaimMannequinCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;
+using OctoshiftCLI.Extensions;
 
 namespace OctoshiftCLI.AdoToGithub.Commands
 {
@@ -19,7 +20,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             var githubOrgOption = new Option<string>("--github-org")
             {
                 IsRequired = true,
-                Description = "Uses GH_PAT env variable."
+                Description = "Uses GH_PAT env variable or --github-pat arg."
             };
 
             var mannequinUsernameOption = new Option<string>("--mannequin-user")
@@ -38,8 +39,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                 IsRequired = false,
                 Description = "Map the user even if it was previously mapped"
             };
-
-
+            var githubPatOption = new Option<string>("--github-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -49,9 +52,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(mannequinUsernameOption);
             AddOption(targetUsernameOption);
             AddOption(forceOption);
+            AddOption(githubPatOption);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, bool, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, bool, string, bool>(Invoke);
         }
 
         public async Task Invoke(
@@ -59,6 +63,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
           string mannequinUser,
           string targetUser,
           bool force = false,
+          string githubPat = null,
           bool verbose = false)
         {
             _log.Verbose = verbose;
@@ -68,8 +73,12 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log.LogInformation($"GITHUB ORG: {githubOrg}");
             _log.LogInformation($"MANNEQUIN: {mannequinUser}");
             _log.LogInformation($"RECLAIMING USER: {targetUser}");
+            if (githubPat.HasValue())
+            {
+                _log.LogInformation("GITHUB PAT: ***");
+            }
 
-            var githubApi = _githubApiFactory.Create();
+            var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
 
             _log.LogInformation($"GITHUB ORG: {githubOrg}");
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);

--- a/src/ado2gh/Commands/ReclaimMannequinCommand.cs
+++ b/src/ado2gh/Commands/ReclaimMannequinCommand.cs
@@ -73,7 +73,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log.LogInformation($"GITHUB ORG: {githubOrg}");
             _log.LogInformation($"MANNEQUIN: {mannequinUser}");
             _log.LogInformation($"RECLAIMING USER: {targetUser}");
-            if (githubPat.HasValue())
+            if (githubPat is not null)
             {
                 _log.LogInformation("GITHUB PAT: ***");
             }

--- a/src/ado2gh/Commands/ReclaimMannequinCommand.cs
+++ b/src/ado2gh/Commands/ReclaimMannequinCommand.cs
@@ -1,7 +1,6 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;
-using OctoshiftCLI.Extensions;
 
 namespace OctoshiftCLI.AdoToGithub.Commands
 {

--- a/src/ado2gh/GithubApiFactory.cs
+++ b/src/ado2gh/GithubApiFactory.cs
@@ -21,11 +21,6 @@ namespace OctoshiftCLI.AdoToGithub
             _versionProvider = versionProvider;
         }
 
-        public virtual GithubApi Create()
-        {
-            return Create(null, null);
-        }
-
         public virtual GithubApi Create(string apiUrl = null, string personalAccessToken = null)
         {
             apiUrl ??= DEFAULT_API_URL;

--- a/src/ado2gh/GithubApiFactory.cs
+++ b/src/ado2gh/GithubApiFactory.cs
@@ -21,6 +21,11 @@ namespace OctoshiftCLI.AdoToGithub
             _versionProvider = versionProvider;
         }
 
+        public virtual GithubApi Create()
+        {
+            return Create(null, null);
+        }
+
         public virtual GithubApi Create(string apiUrl = null, string personalAccessToken = null)
         {
             apiUrl ??= DEFAULT_API_URL;

--- a/src/gei/Commands/ReclaimMannequinCommand.cs
+++ b/src/gei/Commands/ReclaimMannequinCommand.cs
@@ -73,7 +73,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             _log.LogInformation($"GITHUB TARGET ORG: {githubTargetOrg}");
             _log.LogInformation($"MANNEQUIN: {mannequinUser}");
             _log.LogInformation($"RECLAIMING USER: {targetUser}");
-            if (githubPat.HasValue())
+            if (githubPat is not null)
             {
                 _log.LogInformation("GITHUB PAT: ***");
             }

--- a/src/gei/Commands/ReclaimMannequinCommand.cs
+++ b/src/gei/Commands/ReclaimMannequinCommand.cs
@@ -9,13 +9,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         private readonly OctoLogger _log;
         private readonly ITargetGithubApiFactory _targetGithubApiFactory;
 
-        private readonly EnvironmentVariableProvider _environmentVariableProvider;
-
-        public ReclaimMannequinCommand(OctoLogger log, ITargetGithubApiFactory targetGithubApiFactory, EnvironmentVariableProvider environmentVariableProvider) : base("reclaim-mannequin")
+        public ReclaimMannequinCommand(OctoLogger log, ITargetGithubApiFactory targetGithubApiFactory) : base("reclaim-mannequin")
         {
             _log = log;
             _targetGithubApiFactory = targetGithubApiFactory;
-            _environmentVariableProvider = environmentVariableProvider;
 
             Description = "Reclaims a mannequin user. An invite will be sent and the user will have to accept for the remapping to occur.";
 
@@ -64,8 +61,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
           bool force = false,
           bool verbose = false)
         {
-            const string targetApiUrl = "https://api.github.com";
-
             _log.Verbose = verbose;
 
             _log.LogInformation("Reclaming Mannequin...");
@@ -74,7 +69,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             _log.LogInformation($"MANNEQUIN: {mannequinUser}");
             _log.LogInformation($"RECLAIMING USER: {targetUser}");
 
-            var githubApi = _targetGithubApiFactory.Create(targetApiUrl);
+            var githubApi = _targetGithubApiFactory.Create();
 
             _log.LogInformation($"GITHUB ORG: {githubTargetOrg}");
             var githubOrgId = await githubApi.GetOrganizationId(githubTargetOrg);

--- a/src/gei/Commands/ReclaimMannequinCommand.cs
+++ b/src/gei/Commands/ReclaimMannequinCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;
+using OctoshiftCLI.Extensions;
 
 namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 {
@@ -38,8 +39,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 IsRequired = false,
                 Description = "Map the user even if it was previously mapped"
             };
-
-
+            var githubPatOption = new Option<string>("--github-pat")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -49,9 +52,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(mannequinUsernameOption);
             AddOption(targetUsernameOption);
             AddOption(forceOption);
+            AddOption(githubPatOption);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, bool, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, bool, string, bool>(Invoke);
         }
 
         public async Task Invoke(
@@ -59,6 +63,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
           string mannequinUser,
           string targetUser,
           bool force = false,
+          string githubPat = null,
           bool verbose = false)
         {
             _log.Verbose = verbose;
@@ -68,8 +73,12 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             _log.LogInformation($"GITHUB TARGET ORG: {githubTargetOrg}");
             _log.LogInformation($"MANNEQUIN: {mannequinUser}");
             _log.LogInformation($"RECLAIMING USER: {targetUser}");
+            if (githubPat.HasValue())
+            {
+                _log.LogInformation("GITHUB PAT: ***");
+            }
 
-            var githubApi = _targetGithubApiFactory.Create();
+            var githubApi = _targetGithubApiFactory.Create(targetPersonalAccessToken: githubPat);
 
             _log.LogInformation($"GITHUB ORG: {githubTargetOrg}");
             var githubOrgId = await githubApi.GetOrganizationId(githubTargetOrg);

--- a/src/gei/Commands/ReclaimMannequinCommand.cs
+++ b/src/gei/Commands/ReclaimMannequinCommand.cs
@@ -1,7 +1,6 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;
-using OctoshiftCLI.Extensions;
 
 namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 {

--- a/src/gei/Commands/ReclaimMannequinCommand.cs
+++ b/src/gei/Commands/ReclaimMannequinCommand.cs
@@ -101,16 +101,14 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 throw new OctoshiftCliException($"Failed to reclaim {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId}) Reason: {result.Errors[0].Message}");
             }
 
-            if (result.Data.CreateAttributionInvitation != null &&
-                result.Data.CreateAttributionInvitation.Source.Id == mannequin.Id &&
-                result.Data.CreateAttributionInvitation.Target.Id == targetUserId)
-            {
-                _log.LogInformation($"Successfully reclaimed {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId})");
-            }
-            else
+            if (result.Data.CreateAttributionInvitation is null ||
+                result.Data.CreateAttributionInvitation.Source.Id != mannequin.Id ||
+                result.Data.CreateAttributionInvitation.Target.Id != targetUserId)
             {
                 throw new OctoshiftCliException($"Failed to reclaim {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId})");
             }
+
+            _log.LogInformation($"Successfully reclaimed {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId})");
         }
     }
 }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->
Issue #356 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created) - #360 

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->