### PR TITLE
Simplified README to minimize duplication with official docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@
 [![Actions Status: CI](https://github.com/github/octoshiftcli/workflows/CI/badge.svg)](https://github.com/github/octoshiftcli/actions?query=workflow%3ACI)
 
 
-The [GitHub Enterprise Importer](https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer) (GEI, formerly Octoshift) is a highly customizable API-first migration offering designed to help you move your enterprise to GitHub Enterprise Cloud. The GEI-CLI wraps the GEI APIs as a cross-platform .NET Core console application to simplify customizing your migration experience.
+The [GitHub Enterprise Importer](https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer) (GEI, formerly Octoshift) is a highly customizable API-first migration offering designed to help you move your enterprise to GitHub Enterprise Cloud. The GEI-CLI wraps the GEI APIs as a cross-platform console application to simplify customizing your migration experience.
 
 > GEI is in a private preview for GitHub Enterprise Cloud. It needs to be enabled before using this CLI. Please reach out to [GitHub Sales](https://github.com/enterprise/contact) to enquire about getting into the private beta. 
-
-This version of the GEI-CLI is informally maintained by GitHub. However, this is **not a supported GitHub product**. Customers leveraging these tools must understand that any support must come through a paid GitHub Expert Services engagement.
 
 ## Supported Scenarios
 GEI-CLI is continuing to expand what it can support. However, it supports the following scenarios at present:
@@ -18,8 +16,57 @@ GEI-CLI is continuing to expand what it can support. However, it supports the fo
 
 Learn more about what exactly is migrated and any limitations in the [GEI documentation](https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer/about-github-enterprise-importer). 
 
+## Using the GEI CLI
+There are 2 separate CLI's that we ship:
+- `ado2gh` - Intended for migrations from Azure DevOps -> GitHub
+- `gh gei` - Intended for GitHub -> GitHub migrations
+
+To use `ado2gh` download the latest version from the [Releases](https://github.com/github/gh-gei/releases/latest) in this repo.
+
+To use `gh gei` first install the latest [GitHub CLI](https://github.com/cli/cli#installation), then run the command
+>`gh extension install github/gh-gei`
+
+We update the gei extension frequently, to ensure you're using the latest version run this command on a regular basis:
+>`gh extension upgrade github/gh-gei`
+
+To see the available commands and options run:
+
+>`ado2gh --help`
+
+>`gh gei --help`
+
+### GitHub to GitHub Usage (GHEC -> GHEC)
+1. Create Personal Access Tokens with access to the source GitHub org, and the target GitHub org (for more details on scopes needed refer to our [official documentation](https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer)).
+
+2. Set the GH_SOURCE_PAT and GH_PAT environment variables.
+
+3. Run the `generate-script` command to generate a migration script.
+>`gh gei generate-script --github-source-org ORGNAME --github-target-org ORGNAME`
+
+4. The previous command will have created a migrate.ps1 script. Review the steps in the generated script and tweak if necessary.
+
+5. The migrate.ps1 script requires powershell to run. If not already installed see the [install instructions](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.2) to install powershell on Windows, Linux, or Mac. Then run the script.
+
+Refer to the [official documentation](https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer) for more details (and differences when migrating from GHES or to GHAE).
+
+### Azure DevOps to GitHub Usage
+1. Create Personal Access Tokens with access to the Azure DevOps org, and the GitHub org (for more details on scopes needed refer to our [official documentation](https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer)).
+
+2. Set the ADO_PAT and GH_PAT environment variables.
+
+3. Run the `generate-script` command to generate a migration script.
+>`ado2gh generate-script --ado-org ORGNAME --github-org ORGNAME --all`
+
+4. The previous command will have created a migrate.ps1 script. Review the steps in the generated script and tweak if necessary.
+
+5. The migrate.ps1 script requires powershell to run. If not already installed see the [install instructions](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.2) to install powershell on Windows, Linux, or Mac. Then run the script.
+
+Refer to the [official documentation](https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer) for more details.
+
 ## Quick Start Videos
 You'll find videos below to help you quickly get started with the GEI CLI. Be sure to pick the videos relevant to your migration scenario. 
+
+>NOTE: We don't update these videos as often as we update the CLI, so they may not exactly match the functionality in the latest release of this CLI.
 
 ### Migrating GitHub to GitHub
 The quick start video below will help you start migrating between GitHub organizations. 
@@ -30,152 +77,6 @@ The quick start video below will help you start migrating between GitHub organiz
 Video guides below will help you get started with your first migration. Then help you build up to orchestrating a complete end-to-end production migration. 
 * Running your first few migrations: https://www.youtube.com/watch?v=yfnXbwtXY80
 * Orchestrating an end-to-end production migration: https://www.youtube.com/watch?v=AtFB-U1Og4c
-
-## GitHub to GitHub Migration Usage
-
-General usage will use the `generate-script` command to create a script that can be used to migrate all repositories from a GitHub organization. 
-### Command line
-To get started you'll need to download the official [GitHub CLI](https://cli.github.com). You can run `gh extension install github/gh-gei` to install the GEI CLI. Once installed, run `gh gei --help` to learn about the options.
-
-```
-gh-gei
-  CLI for GitHub Enterprise Importer.
-
-Usage:
-  gh-gei [options] [command]
-
-Options:
-  --version       Show version information
-  -?, -h, --help  Show help and usage information
-
-Commands:
-  generate-script       Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it.
-  grant-migrator-role   Allows an organization admin to grant a USER or TEAM the migrator role for a single GitHub organization. The migrator role allows the role assignee to perform migrations into the target organization.
-                        Note: Expects GH_PAT env variable to be set.
-  migrate-repo          Invokes the GitHub APIs to migrate the repo and all repo data.
-  revoke-migrator-role  Allows an organization admin to revoke the migrator role for a USER or TEAM for a single GitHub organization. This will remove their ability to run a migration into the target organization.
-                        Note: Expects GH_PAT env variable to be set.
-```
-
-To generate a migration script, you'll need to set `GH_PAT` as an environment variable for your destination and `GH_SOURCE_PAT` for your source location. 
-
-## GitHub Enterprise Server (GHES) to GitHub Migration Usage
-
-General usage will use the `generate-script` command to create a script that can be used to migrate all repositories from a GHES organization.
-
-Due to many GHES instances containing firewall rules restricting the direct API access that GEI needs to perform a migration, the GEI CLI uploads the migration's archive data to Azure Blob Storage as a step prior to starting the migration using GEI. This allows GEI to perform a migration without directly accessing the GHES instance. To get started you'll need to setup an [Azure storage account](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal). Then, you'll pass in a [connection string](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/api/connection-strings/storage-connection-strings) to the CLI for that Azure storage account, specified in the parameters below. GEI CLI will take care of the rest.
-
-### Command Line
-
-Generating a migration script for GHES is very similar to GitHub to GitHub migration scripts, but requires a couple extra parameters. You can run `gh gei generate-script --help` to learn about all of the options.
-
-The extra options you will need when migrating from GHES are:
-- `--ghes-api-url` - (Required) The api endpoint for the hostname of your GHES instance. For example: http(s)://api.myghes.com"
-- `--azure-storage-connection-string` - (Required) The connection string for the Azure storage account, used to upload data archives pre-migration. For example: \"DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net\". It's recommend to use quotes around this value since the connection string itself uses characters that might otherwise be interpreted by bash.
-- `--no-ssl-verify` (Optional) Disables SSL verification when communicating with your GHES instance. All other migration steps will continue to verify SSL. If your GHES instance has a self-signed SSL certificate then setting this flag will allow data to be extracted.
-
-Here's an example:
-```
-gh gei generate-script --github-source-org "source-ghes-org" --github-target-org "target-ghec-org" --ghes-api-url "https://api.myghesinstance.com" --azure-storage-connection-string "DefaultEndpointsProtocol=https;AccountName=myazureaccount;AccountKey=myazurestoragekey;EndpointSuffix=core.windows.net" --no-ssl-verify
-```
-
-This will generate a new file (named `./migrate.ps1` by default) which gives you an opportunity to review the steps GEI-CLI will take. Once ready, running the `./migrate.ps1` file will kick off the migration!
-
-After running the migration and validating the migration data, you will need to remove the archive data from your Azure storage account. If you're done with all of your migrations, the blob container(s) containing the archives can be deleted. 
-
-## Azure DevOps to GitHub Migration Usage
-
-Execute the executable without any parameters to learn about the options. General usage will use the `generate-script` option to create a script that can be used to migrate all repositories from an Azure DevOps org and re-wire Azure Boards and Azure Pipelines connections.
-
-### Command line
-```
-ado2gh
-  Migrates Azure DevOps repos to GitHub
-Usage:
-  ado2gh [options] [command]
-
-Options:
-  --version       Show version information
-  -?, -h, --help  Show help and usage information
-
-Commands:
-  generate-script
-  rewire-pipeline
-  integrate-boards
-  share-service-connection
-  disable-ado-repo
-  lock-ado-repo             Makes the ADO repo read-only for all users. It does this by adding Deny permissions for the Project Valid Users group on the repo.
-  configure-auto-link
-  create-team               Creates a GitHub team and optionally links it to an IdP group.
-  add-team-to-repo
-  migrate-repo
-```
-
-To generate a script, you'll need to set an `ADO_PAT` as an environment variable. Performing any of the commands that touch GitHub will need the `GH_PAT` environment variable.
-
-### Running a Migration 
-
-Covering running a migration from **Azure DevOps** to **GitHub.com**. 
-
-#### Download and Configure the GH-GEI command-line Tool
-
-Navigate to the `Releases` for this repository and grab the latest release for your local operating system. Note: ado2gh is for Azure DevOps -> GitHub migrations, gei is for GitHub -> GitHub migrations.
-![Releases](https://user-images.githubusercontent.com/29484535/145065021-35f37a00-1a25-42a4-804d-11fd9f8cc811.png)
-Once you have downloaded the `Release`, you need to extract it to your local machine.
-**Note** you will want to place the `octoshift` executable somewhere easy to reference or add to your path.
-![Folder View](https://user-images.githubusercontent.com/29484535/145065026-a519a7f0-fc1d-46a1-a1a5-cd96743b1bd1.png)
-
-* [Linux add folder to path](https://linuxize.com/post/how-to-add-directory-to-path-in-linux/)
-* [Powershell add folder to path](https://stackoverflow.com/questions/714877/setting-windows-powershell-environment-variables/714918)
-
-Once you have pathed the tooling, you will need to set `2` environment variables. 
-
-* One will be called `GH_PAT` and will be your **GitHub Personal Access Token**
-* The other will be called `ADO_PAT` and will be your **Azure DevOps Access Token** 
-
-The scope needed for each token will depend on what command(s) you want run. See the scenarios below to ensure you have properly scoped personal access tokens. It's recommended that you pick the scenario which fits the needs of everything you want to do as part of migrating. 
-
-#### I just want to run some migrations and grant/revoke the migrator role
-Create a GitHub and Azure DevOps personal access tokens with the scope defined in GEI's [documentation](https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer/migrating-to-github-enterprise-cloud-with-the-importer#step-2-assign-the-migration-permissions-role-and-ensure-the-migrator-has-the-expected-pat-scopes). This will allow you to run these commands:
-
-* generate-script (--repos-only)
-* migrate-repo
-* grant/revoke-migrator-role
-* create-team
-* add-team-to-repo
-* configure-autolink
-
-#### I want to do the above and also lock & disable the repository being migrated from Azure DevOps
-In order to use the following pre & post migration commands:
-
-* lock-ado-repo
-* disable-ado-repo
-* generate script (without the --repos-only flag)
-
-You will need to include these additional scopes for your Azure DevOps personal access token in addition to the ones listed in GEI's [documentation](https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer/migrating-to-github-enterprise-cloud-with-the-importer#step-2-assign-the-migration-permissions-role-and-ensure-the-migrator-has-the-expected-pat-scopes):
-
-* `Service Connection (Read)`
-* `Build (Read & execute)`
-* `Security (Manage)`
-* `Code (Read, write, and manage)`
-
-#### I want to do the above and also re-connect Azure Pipelines & Boards to the newly migrated repository on GitHub
-If you want to re-connect an Azure Pipline or Board to the migrated repo then you'll need your ADO personal access token to be `full access`.
-
-![image](https://user-images.githubusercontent.com/40493721/145903240-6a6d04cd-ba03-47f4-84aa-6af741a8ddd6.png)
-
-At this point, you can now begin to run and test the import process.
-
-#### Run the Migrations
-
-Once you have configured the `octoshift`(*gh-gei*) command-line tool and `environment variables` for the person access tokens, you can run the command-line tool and see all available options.
-![octoshift help](https://user-images.githubusercontent.com/29484535/145065029-ea8b3fcd-fcea-4f9b-ba7e-f9d3407e17fa.png)
-
-The first step you will want to run is `generate-script` to help outline all commands to migrate an entire **Azure Project**
-This command will generate a `migrate.ps1` file in the local folder. You will want to open it with an editor tool as it can be quite large. It's recommended that you include the `--repos-only` flag the first time. 
-Tools like `Atom`, `VSCode`, or `NotePad++` are great ways to see the data.
-
-You can then use this as a guide to pick and choose which commands you would like to run.
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The [GitHub Enterprise Importer](https://docs.github.com/en/early-access/github/
 > GEI is in a private preview for GitHub Enterprise Cloud. It needs to be enabled before using this CLI. Please reach out to [GitHub Sales](https://github.com/enterprise/contact) to enquire about getting into the private beta. 
 
 ## Using the GEI CLI
-There are 2 separate CLI's that we ship:
+There are 2 separate CLIs that we ship:
 - `gh gei` - Intended for running migrations from anywhere supported to GitHub.
 - `ado2gh` - Extends the basic migration support in `gh gei` to include extra commands such as re-wiring Azure Pipelines and configure Azure Boards integration post-migration.
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,6 @@ You'll find videos below to help you quickly get started with the GEI CLI. Be su
 
 >NOTE: We don't update these videos as often as we update the CLI, so they may not exactly match the functionality in the latest release of this CLI.
 
-### Migrating GitHub to GitHub
-The quick start video below will help you start migrating between GitHub organizations. 
-
-* Migrating GitHub to GitHub with the GEI CLI: https://youtu.be/5cQkM_8n5YY
-
 ### Migrating from Azure DevOps to GitHub
 Video guides below will help you get started with your first migration. Then help you build up to orchestrating a complete end-to-end production migration. 
 * Running your first few migrations: https://www.youtube.com/watch?v=yfnXbwtXY80

--- a/README.md
+++ b/README.md
@@ -7,19 +7,10 @@ The [GitHub Enterprise Importer](https://docs.github.com/en/early-access/github/
 
 > GEI is in a private preview for GitHub Enterprise Cloud. It needs to be enabled before using this CLI. Please reach out to [GitHub Sales](https://github.com/enterprise/contact) to enquire about getting into the private beta. 
 
-## Supported Scenarios
-GEI-CLI is continuing to expand what it can support. However, it supports the following scenarios at present:
-
-* Azure DevOps -> GitHub Enterprise Cloud migrations
-* GitHub Enterprise Cloud -> GitHub Enterprise Cloud migrations
-* GitHub Enterprise Server (version 3.4.1 or newer) -> GitHub Enterprise Cloud migrations
-
-Learn more about what exactly is migrated and any limitations in the [GEI documentation](https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer/about-github-enterprise-importer). 
-
 ## Using the GEI CLI
 There are 2 separate CLI's that we ship:
-- `ado2gh` - Intended for migrations from Azure DevOps -> GitHub
-- `gh gei` - Intended for GitHub -> GitHub migrations
+- `gh gei` - Indented for running migrations from anywhere supported to GitHub.
+- `ado2gh` - Extends the basic migration support in `gh gei` to include extra commands such as re-wiring Azure Pipelines and configure Azure Boards integration post-migration
 
 To use `ado2gh` download the latest version from the [Releases](https://github.com/github/gh-gei/releases/latest) in this repo.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ The [GitHub Enterprise Importer](https://docs.github.com/en/early-access/github/
 
 ## Using the GEI CLI
 There are 2 separate CLI's that we ship:
-- `gh gei` - Indented for running migrations from anywhere supported to GitHub.
-- `ado2gh` - Extends the basic migration support in `gh gei` to include extra commands such as re-wiring Azure Pipelines and configure Azure Boards integration post-migration
+- `gh gei` - Intended for running migrations from anywhere supported to GitHub.
+- `ado2gh` - Extends the basic migration support in `gh gei` to include extra commands such as re-wiring Azure Pipelines and configure Azure Boards integration post-migration.
 
 To use `ado2gh` download the latest version from the [Releases](https://github.com/github/gh-gei/releases/latest) in this repo.
 


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Issue #327 

Tried to keep the documentation in our readme to a bare minimum to minimize duplication with our official docs.

This will hopefully make it easier for us to keep our docs up to date as we roll out new features, as there will only be one place to change.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->