### PR TITLE
add inventory-report command

### DIFF
--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -21,6 +21,40 @@ namespace OctoshiftCLI
             _adoBaseUrl = adoServerUrl?.TrimEnd('/');
         }
 
+        public async Task<string> GetOrgOwner(string org)
+        {
+            var url = $"{_adoBaseUrl}/{org}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
+
+            var payload = new
+            {
+                contributionIds = new[]
+                {
+                    "ms.vss-admin-web.organization-admin-overview-delay-load-data-provider"
+                },
+                dataProviderContext = new
+                {
+                    properties = new
+                    {
+                        sourcePage = new
+                        {
+                            routeValues = new
+                            {
+                                adminPivot = "organizationOverview"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var response = await _client.PostAsync(url, payload);
+            var data = JObject.Parse(response);
+
+            var ownerName = (string)data["dataProviders"]["ms.vss-admin-web.organization-admin-overview-delay-load-data-provider"]["currentOwner"]["name"];
+            var ownerEmail = (string)data["dataProviders"]["ms.vss-admin-web.organization-admin-overview-delay-load-data-provider"]["currentOwner"]["email"];
+
+            return $"{ownerName} ({ownerEmail})";
+        }
+
         public virtual async Task<string> GetUserId()
         {
             var url = "https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=5.0-preview.1";

--- a/src/OctoshiftCLI.Tests/AdoApiTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoApiTests.cs
@@ -825,6 +825,47 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task GetOrgOwner_Returns_Owner()
+        {
+            var orgName = "FOO-ORG";
+            var ownerName = "Dave";
+            var ownerEmail = "dave@gmail.com";
+
+            var endpoint = $"https://dev.azure.com/{orgName}/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1";
+
+            var payload = new
+            {
+                contributionIds = new[]
+                {
+                    "ms.vss-admin-web.organization-admin-overview-delay-load-data-provider"
+                },
+                dataProviderContext = new
+                {
+                    properties = new
+                    {
+                        sourcePage = new
+                        {
+                            routeValues = new
+                            {
+                                adminPivot = "organizationOverview"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var json = $@"{{ dataProviders: {{ ""ms.vss-admin-web.organization-admin-overview-delay-load-data-provider"": {{ currentOwner: {{ name: '{ownerName}', email: '{ownerEmail}' }} }} }} }}";
+
+            var mockClient = TestHelpers.CreateMock<AdoClient>();
+            mockClient.Setup(m => m.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson()))).ReturnsAsync(json);
+
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var result = await sut.GetOrgOwner(orgName);
+
+            result.Should().Be($"{ownerName} ({ownerEmail})");
+        }
+
+        [Fact]
         public async Task DisableRepo_Should_Send_Correct_Payload()
         {
             var orgName = "foo-org";

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using OctoshiftCLI.AdoToGithub;
+using OctoshiftCLI.AdoToGithub.Commands;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+{
+    public class InventoryReportCommandTests
+    {
+        [Fact]
+        public void Should_Have_Options()
+        {
+            var command = new InventoryReportCommand(null, null, null);
+            Assert.NotNull(command);
+            Assert.Equal("inventory-report", command.Name);
+            Assert.Equal(3, command.Options.Count);
+
+            TestHelpers.VerifyCommandOption(command.Options, "ado-org", false);
+            TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
+            TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+        }
+
+        [Fact]
+        public async Task Happy_Path()
+        {
+            var adoOrg = "FooOrg";
+            var orgs = new List<string>() { adoOrg };
+            var userId = Guid.NewGuid().ToString();
+            var csvContent = "csv stuff";
+
+            var mockAdo = TestHelpers.CreateMock<AdoApi>();
+            mockAdo.Setup(x => x.GetUserId()).ReturnsAsync(userId);
+            mockAdo.Setup(x => x.GetOrganizations(userId)).ReturnsAsync(orgs);
+
+            var mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
+            mockAdoApiFactory.Setup(m => m.Create(null)).Returns(mockAdo.Object);
+
+            var mockOrgsCsvGenerator = TestHelpers.CreateMock<OrgsCsvGeneratorService>();
+            mockOrgsCsvGenerator.Setup(m => m.Generate(mockAdo.Object, orgs)).ReturnsAsync(csvContent);
+
+            var script = "";
+
+            var command = new InventoryReportCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockAdoApiFactory.Object, mockOrgsCsvGenerator.Object)
+            {
+                WriteToFile = (_, contents) =>
+                {
+                    script = contents;
+                    return Task.CompletedTask;
+                }
+            };
+
+            await command.Invoke(null);
+
+            script.Should().Be(csvContent);
+        }
+
+        [Fact]
+        public async Task Scoped_To_Single_Org()
+        {
+            var adoOrg = "FooOrg";
+            var orgs = new List<string>() { adoOrg };
+            var userId = Guid.NewGuid().ToString();
+            var csvContent = "csv stuff";
+
+            var mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
+            mockAdoApiFactory.Setup(m => m.Create(null)).Returns((AdoApi)null);
+
+            var mockOrgsCsvGenerator = TestHelpers.CreateMock<OrgsCsvGeneratorService>();
+            mockOrgsCsvGenerator.Setup(m => m.Generate(null, orgs)).ReturnsAsync(csvContent);
+
+            var script = "";
+
+            var command = new InventoryReportCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockAdoApiFactory.Object, mockOrgsCsvGenerator.Object)
+            {
+                WriteToFile = (_, contents) =>
+                {
+                    script = contents;
+                    return Task.CompletedTask;
+                }
+            };
+
+            await command.Invoke(adoOrg);
+
+            script.Should().Be(csvContent);
+        }
+
+        [Fact]
+        public async Task It_Uses_The_Ado_Pat_When_Provided()
+        {
+            const string adoPat = "ado-pat";
+
+            var mockAdo = TestHelpers.CreateMock<AdoApi>();
+            var mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
+            var mockOrgsCsvGeneratorService = TestHelpers.CreateMock<OrgsCsvGeneratorService>();
+
+            var command = new InventoryReportCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockAdoApiFactory.Object, mockOrgsCsvGeneratorService.Object);
+            await command.Invoke("some org", adoPat);
+
+            mockAdoApiFactory.Verify(m => m.Create(adoPat));
+        }
+    }
+}

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -4,12 +4,10 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using OctoshiftCLI.Extensions;
 
-[assembly: InternalsVisibleTo("OctoshiftCLI.Tests")]
 namespace OctoshiftCLI.AdoToGithub.Commands
 {
     public class GenerateScriptCommand : Command

--- a/src/ado2gh/Commands/InventoryReportCommand.cs
+++ b/src/ado2gh/Commands/InventoryReportCommand.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace OctoshiftCLI.AdoToGithub.Commands
+{
+    public class InventoryReportCommand : Command
+    {
+        internal Func<string, string, Task> WriteToFile = async (path, contents) => await File.WriteAllTextAsync(path, contents);
+
+        private readonly OctoLogger _log;
+        private readonly AdoApiFactory _adoApiFactory;
+        private readonly OrgsCsvGeneratorService _orgsCsvGenerator;
+
+        public InventoryReportCommand(OctoLogger log, AdoApiFactory adoApiFactory, OrgsCsvGeneratorService orgsCsvGeneratorService) : base("inventory-report")
+        {
+            _log = log;
+            _adoApiFactory = adoApiFactory;
+            _orgsCsvGenerator = orgsCsvGeneratorService;
+
+            Description = "Generates several CSV files containing lists of ADO orgs, team projects, repos, and pipelines. Useful for planning large migrations. The repos.csv can be fed as an input into other commands to help splitting large migrations up into batches.";
+            Description += Environment.NewLine;
+            Description += "Note: Expects ADO_PAT env variable or --ado-pat option to be set.";
+
+            IsHidden = true;
+
+            var adoOrg = new Option<string>("--ado-org")
+            {
+                IsRequired = false,
+                Description = "If not provided will iterate over all orgs that ADO_PAT has access to."
+            };
+            var adoPat = new Option<string>("--ado-pat")
+            {
+                IsRequired = false
+            };
+            var verbose = new Option("--verbose")
+            {
+                IsRequired = false
+            };
+
+            AddOption(adoOrg);
+            AddOption(adoPat);
+            AddOption(verbose);
+
+            Handler = CommandHandler.Create<string, string, bool>(Invoke);
+        }
+
+        public async Task Invoke(string adoOrg, string adoPat = null, bool verbose = false)
+        {
+            _log.Verbose = verbose;
+
+            _log.LogInformation("Creating inventory report...");
+
+            if (!string.IsNullOrWhiteSpace(adoOrg))
+            {
+                _log.LogInformation($"ADO ORG: {adoOrg}");
+            }
+
+            if (adoPat is not null)
+            {
+                _log.LogInformation("ADO PAT: ***");
+            }
+
+            var ado = _adoApiFactory.Create(adoPat);
+
+            var orgs = new List<string>() { adoOrg };
+
+            if (string.IsNullOrWhiteSpace(adoOrg))
+            {
+                var userId = await ado.GetUserId();
+                orgs = (await ado.GetOrganizations(userId)).ToList();
+            }
+
+            var orgsCsvText = await _orgsCsvGenerator.Generate(ado, orgs);
+
+            await WriteToFile("orgs.csv", orgsCsvText);
+            _log.LogSuccess("orgs.csv generated");
+        }
+    }
+}

--- a/src/ado2gh/OrgsCsvGeneratorService.cs
+++ b/src/ado2gh/OrgsCsvGeneratorService.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OctoshiftCLI.AdoToGithub
+{
+    public class OrgsCsvGeneratorService
+    {
+        public virtual async Task<string> Generate(AdoApi ado, IEnumerable<string> orgs)
+        {
+            var result = new StringBuilder();
+
+            result.AppendLine("name,owner");
+
+            if (ado != null && orgs != null)
+            {
+                foreach (var org in orgs)
+                {
+                    var owner = await ado.GetOrgOwner(org);
+                    result.AppendLine($"{org},{owner}");
+                }
+            }
+
+            return result.ToString();
+        }
+    }
+}

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -4,10 +4,12 @@ using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using OctoshiftCLI.AdoToGithub.Commands;
 
+[assembly: InternalsVisibleTo("OctoshiftCLI.Tests")]
 namespace OctoshiftCLI.AdoToGithub
 {
     public static class Program
@@ -26,6 +28,7 @@ namespace OctoshiftCLI.AdoToGithub
                 .AddSingleton<GithubApiFactory>()
                 .AddSingleton<RetryPolicy>()
                 .AddSingleton<VersionChecker>()
+                .AddSingleton<OrgsCsvGeneratorService>()
                 .AddSingleton<IVersionProvider, VersionChecker>(sp => sp.GetRequiredService<VersionChecker>())
                 .AddHttpClient();
 

--- a/src/gei/gei.csproj
+++ b/src/gei/gei.csproj
@@ -18,8 +18,4 @@
     <ProjectReference Include="..\Octoshift\Octoshift.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Issue #310 

Added `inventory-report` command. For now it only generates an orgs.csv with org name and org owner. If you don't provide `--ado-org` it will include all orgs the PAT has access to.

For now the command is hidden until we get a bit more functionality added in future PR's.

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->