### PR TITLE
Add CLI's root and executing commands to user-agent header

### DIFF
--- a/src/Octoshift/AdoClient.cs
+++ b/src/Octoshift/AdoClient.cs
@@ -26,6 +26,10 @@ namespace OctoshiftCLI
                 var authToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{personalAccessToken}"));
                 _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", authToken);
                 _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OctoshiftCLI", versionProvider?.GetCurrentVersion()));
+                if (versionProvider?.GetVersionComments() is { } comments)
+                {
+                    _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(comments));
+                }
             }
         }
 

--- a/src/Octoshift/CliContext.cs
+++ b/src/Octoshift/CliContext.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace OctoshiftCLI
+{
+    public static class CliContext
+    {
+        private static string _rootCommand;
+        private static string _executingCommand;
+
+        public static string RootCommand
+        {
+            set => _rootCommand = _rootCommand is null
+                ? value
+                : throw new InvalidOperationException("Value can only be set once.");
+            get => _rootCommand;
+        }
+
+
+        public static string ExecutingCommand
+        {
+            set => _executingCommand = _executingCommand is null
+                ? value
+                : throw new InvalidOperationException("Value can only be set once.");
+            get => _executingCommand;
+        }
+    }
+}

--- a/src/Octoshift/CliContext.cs
+++ b/src/Octoshift/CliContext.cs
@@ -15,7 +15,6 @@ namespace OctoshiftCLI
             get => _rootCommand;
         }
 
-
         public static string ExecutingCommand
         {
             set => _executingCommand = _executingCommand is null

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -25,9 +25,13 @@ namespace OctoshiftCLI
             if (_httpClient != null)
             {
                 _httpClient.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
-                _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OctoshiftCLI", versionProvider?.GetCurrentVersion()));
                 _httpClient.DefaultRequestHeaders.Add("GraphQL-Features", "import_api,mannequin_claiming");
                 _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", personalAccessToken);
+                _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OctoshiftCLI", versionProvider?.GetCurrentVersion()));
+                if (versionProvider?.GetVersionComments() is { } comments)
+                {
+                    _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(comments));
+                }
             }
         }
 

--- a/src/Octoshift/IVersionProvider.cs
+++ b/src/Octoshift/IVersionProvider.cs
@@ -3,5 +3,6 @@
     public interface IVersionProvider
     {
         string GetCurrentVersion();
+        string GetVersionComments();
     }
 }

--- a/src/Octoshift/VersionChecker.cs
+++ b/src/Octoshift/VersionChecker.cs
@@ -12,20 +12,7 @@ namespace OctoshiftCLI
         private string _latestVersion;
         private readonly HttpClient _httpClient;
 
