### PR TITLE
fix: Prefer DateTime.UtcNow instead of DateTime.Now

### DIFF
--- a/src/Octoshift/OctoLogger.cs
+++ b/src/Octoshift/OctoLogger.cs
@@ -29,7 +29,7 @@ namespace OctoshiftCLI
 
         public OctoLogger()
         {
-            var logStartTime = DateTime.Now;
+            var logStartTime = DateTime.UtcNow;
             _logFilePath = $"{logStartTime:yyyyMMddHHmmss}.octoshift.log";
             _verboseFilePath = $"{logStartTime:yyyyMMddHHmmss}.octoshift.verbose.log";
 
@@ -63,7 +63,7 @@ namespace OctoshiftCLI
             _writeToVerboseLog(output);
         }
 
-        private string FormatMessage(string msg, string level) => $"[{DateTime.Now.ToShortTimeString()}] [{level}] {msg}\n";
+        private string FormatMessage(string msg, string level) => $"[{DateTime.UtcNow.ToShortTimeString()}] [{level}] {msg}\n";
 
         private string MaskSecrets(string msg)
         {

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -314,7 +314,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var metadataArchiveUrl = await WaitForArchiveGeneration(ghesApi, githubSourceOrg, metadataArchiveId);
             _log.LogInformation($"Archive (metadata) download url: {metadataArchiveUrl}");
 
-            var timeNow = $"{DateTime.Now:yyyy-MM-dd_HH-mm-ss}";
+            var timeNow = $"{DateTime.UtcNow:yyyy-MM-dd_HH-mm-ss}";
 
             var gitArchiveFileName = $"{timeNow}-{gitDataArchiveId}-{GIT_ARCHIVE_FILE_NAME}";
             var metadataArchiveFileName = $"{timeNow}-{metadataArchiveId}-{METADATA_ARCHIVE_FILE_NAME}";
@@ -334,8 +334,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
         private async Task<string> WaitForArchiveGeneration(GithubApi githubApi, string githubSourceOrg, int archiveId)
         {
-            var timeout = DateTime.Now.AddHours(ARCHIVE_GENERATION_TIMEOUT_IN_HOURS);
-            while (DateTime.Now < timeout)
+            var timeout = DateTime.UtcNow.AddHours(ARCHIVE_GENERATION_TIMEOUT_IN_HOURS);
+            while (DateTime.UtcNow < timeout)
             {
                 var archiveStatus = await githubApi.GetArchiveMigrationStatus(githubSourceOrg, archiveId);
                 _log.LogInformation($"Waiting for archive with id {archiveId} generation to finish. Current status: {archiveStatus}");


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [X] Did you write/update appropriate tests
- [X] Release notes updated (if appropriate)
- [X] Appropriate logging output
- [X] Issue linked
- [X] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->

### Explanation / Reason behind this PR
We should prefer the use of `DateTime.UtcNow`  instead of `DateTime.Now`. Even tho I prefer UtcNow vs Now, I still do not recommend the use of this struct across the codebase. As a better solution, e.g., a wrapper (like an interface IDateTimeProvider) might be added as a singleton service. That way we could properly unit test our codebase. WDYT?

### Further Details
While I was studying this solution, I did some improvements that you may want to benefit from. If it doesn't add value to your project feel free to close the PR 👍 