-        public VersionChecker(HttpClient httpClient)
-        {
-            _httpClient = httpClient;
-
-            if (_httpClient != null)
-            {
-                _httpClient.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
-                _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OctoshiftCLI", GetCurrentVersion()));
-                if (GetVersionComments() is { } comments)
-                {
-                    _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(comments));
-                }
-            }
-        }
+        public VersionChecker(HttpClient httpClient) => _httpClient = httpClient;
 
         public async Task<bool> IsLatest()
         {
@@ -51,6 +38,13 @@ namespace OctoshiftCLI
         {
             if (_latestVersion.IsNullOrWhiteSpace())
             {
+                _httpClient.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+                _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OctoshiftCLI", GetCurrentVersion()));
+                if (GetVersionComments() is { } comments)
+                {
+                    _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(comments));
+                }
+
                 const string url = "https://api.github.com/repos/github/gh-gei/releases/latest";
 
                 var response = await _httpClient.GetAsync(url);

--- a/src/Octoshift/VersionChecker.cs
+++ b/src/Octoshift/VersionChecker.cs
@@ -12,7 +12,20 @@ namespace OctoshiftCLI
         private string _latestVersion;
         private readonly HttpClient _httpClient;
 
-        public VersionChecker(HttpClient httpClient) => _httpClient = httpClient;
+        public VersionChecker(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+
+            if (_httpClient != null)
+            {
+                _httpClient.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+                _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OctoshiftCLI", GetCurrentVersion()));
+                if (GetVersionComments() is { } comments)
+                {
+                    _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(comments));
+                }
+            }
+        }
 
         public async Task<bool> IsLatest()
         {
@@ -38,10 +51,7 @@ namespace OctoshiftCLI
         {
             if (_latestVersion.IsNullOrWhiteSpace())
             {
-                _httpClient.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
-                _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OctoshiftCLI", GetCurrentVersion()));
-
-                var url = "https://api.github.com/repos/github/gh-gei/releases/latest";
+                const string url = "https://api.github.com/repos/github/gh-gei/releases/latest";
 
                 var response = await _httpClient.GetAsync(url);
                 response.EnsureSuccessStatusCode();

--- a/src/Octoshift/VersionChecker.cs
+++ b/src/Octoshift/VersionChecker.cs
@@ -29,6 +29,11 @@ namespace OctoshiftCLI
             return Assembly.GetExecutingAssembly().GetName().Version.ToString();
         }
 
+        public string GetVersionComments() =>
+            CliContext.RootCommand.HasValue() && CliContext.ExecutingCommand.HasValue()
+                ? $"({CliContext.RootCommand}/{CliContext.ExecutingCommand})"
+                : null;
+
         public async Task<string> GetLatestVersion()
         {
             if (_latestVersion.IsNullOrWhiteSpace())

--- a/src/OctoshiftCLI.Tests/AdoClientTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoClientTests.cs
@@ -990,6 +990,41 @@ namespace OctoshiftCLI.Tests
                 ItExpr.IsAny<CancellationToken>());
         }
 
+        [Fact]
+        public void It_Sets_User_Agent_Header_With_Comments()
+        {
+            // Arrange
+            const string currentVersion = "1.1.1.1";
+            const string versionComments = "(COMMENTS)";
+
+            using var httpClient = new HttpClient();
+
+            var mockVersionProvider = new Mock<IVersionProvider>();
+            mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+            mockVersionProvider.Setup(m => m.GetVersionComments()).Returns(versionComments);
+
+            // Act
+            _ = new AdoClient(null, httpClient, mockVersionProvider.Object, PERSONAL_ACCESS_TOKEN);
+
+            // Assert
+            httpClient.DefaultRequestHeaders.UserAgent.Should().HaveCount(2);
+            httpClient.DefaultRequestHeaders.UserAgent.ToString().Should().Be($"OctoshiftCLI/{currentVersion} {versionComments}");
+        }
+
+        [Fact]
+        public void It_Only_Sets_The_Product_Name_In_User_Agent_Header_When_Version_Provider_Is_Null()
+        {
+            // Arrange
+            using var httpClient = new HttpClient();
+
+            // Act
+            _ = new AdoClient(null, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            // Assert
+            httpClient.DefaultRequestHeaders.UserAgent.Should().HaveCount(1);
+            httpClient.DefaultRequestHeaders.UserAgent.ToString().Should().Be("OctoshiftCLI");
+        }
+
         private Mock<HttpMessageHandler> MockHttpHandlerForGet() =>
             MockHttpHandler(req => req.Method == HttpMethod.Get);
 

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -1440,6 +1440,41 @@ query($id: ID!, $first: Int, $after: String) {
                 .WithParameterName("pageInfoSelector");
         }
 
+        [Fact]
+        public void It_Sets_User_Agent_Header_With_Comments()
+        {
+            // Arrange
+            const string currentVersion = "1.1.1.1";
+            const string versionComments = "(COMMENTS)";
+
+            using var httpClient = new HttpClient();
+
+            var mockVersionProvider = new Mock<IVersionProvider>();
+            mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+            mockVersionProvider.Setup(m => m.GetVersionComments()).Returns(versionComments);
+
+            // Act
+            _ = new GithubClient(null, httpClient, mockVersionProvider.Object, PERSONAL_ACCESS_TOKEN);
+
+            // Assert
+            httpClient.DefaultRequestHeaders.UserAgent.Should().HaveCount(2);
+            httpClient.DefaultRequestHeaders.UserAgent.ToString().Should().Be($"OctoshiftCLI/{currentVersion} {versionComments}");
+        }
+
+        [Fact]
+        public void It_Only_Sets_The_Product_Name_In_User_Agent_Header_When_Version_Provider_Is_Null()
+        {
+            // Arrange
+            using var httpClient = new HttpClient();
+
+            // Act
+            _ = new GithubClient(null, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            // Assert
+            httpClient.DefaultRequestHeaders.UserAgent.Should().HaveCount(1);
+            httpClient.DefaultRequestHeaders.UserAgent.ToString().Should().Be("OctoshiftCLI");
+        }
+
         private object CreateRepositoryMigration(string migrationId = null, string state = RepositoryMigrationStatus.Succeeded) => new
         {
             id = migrationId ?? Guid.NewGuid().ToString(),

--- a/src/OctoshiftCLI.Tests/VersionCheckerTests.cs
+++ b/src/OctoshiftCLI.Tests/VersionCheckerTests.cs
@@ -1,0 +1,27 @@
+using FluentAssertions;
+using Xunit;
+
+namespace OctoshiftCLI.Tests
+{
+    public class VersionCheckerTests
+    {
+        [Fact]
+        public void GetVersionComments_Returns_Root_And_Executing_Commands()
+        {
+            // Arrange
+            const string rootCommand = "ROOT_COMMAND";
+            const string executingCommand = "EXECUTING_COMMAND";
+
+            CliContext.RootCommand = rootCommand;
+            CliContext.ExecutingCommand = executingCommand;
+
+            var versionChecker = new VersionChecker(null);
+
+            // Act
+            var comments = versionChecker.GetVersionComments();
+
+            // Assert
+            comments.Should().Be($"({rootCommand}/{executingCommand})");
+        }
+    }
+}

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -42,7 +42,15 @@ namespace OctoshiftCLI.AdoToGithub
                 Logger.LogVerbose(ex.ToString());
             }
 
+            SetContext(parser.Parse(args));
+
             await parser.InvokeAsync(args);
+        }
+
+        private static void SetContext(ParseResult parseResult)
+        {
+            CliContext.RootCommand = parseResult.RootCommandResult.Command.Name;
+            CliContext.ExecutingCommand = parseResult.CommandResult.Command.Name;
         }
 
         private static async Task LatestVersionCheck(ServiceProvider sp)

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -32,17 +32,17 @@ namespace OctoshiftCLI.AdoToGithub
             var serviceProvider = serviceCollection.BuildServiceProvider();
             var parser = BuildParser(serviceProvider);
 
+            SetContext(parser.Parse(args));
+
             try
             {
                 await LatestVersionCheck(serviceProvider);
             }
             catch (Exception ex)
             {
-                Logger.LogWarning($"Could not retrieve latest ado2gh version from github.com, please ensure you are using the latest version by downloading it from https://github.com/github/gh-gei/releases/latest");
+                Logger.LogWarning("Could not retrieve latest ado2gh version from github.com, please ensure you are using the latest version by downloading it from https://github.com/github/gh-gei/releases/latest");
                 Logger.LogVerbose(ex.ToString());
             }
-
-            SetContext(parser.Parse(args));
 
             await parser.InvokeAsync(args);
         }

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -49,17 +49,17 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
             var serviceProvider = serviceCollection.BuildServiceProvider();
             var parser = BuildParser(serviceProvider);
 
+            SetContext(parser.Parse(args));
+
             try
             {
                 await LatestVersionCheck(serviceProvider);
             }
             catch (Exception ex)
             {
-                Logger.LogWarning($"Could not retrieve latest gei CLI version from github.com, please ensure you are using the latest version by running: gh extension upgrade gei");
+                Logger.LogWarning("Could not retrieve latest gei CLI version from github.com, please ensure you are using the latest version by running: gh extension upgrade gei");
                 Logger.LogVerbose(ex.ToString());
             }
-
-            SetContext(parser.Parse(args));
 
             await parser.InvokeAsync(args);
         }

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -59,7 +59,15 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
                 Logger.LogVerbose(ex.ToString());
             }
 
+            SetContext(parser.Parse(args));
+
             await parser.InvokeAsync(args);
+        }
+
+        private static void SetContext(ParseResult parseResult)
+        {
+            CliContext.RootCommand = parseResult.RootCommandResult.Command.Name;
+            CliContext.ExecutingCommand = parseResult.CommandResult.Command.Name;
         }
 
         private static async Task LatestVersionCheck(ServiceProvider sp)


### PR DESCRIPTION
Closes #130 

This PR adds the following changes: 
1. `CliContext` that is supposed to have all CLI contextual data. The fields are all static and should be set in application entry point. 
2. CLI's root and executing commands were added to the `user-agent` header in `GithubClient` and `AdoClient`.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate) --> no need to update the release notes
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created) --> no doc updates