### PR TITLE
rename: Added Async suffix to GitHubApi methods

### DIFF
--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -24,7 +24,7 @@ namespace OctoshiftCLI
             _retryPolicy = retryPolicy;
         }
 
-        public virtual async Task AddAutoLink(string org, string repo, string keyPrefix, string urlTemplate)
+        public virtual async Task AddAutoLinkAsync(string org, string repo, string keyPrefix, string urlTemplate)
         {
             if (string.IsNullOrWhiteSpace(keyPrefix))
             {
@@ -46,7 +46,7 @@ namespace OctoshiftCLI
             await _client.PostAsync(url, payload);
         }
 
-        public virtual async Task<List<(int Id, string KeyPrefix, string UrlTemplate)>> GetAutoLinks(string org, string repo)
+        public virtual async Task<List<(int Id, string KeyPrefix, string UrlTemplate)>> GetAutoLinksAsync(string org, string repo)
         {
             var url = $"{_apiUrl}/repos/{org}/{repo}/autolinks";
 
@@ -55,14 +55,14 @@ namespace OctoshiftCLI
                                 .ToListAsync();
         }
 
-        public virtual async Task DeleteAutoLink(string org, string repo, int autoLinkId)
+        public virtual async Task DeleteAutoLinkAsync(string org, string repo, int autoLinkId)
         {
             var url = $"{_apiUrl}/repos/{org}/{repo}/autolinks/{autoLinkId}";
 
             await _client.DeleteAsync(url);
         }
 
-        public virtual async Task<string> CreateTeam(string org, string teamName)
+        public virtual async Task<string> CreateTeamAsync(string org, string teamName)
         {
             var url = $"{_apiUrl}/orgs/{org}/teams";
             var payload = new { name = teamName, privacy = "closed" };
@@ -73,7 +73,7 @@ namespace OctoshiftCLI
             return (string)data["id"];
         }
 
-        public virtual async Task<IEnumerable<string>> GetTeams(string org)
+        public virtual async Task<IEnumerable<string>> GetTeamsAsync(string org)
         {
             var url = $"{_apiUrl}/orgs/{org}/teams";
 
@@ -82,7 +82,7 @@ namespace OctoshiftCLI
                 .ToListAsync();
         }
 
-        public virtual async Task<IEnumerable<string>> GetTeamMembers(string org, string teamSlug)
+        public virtual async Task<IEnumerable<string>> GetTeamMembersAsync(string org, string teamSlug)
         {
             var url = $"{_apiUrl}/orgs/{org}/teams/{teamSlug}/members?per_page=100";
 
@@ -90,21 +90,21 @@ namespace OctoshiftCLI
                                             ex => ex.StatusCode == HttpStatusCode.NotFound);
         }
 
-        public virtual async Task<IEnumerable<string>> GetRepos(string org)
+        public virtual async Task<IEnumerable<string>> GetReposAsync(string org)
         {
             var url = $"{_apiUrl}/orgs/{org}/repos?per_page=100";
 
             return await _client.GetAllAsync(url).Select(x => (string)x["name"]).ToListAsync();
         }
 
-        public virtual async Task RemoveTeamMember(string org, string teamSlug, string member)
+        public virtual async Task RemoveTeamMemberAsync(string org, string teamSlug, string member)
         {
             var url = $"{_apiUrl}/orgs/{org}/teams/{teamSlug}/memberships/{member}";
 
             await _client.DeleteAsync(url);
         }
 
-        public virtual async Task AddTeamSync(string org, string teamName, string groupId, string groupName, string groupDesc)
+        public virtual async Task AddTeamSyncAsync(string org, string teamName, string groupId, string groupName, string groupDesc)
         {
             var url = $"{_apiUrl}/orgs/{org}/teams/{teamName}/team-sync/group-mappings";
             var payload = new
@@ -118,7 +118,7 @@ namespace OctoshiftCLI
             await _client.PatchAsync(url, payload);
         }
 
-        public virtual async Task AddTeamToRepo(string org, string repo, string teamSlug, string role)
+        public virtual async Task AddTeamToRepoAsync(string org, string repo, string teamSlug, string role)
         {
             var url = $"{_apiUrl}/orgs/{org}/teams/{teamSlug}/repos/{org}/{repo}";
             var payload = new { permission = role };
@@ -126,7 +126,7 @@ namespace OctoshiftCLI
             await _client.PutAsync(url, payload);
         }
 
-        public virtual async Task<string> GetOrganizationId(string org)
+        public virtual async Task<string> GetOrganizationIdAsync(string org)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -143,7 +143,7 @@ namespace OctoshiftCLI
             return (string)data["data"]["organization"]["id"];
         }
 
-        public virtual async Task<string> CreateAdoMigrationSource(string orgId, string adoServerUrl)
+        public virtual async Task<string> CreateAdoMigrationSourceAsync(string orgId, string adoServerUrl)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -171,7 +171,7 @@ namespace OctoshiftCLI
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
 
-        public virtual async Task<string> CreateGhecMigrationSource(string orgId)
+        public virtual async Task<string> CreateGhecMigrationSourceAsync(string orgId)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -197,7 +197,7 @@ namespace OctoshiftCLI
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
 
-        public virtual async Task<string> StartMigration(string migrationSourceId, string sourceRepoUrl, string orgId, string repo, string sourceToken, string targetToken, string gitArchiveUrl = null, string metadataArchiveUrl = null, bool skipReleases = false)
+        public virtual async Task<string> StartMigrationAsync(string migrationSourceId, string sourceRepoUrl, string orgId, string repo, string sourceToken, string targetToken, string gitArchiveUrl = null, string metadataArchiveUrl = null, bool skipReleases = false)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -266,7 +266,7 @@ namespace OctoshiftCLI
             return (string)data["data"]["startRepositoryMigration"]["repositoryMigration"]["id"];
         }
 
-        public virtual async Task<string> GetMigrationState(string migrationId)
+        public virtual async Task<string> GetMigrationStateAsync(string migrationId)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -282,7 +282,7 @@ namespace OctoshiftCLI
             return (string)data["data"]["node"]["state"];
         }
 
-        public virtual async Task<IEnumerable<(string MigrationId, string State)>> GetMigrationStates(string orgId)
+        public virtual async Task<IEnumerable<(string MigrationId, string State)>> GetMigrationStatesAsync(string orgId)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -325,7 +325,7 @@ namespace OctoshiftCLI
                 .ToListAsync();
         }
 
-        public virtual async Task<string> GetMigrationFailureReason(string migrationId)
+        public virtual async Task<string> GetMigrationFailureReasonAsync(string migrationId)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -341,7 +341,7 @@ namespace OctoshiftCLI
             return (string)data["data"]["node"]["failureReason"];
         }
 
-        public virtual async Task<int> GetIdpGroupId(string org, string groupName)
+        public virtual async Task<int> GetIdpGroupIdAsync(string org, string groupName)
         {
             var url = $"{_apiUrl}/orgs/{org}/external-groups";
 
@@ -352,7 +352,7 @@ namespace OctoshiftCLI
             return (int)data["groups"].Children().Single(x => ((string)x["group_name"]).ToUpper() == groupName.ToUpper())["group_id"];
         }
 
-        public virtual async Task<string> GetTeamSlug(string org, string teamName)
+        public virtual async Task<string> GetTeamSlugAsync(string org, string teamName)
         {
             var url = $"{_apiUrl}/orgs/{org}/teams";
 
@@ -362,7 +362,7 @@ namespace OctoshiftCLI
             return (string)response["slug"];
         }
 
-        public virtual async Task AddEmuGroupToTeam(string org, string teamSlug, int groupId)
+        public virtual async Task AddEmuGroupToTeamAsync(string org, string teamSlug, int groupId)
         {
             var url = $"{_apiUrl}/orgs/{org}/teams/{teamSlug}/external-groups";
             var payload = new { group_id = groupId };
@@ -370,7 +370,7 @@ namespace OctoshiftCLI
             await _client.PatchAsync(url, payload);
         }
 
-        public virtual async Task<bool> GrantMigratorRole(string org, string actor, string actorType)
+        public virtual async Task<bool> GrantMigratorRoleAsync(string org, string actor, string actorType)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -397,7 +397,7 @@ namespace OctoshiftCLI
             }
         }
 
-        public virtual async Task<bool> RevokeMigratorRole(string org, string actor, string actorType)
+        public virtual async Task<bool> RevokeMigratorRoleAsync(string org, string actor, string actorType)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -424,13 +424,13 @@ namespace OctoshiftCLI
             }
         }
 
-        public virtual async Task DeleteRepo(string org, string repo)
+        public virtual async Task DeleteRepoAsync(string org, string repo)
         {
             var url = $"{_apiUrl}/repos/{org}/{repo}";
             await _client.DeleteAsync(url);
         }
 
-        public virtual async Task<int> StartGitArchiveGeneration(string org, string repo)
+        public virtual async Task<int> StartGitArchiveGenerationAsync(string org, string repo)
         {
             var url = $"{_apiUrl}/orgs/{org}/migrations";
 
@@ -445,7 +445,7 @@ namespace OctoshiftCLI
             return (int)data["id"];
         }
 
-        public virtual async Task<int> StartMetadataArchiveGeneration(string org, string repo)
+        public virtual async Task<int> StartMetadataArchiveGenerationAsync(string org, string repo)
         {
             var url = $"{_apiUrl}/orgs/{org}/migrations";
 
@@ -462,7 +462,7 @@ namespace OctoshiftCLI
             return (int)data["id"];
         }
 
-        public virtual async Task<string> GetArchiveMigrationStatus(string org, int migrationId)
+        public virtual async Task<string> GetArchiveMigrationStatusAsync(string org, int migrationId)
         {
             var url = $"{_apiUrl}/orgs/{org}/migrations/{migrationId}";
 
@@ -472,7 +472,7 @@ namespace OctoshiftCLI
             return (string)data["state"];
         }
 
-        public virtual async Task<string> GetArchiveMigrationUrl(string org, int migrationId)
+        public virtual async Task<string> GetArchiveMigrationUrlAsync(string org, int migrationId)
         {
             var url = $"{_apiUrl}/orgs/{org}/migrations/{migrationId}/archive";
 
@@ -480,7 +480,7 @@ namespace OctoshiftCLI
             return response;
         }
 
-        public virtual async Task<IEnumerable<Mannequin>> GetMannequins(string orgId)
+        public virtual async Task<IEnumerable<Mannequin>> GetMannequinsAsync(string orgId)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -495,7 +495,7 @@ namespace OctoshiftCLI
                 .ToListAsync();
         }
 
-        public virtual async Task<string> GetUserId(string login)
+        public virtual async Task<string> GetUserIdAsync(string login)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -511,7 +511,7 @@ namespace OctoshiftCLI
             return data["data"]["user"].Any() ? (string)data["data"]["user"]["id"] : null;
         }
 
-        public virtual async Task<MannequinReclaimResult> ReclaimMannequin(string orgId, string mannequinId, string targetUserId)
+        public virtual async Task<MannequinReclaimResult> ReclaimMannequinAsync(string orgId, string mannequinId, string targetUserId)
         {
             var url = $"{_apiUrl}/graphql";
             var mutation = "mutation($orgId: ID!,$sourceId: ID!,$targetId: ID!)";

--- a/src/Octoshift/ReclaimService.cs
+++ b/src/Octoshift/ReclaimService.cs
@@ -83,7 +83,7 @@ namespace Octoshift
 
         public virtual async Task ReclaimMannequin(string mannequinUser, string mannequinId, string targetUser, string githubOrg, bool force)
         {
-            var githubOrgId = await _githubApi.GetOrganizationId(githubOrg);
+            var githubOrgId = await _githubApi.GetOrganizationIdAsync(githubOrg);
 
             var mannequins = new Mannequins((await GetMannequins(githubOrgId)).GetByLogin(mannequinUser, mannequinId));
             if (mannequins.IsEmpty())
@@ -98,7 +98,7 @@ namespace Octoshift
                 throw new OctoshiftCliException($"User {mannequinUser} is already mapped to a user. Use the force option if you want to reclaim the mannequin again.");
             }
 
-            var targetUserId = await _githubApi.GetUserId(targetUser);
+            var targetUserId = await _githubApi.GetUserIdAsync(targetUser);
             if (targetUserId == null)
             {
                 throw new OctoshiftCliException($"Target user {targetUser} not found.");
@@ -109,7 +109,7 @@ namespace Octoshift
             // get all unique mannequins by login and id and map them all to the same target
             foreach (var mannequin in mannequins.GetUniqueUsers())
             {
-                var result = await _githubApi.ReclaimMannequin(githubOrgId, mannequin.Id, targetUserId);
+                var result = await _githubApi.ReclaimMannequinAsync(githubOrgId, mannequin.Id, targetUserId);
 
                 success &= HandleResult(mannequinUser, targetUser, mannequin, targetUserId, result);
             }
@@ -139,7 +139,7 @@ namespace Octoshift
                 throw new OctoshiftCliException($"Invalid Header. Should be: {CSVHEADER}");
             }
 
-            var githubOrgId = await _githubApi.GetOrganizationId(githubTargetOrg);
+            var githubOrgId = await _githubApi.GetOrganizationIdAsync(githubTargetOrg);
 
             var mannequins = await GetMannequins(githubOrgId);
 
@@ -166,7 +166,7 @@ namespace Octoshift
                     continue;
                 }
 
-                var claimantId = await _githubApi.GetUserId(claimantLogin);
+                var claimantId = await _githubApi.GetUserIdAsync(claimantLogin);
 
                 if (claimantId == null)
                 {
@@ -174,7 +174,7 @@ namespace Octoshift
                     continue;
                 }
 
-                var result = await _githubApi.ReclaimMannequin(githubOrgId, userid, claimantId);
+                var result = await _githubApi.ReclaimMannequinAsync(githubOrgId, userid, claimantId);
 
                 HandleResult(login, claimantLogin, mannequin, claimantId, result);
             }
@@ -182,7 +182,7 @@ namespace Octoshift
 
         private async Task<Mannequins> GetMannequins(string githubOrgId)
         {
-            var returnedMannequins = await _githubApi.GetMannequins(githubOrgId);
+            var returnedMannequins = await _githubApi.GetMannequinsAsync(githubOrgId);
 
             return new Mannequins(returnedMannequins);
         }

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -77,12 +77,12 @@ namespace OctoshiftCLI.IntegrationTests
 
         public async Task ResetGithubTestEnvironment(string githubOrg)
         {
-            var githubRepos = await _githubApi.GetRepos(githubOrg);
+            var githubRepos = await _githubApi.GetReposAsync(githubOrg);
 
             foreach (var repo in githubRepos)
             {
                 _output.WriteLine($"Deleting GitHub repo: {githubOrg}\\{repo}...");
-                await _githubApi.DeleteRepo(githubOrg, repo);
+                await _githubApi.DeleteRepoAsync(githubOrg, repo);
             }
 
             var githubTeams = await GetTeamSlugs(githubOrg);
@@ -488,7 +488,7 @@ steps:
         public async Task AssertGithubRepoExists(string githubOrg, string repo)
         {
             _output.WriteLine("Checking that the repos in GitHub exist...");
-            var repos = await _githubApi.GetRepos(githubOrg);
+            var repos = await _githubApi.GetReposAsync(githubOrg);
             repos.Should().Contain(repo);
         }
 
@@ -541,7 +541,7 @@ steps:
         {
             _output.WriteLine("Checking that the GitHub teams are linked to IdP groups...");
 
-            var teamSlug = await _githubApi.GetTeamSlug(githubOrg, teamName);
+            var teamSlug = await _githubApi.GetTeamSlugAsync(githubOrg, teamName);
             var idp = await GetTeamIdPGroup(githubOrg, teamSlug);
             idp.ToLower().Should().Be(idpGroup?.ToLower());
         }
@@ -550,7 +550,7 @@ steps:
         {
             _output.WriteLine("Checking that the GitHub teams have repo permissions...");
 
-            var teamSlug = await _githubApi.GetTeamSlug(githubOrg, teamName);
+            var teamSlug = await _githubApi.GetTeamSlugAsync(githubOrg, teamName);
             var actualRole = await GetTeamRepoRole(githubOrg, teamSlug, repo);
             actualRole.Should().Be(role);
         }

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -20,7 +20,7 @@ namespace OctoshiftCLI.Tests
         private readonly RetryPolicy _retryPolicy = new RetryPolicy(TestHelpers.CreateMock<OctoLogger>().Object);
 
         [Fact]
-        public async Task AddAutoLink_Calls_The_Right_Endpoint_With_Payload()
+        public async Task AddAutoLinkAsync_Calls_The_Right_Endpoint_With_Payload()
         {
             // Arrange
             const string org = "ORG";
@@ -43,14 +43,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            await githubApi.AddAutoLink(org, repo, keyPrefix, urlTemplate);
+            await githubApi.AddAutoLinkAsync(org, repo, keyPrefix, urlTemplate);
 
             // Assert
             githubClientMock.Verify(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
         }
 
         [Fact]
-        public async Task AddAutoLink_Replaces_Spaces_In_Url_Tempalte()
+        public async Task AddAutoLinkAsync_Replaces_Spaces_In_Url_Tempalte()
         {
             // Arrange
             const string org = "ORG";
@@ -73,14 +73,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            await githubApi.AddAutoLink(org, repo, keyPrefix, urlTemplate);
+            await githubApi.AddAutoLinkAsync(org, repo, keyPrefix, urlTemplate);
 
             // Assert
             githubClientMock.Verify(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
         }
 
         [Fact]
-        public async Task GetAutoLinks_Calls_The_Right_Endpoint()
+        public async Task GetAutoLinksAsync_Calls_The_Right_Endpoint()
         {
             // Arrange
             const string org = "ORG";
@@ -92,14 +92,14 @@ namespace OctoshiftCLI.Tests
             githubClientMock.Setup(x => x.GetAllAsync(It.IsAny<string>())).Returns(AsyncEnumerable.Empty<JToken>());
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            await githubApi.GetAutoLinks(org, repo);
+            await githubApi.GetAutoLinksAsync(org, repo);
 
             // Assert
             githubClientMock.Verify(m => m.GetAllAsync(url));
         }
 
         [Fact]
-        public async Task DeleteAutoLink_Calls_The_Right_Endpoint()
+        public async Task DeleteAutoLinkAsync_Calls_The_Right_Endpoint()
         {
             // Arrange
             const string org = "ORG";
@@ -111,14 +111,14 @@ namespace OctoshiftCLI.Tests
             var githubClientMock = TestHelpers.CreateMock<GithubClient>();
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            await githubApi.DeleteAutoLink(org, repo, autoLinkId);
+            await githubApi.DeleteAutoLinkAsync(org, repo, autoLinkId);
 
             // Assert
             githubClientMock.Verify(m => m.DeleteAsync(url));
         }
 
         [Fact]
-        public async Task CreateTeam_Returns_Created_Team_Id()
+        public async Task CreateTeamAsync_Returns_Created_Team_Id()
         {
             // Arrange
             const string org = "ORG";
@@ -137,14 +137,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var result = await githubApi.CreateTeam(org, teamName);
+            var result = await githubApi.CreateTeamAsync(org, teamName);
 
             // Assert
             result.Should().Be(teamId);
         }
 
         [Fact]
-        public async Task GetTeams_Returns_All_Teams()
+        public async Task GetTeamsAsync_Returns_All_Teams()
         {
             // Arrange
             const string org = "ORG";
@@ -171,7 +171,7 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var result = (await githubApi.GetTeams(org)).ToArray();
+            var result = (await githubApi.GetTeamsAsync(org)).ToArray();
 
             // Assert
             result.Should().HaveCount(4);
@@ -179,7 +179,7 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task GetTeamMembers_Returns_Team_Members()
+        public async Task GetTeamMembersAsync_Returns_Team_Members()
         {
             // Arrange
             const string org = "ORG";
@@ -235,7 +235,7 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var result = (await githubApi.GetTeamMembers(org, teamName)).ToArray();
+            var result = (await githubApi.GetTeamMembersAsync(org, teamName)).ToArray();
 
             // Assert
             result.Should().HaveCount(4);
@@ -243,7 +243,7 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task GetTeamMembers_Retries_On_404()
+        public async Task GetTeamMembersAsync_Retries_On_404()
         {
             // Arrange
             const string org = "ORG";
@@ -263,14 +263,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var result = (await githubApi.GetTeamMembers(org, teamName)).ToArray();
+            var result = (await githubApi.GetTeamMembersAsync(org, teamName)).ToArray();
 
             // Assert
             result.Should().HaveCount(1);
         }
 
         [Fact]
-        public async Task GetRepos_Returns_Names_Of_All_Repositories()
+        public async Task GetReposAsync_Returns_Names_Of_All_Repositories()
         {
             // Arrange
             const string org = "ORG";
@@ -324,7 +324,7 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var result = (await githubApi.GetRepos(org)).ToArray();
+            var result = (await githubApi.GetReposAsync(org)).ToArray();
 
             // Assert
             result.Should().HaveCount(4);
@@ -332,7 +332,7 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task RemoveTeamMember_Calls_The_Right_Endpoint()
+        public async Task RemoveTeamMemberAsync_Calls_The_Right_Endpoint()
         {
             // Arrange
             const string org = "ORG";
@@ -346,14 +346,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            await githubApi.RemoveTeamMember(org, teamName, member);
+            await githubApi.RemoveTeamMemberAsync(org, teamName, member);
 
             // Assert
             githubClientMock.Verify(m => m.DeleteAsync(url));
         }
 
         [Fact]
-        public async Task AddTeamSync_Calls_The_Right_Endpoint_With_Payload()
+        public async Task AddTeamSyncAsync_Calls_The_Right_Endpoint_With_Payload()
         {
             // Arrange
             const string org = "ORG";
@@ -372,14 +372,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            await githubApi.AddTeamSync(org, teamName, groupId, groupName, groupDesc);
+            await githubApi.AddTeamSyncAsync(org, teamName, groupId, groupName, groupDesc);
 
             // Assert
             githubClientMock.Verify(m => m.PatchAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
         }
 
         [Fact]
-        public async Task AddTeamToRepo_Calls_The_Right_Endpoint_With_Payload()
+        public async Task AddTeamToRepoAsync_Calls_The_Right_Endpoint_With_Payload()
         {
             // Arrange
             const string org = "ORG";
@@ -394,14 +394,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            await githubApi.AddTeamToRepo(org, repo, teamName, role);
+            await githubApi.AddTeamToRepoAsync(org, repo, teamName, role);
 
             // Assert
             githubClientMock.Verify(m => m.PutAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
         }
 
         [Fact]
-        public async Task GetOrganizationId_Returns_The_Org_Id()
+        public async Task GetOrganizationIdAsync_Returns_The_Org_Id()
         {
             // Arrange
             const string org = "ORG";
@@ -430,7 +430,7 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var result = await githubApi.GetOrganizationId(org);
+            var result = await githubApi.GetOrganizationIdAsync(org);
 
             // Assert
             result.Should().Be(orgId);
@@ -468,14 +468,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var expectedMigrationSourceId = await githubApi.CreateAdoMigrationSource(orgId, null);
+            var expectedMigrationSourceId = await githubApi.CreateAdoMigrationSourceAsync(orgId, null);
 
             // Assert
             expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
         }
 
         [Fact]
-        public async Task CreateAdoMigrationSource_Uses_Ado_Server_Url()
+        public async Task CreateAdoMigrationSourceAsync_Uses_Ado_Server_Url()
         {
             // Arrange
             const string url = "https://api.github.com/graphql";
@@ -507,14 +507,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var expectedMigrationSourceId = await githubApi.CreateAdoMigrationSource(orgId, adoServerUrl);
+            var expectedMigrationSourceId = await githubApi.CreateAdoMigrationSourceAsync(orgId, adoServerUrl);
 
             // Assert
             expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
         }
 
         [Fact]
-        public async Task CreateGhecMigrationSource_Returns_New_Migration_Source_Id()
+        public async Task CreateGhecMigrationSourceAsync_Returns_New_Migration_Source_Id()
         {
             // Arrange
             const string url = "https://api.github.com/graphql";
@@ -545,14 +545,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var expectedMigrationSourceId = await githubApi.CreateGhecMigrationSource(orgId);
+            var expectedMigrationSourceId = await githubApi.CreateGhecMigrationSourceAsync(orgId);
 
             // Assert
             expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
         }
 
         [Fact]
-        public async Task StartMigration_Returns_New_Repository_Migration_Id()
+        public async Task StartMigrationAsync_Returns_New_Repository_Migration_Id()
         {
             // Arrange
             const string migrationSourceId = "MIGRATION_SOURCE_ID";
@@ -649,14 +649,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var expectedRepositoryMigrationId = await githubApi.StartMigration(migrationSourceId, adoRepoUrl, orgId, repo, sourceToken, targetToken, gitArchiveUrl, metadataArchiveUrl);
+            var expectedRepositoryMigrationId = await githubApi.StartMigrationAsync(migrationSourceId, adoRepoUrl, orgId, repo, sourceToken, targetToken, gitArchiveUrl, metadataArchiveUrl);
 
             // Assert
             expectedRepositoryMigrationId.Should().Be(actualRepositoryMigrationId);
         }
 
         [Fact]
-        public async Task GetMigrationState_Returns_The_Migration_State()
+        public async Task GetMigrationStateAsync_Returns_The_Migration_State()
         {
             // Arrange
             const string migrationId = "MIGRATION_ID";
@@ -688,14 +688,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var expectedMigrationState = await githubApi.GetMigrationState(migrationId);
+            var expectedMigrationState = await githubApi.GetMigrationStateAsync(migrationId);
 
             // Assert
             expectedMigrationState.Should().Be(actualMigrationState);
         }
 
         [Fact]
-        public async Task GetMigrationState_Retries_On_502()
+        public async Task GetMigrationStateAsync_Retries_On_502()
         {
             // Arrange
             const string migrationId = "MIGRATION_ID";
@@ -729,14 +729,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var expectedMigrationState = await githubApi.GetMigrationState(migrationId);
+            var expectedMigrationState = await githubApi.GetMigrationStateAsync(migrationId);
 
             // Assert
             expectedMigrationState.Should().Be(actualMigrationState);
         }
 
         [Fact]
-        public async Task GetMigrationFailureReason_Returns_The_Migration_Failure_Reason()
+        public async Task GetMigrationFailureReasonAsync_Returns_The_Migration_Failure_Reason()
         {
             // Arrange
             const string migrationId = "MIGRATION_ID";
@@ -768,14 +768,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var expectedFailureReason = await githubApi.GetMigrationFailureReason(migrationId);
+            var expectedFailureReason = await githubApi.GetMigrationFailureReasonAsync(migrationId);
 
             // Assert
             expectedFailureReason.Should().Be(actualFailureReason);
         }
 
         [Fact]
-        public async Task GetMigrationFailureReason_Retries_On_502()
+        public async Task GetMigrationFailureReasonAsync_Retries_On_502()
         {
             // Arrange
             const string migrationId = "MIGRATION_ID";
@@ -809,14 +809,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var expectedFailureReason = await githubApi.GetMigrationFailureReason(migrationId);
+            var expectedFailureReason = await githubApi.GetMigrationFailureReasonAsync(migrationId);
 
             // Assert
             expectedFailureReason.Should().Be(actualFailureReason);
         }
 
         [Fact]
-        public async Task GetIdpGroupId_Returns_The_Idp_Group_Id()
+        public async Task GetIdpGroupIdAsync_Returns_The_Idp_Group_Id()
         {
             // Arrange
             const string org = "ORG";
@@ -847,14 +847,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var actualGroupId = await githubApi.GetIdpGroupId(org, groupName);
+            var actualGroupId = await githubApi.GetIdpGroupIdAsync(org, groupName);
 
             // Assert
             actualGroupId.Should().Be(expectedGroupId);
         }
 
         [Fact]
-        public async Task GetTeamSlug_Returns_The_Team_Slug()
+        public async Task GetTeamSlugAsync_Returns_The_Team_Slug()
         {
             // Arrange
             const string org = "ORG";
@@ -888,14 +888,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var actualTeamSlug = await githubApi.GetTeamSlug(org, teamName);
+            var actualTeamSlug = await githubApi.GetTeamSlugAsync(org, teamName);
 
             // Assert
             actualTeamSlug.Should().Be(expectedTeamSlug);
         }
 
         [Fact]
-        public async Task AddEmuGroupToTeam_Calls_The_Right_Endpoint_With_Payload()
+        public async Task AddEmuGroupToTeamAsync_Calls_The_Right_Endpoint_With_Payload()
         {
             // Arrange
             const string org = "ORG";
@@ -909,14 +909,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            await githubApi.AddEmuGroupToTeam(org, teamSlug, groupId);
+            await githubApi.AddEmuGroupToTeamAsync(org, teamSlug, groupId);
 
             // Assert
             githubClientMock.Verify(m => m.PatchAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
         }
 
         [Fact]
-        public async Task GrantMigratorRole_Returns_True_On_Success()
+        public async Task GrantMigratorRoleAsync_Returns_True_On_Success()
         {
             // Arrange
             const string org = "ORG";
@@ -946,14 +946,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var actualSuccessState = await githubApi.GrantMigratorRole(org, actor, actorType);
+            var actualSuccessState = await githubApi.GrantMigratorRoleAsync(org, actor, actorType);
 
             // Assert
             actualSuccessState.Should().BeTrue();
         }
 
         [Fact]
-        public async Task GrantMigratorRole_Returns_False_On_HttpRequestException()
+        public async Task GrantMigratorRoleAsync_Returns_False_On_HttpRequestException()
         {
             // Arrange
             const string org = "ORG";
@@ -974,14 +974,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var actualSuccessState = await githubApi.GrantMigratorRole(org, actor, actorType);
+            var actualSuccessState = await githubApi.GrantMigratorRoleAsync(org, actor, actorType);
 
             // Assert
             actualSuccessState.Should().BeFalse();
         }
 
         [Fact]
-        public async Task RevokeMigratorRole_Returns_True_On_Success()
+        public async Task RevokeMigratorRoleAsync_Returns_True_On_Success()
         {
             // Arrange
             const string org = "ORG";
@@ -1011,14 +1011,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var actualSuccessState = await githubApi.RevokeMigratorRole(org, actor, actorType);
+            var actualSuccessState = await githubApi.RevokeMigratorRoleAsync(org, actor, actorType);
 
             // Assert
             actualSuccessState.Should().BeTrue();
         }
 
         [Fact]
-        public async Task RevokeMigratorRole_Returns_False_On_HttpRequestException()
+        public async Task RevokeMigratorRoleAsync_Returns_False_On_HttpRequestException()
         {
             // Arrange
             const string org = "ORG";
@@ -1039,14 +1039,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var actualSuccessState = await githubApi.RevokeMigratorRole(org, actor, actorType);
+            var actualSuccessState = await githubApi.RevokeMigratorRoleAsync(org, actor, actorType);
 
             // Assert
             actualSuccessState.Should().BeFalse();
         }
 
         [Fact]
-        public async Task DeleteRepo_Calls_The_Right_Endpoint()
+        public async Task DeleteRepoAsync_Calls_The_Right_Endpoint()
         {
             // Arrange
             const string org = "FOO-ORG";
@@ -1058,14 +1058,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            await githubApi.DeleteRepo(org, repo);
+            await githubApi.DeleteRepoAsync(org, repo);
 
             // Assert
             githubClientMock.Verify(m => m.DeleteAsync(url));
         }
 
         [Fact]
-        public async Task GetMigrationStates_Returns_All_Migration_States_For_An_Org()
+        public async Task GetMigrationStatesAsync_Returns_All_Migration_States_For_An_Org()
         {
             // Arrange
             const string url = "https://api.github.com/graphql";
@@ -1152,7 +1152,7 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var migrationStates = (await githubApi.GetMigrationStates(orgId)).ToArray();
+            var migrationStates = (await githubApi.GetMigrationStatesAsync(orgId)).ToArray();
 
             // Assert
             migrationStates.Should().HaveCount(4);
@@ -1166,7 +1166,7 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task GetUserId_Returns_The_User_Id()
+        public async Task GetUserIdAsync_Returns_The_User_Id()
         {
             // Arrange
             const string login = "mona";
@@ -1195,14 +1195,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var result = await githubApi.GetUserId(login);
+            var result = await githubApi.GetUserIdAsync(login);
 
             // Assert
             result.Should().Be(userId);
         }
 
         [Fact]
-        public async Task GetUserId_For_No_Existant_User_Returns_Null()
+        public async Task GetUserIdAsync_For_No_Existant_User_Returns_Null()
         {
             // Arrange
             const string login = "idonotexist";
@@ -1239,14 +1239,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var result = await githubApi.GetUserId(login);
+            var result = await githubApi.GetUserIdAsync(login);
 
             // Assert
             result.Should().BeNull();
         }
 
         [Fact]
-        public async Task ReclaimMannequin_Returns_Error()
+        public async Task ReclaimMannequinAsync_Returns_Error()
         {
             // Arrange
             const string orgId = "dummyorgid";
@@ -1320,14 +1320,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var result = await githubApi.ReclaimMannequin(orgId, mannequinId, targetUserId);
+            var result = await githubApi.ReclaimMannequinAsync(orgId, mannequinId, targetUserId);
 
             // Assert
             result.Should().BeEquivalentTo(expectedReclaimMannequinResponse);
         }
 
         [Fact]
-        public async Task GetMannequins_Returns_NoMannequins()
+        public async Task GetMannequinsAsync_Returns_NoMannequins()
         {
             // Arrange
             const string orgId = "ORG_ID";
@@ -1370,14 +1370,14 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var result = await githubApi.GetMannequins(orgId);
+            var result = await githubApi.GetMannequinsAsync(orgId);
 
             // Assert
             result.Count().Should().Be(0);
         }
 
         [Fact]
-        public async Task GetMannequins_Returns_Mannequins()
+        public async Task GetMannequinsAsync_Returns_Mannequins()
         {
             // Arrange
             const string orgId = "ORG_ID";
@@ -1443,7 +1443,7 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var result = await githubApi.GetMannequins(orgId);
+            var result = await githubApi.GetMannequinsAsync(orgId);
 
             // Assert
             result.Count().Should().Be(2);
@@ -1462,7 +1462,7 @@ namespace OctoshiftCLI.Tests
 
 
         [Fact]
-        public async Task ReclaimMannequin_Returns_Success()
+        public async Task ReclaimMannequinAsync_Returns_Success()
         {
             // Arrange
             const string orgId = "dummyorgid";
@@ -1536,7 +1536,7 @@ namespace OctoshiftCLI.Tests
 
             // Act
             var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
-            var result = await githubApi.ReclaimMannequin(orgId, mannequinId, targetUserId);
+            var result = await githubApi.ReclaimMannequinAsync(orgId, mannequinId, targetUserId);
 
             // Assert
             result.Should().BeEquivalentTo(expectedReclaimMannequinResponse);

--- a/src/OctoshiftCLI.Tests/Services/ReclaimServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/Services/ReclaimServiceTests.cs
@@ -47,10 +47,10 @@ namespace OctoshiftCLI.Tests
                 }
             };
 
-            mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(orgId);
-            mockGithubApi.Setup(x => x.GetMannequins(orgId).Result).Returns(mannequinsResponse);
-            mockGithubApi.Setup(x => x.GetUserId(reclaimantLogin).Result).Returns(reclaimantId);
-            mockGithubApi.Setup(x => x.ReclaimMannequin(orgId, mannequinId, reclaimantId).Result).Returns(reclaimMannequinResponse);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(orgId);
+            mockGithubApi.Setup(x => x.GetMannequinsAsync(orgId).Result).Returns(mannequinsResponse);
+            mockGithubApi.Setup(x => x.GetUserIdAsync(reclaimantLogin).Result).Returns(reclaimantId);
+            mockGithubApi.Setup(x => x.ReclaimMannequinAsync(orgId, mannequinId, reclaimantId).Result).Returns(reclaimMannequinResponse);
 
             var csvContent = new string[] {
                 HEADER,
@@ -63,10 +63,10 @@ namespace OctoshiftCLI.Tests
             await reclaimService.ReclaimMannequins(csvContent, TARGET_ORG, true);
 
             // Assert
-            mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG), Times.Once);
-            mockGithubApi.Verify(m => m.GetMannequins(orgId), Times.Once);
-            mockGithubApi.Verify(x => x.ReclaimMannequin(orgId, mannequinId, reclaimantId), Times.Once);
-            mockGithubApi.Verify(x => x.GetUserId(reclaimantLogin), Times.Once);
+            mockGithubApi.Verify(m => m.GetOrganizationIdAsync(TARGET_ORG), Times.Once);
+            mockGithubApi.Verify(m => m.GetMannequinsAsync(orgId), Times.Once);
+            mockGithubApi.Verify(x => x.ReclaimMannequinAsync(orgId, mannequinId, reclaimantId), Times.Once);
+            mockGithubApi.Verify(x => x.GetUserIdAsync(reclaimantLogin), Times.Once);
             mockGithubApi.VerifyNoOtherCalls();
         }
 
@@ -77,7 +77,7 @@ namespace OctoshiftCLI.Tests
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
 
-            mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(orgId);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(orgId);
 
             var octologgerMock = TestHelpers.CreateMock<OctoLogger>();
 
@@ -99,7 +99,7 @@ namespace OctoshiftCLI.Tests
             var orgId = Guid.NewGuid().ToString();
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(orgId);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(orgId);
 
             var octologgerMock = TestHelpers.CreateMock<OctoLogger>();
 
@@ -114,10 +114,10 @@ namespace OctoshiftCLI.Tests
             await reclaimService.ReclaimMannequins(csvContent, TARGET_ORG, false);
 
             // Assert
-            mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG), Times.Once);
-            mockGithubApi.Verify(m => m.GetMannequins(orgId), Times.Once);
-            mockGithubApi.Verify(x => x.ReclaimMannequin(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            mockGithubApi.Verify(x => x.GetUserId(It.IsAny<string>()), Times.Never);
+            mockGithubApi.Verify(m => m.GetOrganizationIdAsync(TARGET_ORG), Times.Once);
+            mockGithubApi.Verify(m => m.GetMannequinsAsync(orgId), Times.Once);
+            mockGithubApi.Verify(x => x.ReclaimMannequinAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            mockGithubApi.Verify(x => x.GetUserIdAsync(It.IsAny<string>()), Times.Never);
             octologgerMock.Verify(m => m.LogError($"Invalid line: \"login\". Will ignore it."), Times.Once);
             mockGithubApi.VerifyNoOtherCalls();
         }
@@ -131,7 +131,7 @@ namespace OctoshiftCLI.Tests
                 "INVALID_HEADER"
             };
 
-            // Act
+            // Act & Assert
             await FluentActions
                 .Invoking(async () => await reclaimService.ReclaimMannequins(csvContent, TARGET_ORG, false))
                 .Should().ThrowAsync<OctoshiftCliException>();
@@ -143,7 +143,7 @@ namespace OctoshiftCLI.Tests
             var orgId = Guid.NewGuid().ToString();
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(orgId);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(orgId);
 
             var octologgerMock = TestHelpers.CreateMock<OctoLogger>();
 
@@ -158,10 +158,10 @@ namespace OctoshiftCLI.Tests
             await reclaimService.ReclaimMannequins(csvContent, TARGET_ORG, false);
 
             // Assert
-            mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG), Times.Once);
-            mockGithubApi.Verify(m => m.GetMannequins(orgId), Times.Once);
-            mockGithubApi.Verify(x => x.ReclaimMannequin(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            mockGithubApi.Verify(x => x.GetUserId(It.IsAny<string>()), Times.Never);
+            mockGithubApi.Verify(m => m.GetOrganizationIdAsync(TARGET_ORG), Times.Once);
+            mockGithubApi.Verify(m => m.GetMannequinsAsync(orgId), Times.Once);
+            mockGithubApi.Verify(x => x.ReclaimMannequinAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            mockGithubApi.Verify(x => x.GetUserIdAsync(It.IsAny<string>()), Times.Never);
             octologgerMock.Verify(m => m.LogError($"Invalid line: \",,mona_gh\". Mannequin login is not defined. Will ignore it."), Times.Once);
             mockGithubApi.VerifyNoOtherCalls();
         }
@@ -172,7 +172,7 @@ namespace OctoshiftCLI.Tests
             var orgId = Guid.NewGuid().ToString();
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(orgId);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(orgId);
 
             var octologgerMock = TestHelpers.CreateMock<OctoLogger>();
 
@@ -187,10 +187,10 @@ namespace OctoshiftCLI.Tests
             await reclaimService.ReclaimMannequins(csvContent, TARGET_ORG, false);
 
             // Assert
-            mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG), Times.Once);
-            mockGithubApi.Verify(m => m.GetMannequins(orgId), Times.Once);
-            mockGithubApi.Verify(x => x.ReclaimMannequin(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            mockGithubApi.Verify(x => x.GetUserId(It.IsAny<string>()), Times.Never);
+            mockGithubApi.Verify(m => m.GetOrganizationIdAsync(TARGET_ORG), Times.Once);
+            mockGithubApi.Verify(m => m.GetMannequinsAsync(orgId), Times.Once);
+            mockGithubApi.Verify(x => x.ReclaimMannequinAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            mockGithubApi.Verify(x => x.GetUserIdAsync(It.IsAny<string>()), Times.Never);
             octologgerMock.Verify(m => m.LogError("Invalid line: \"xx,id,\". Target User is not defined. Will ignore it."), Times.Once);
             mockGithubApi.VerifyNoOtherCalls();
         }
@@ -201,7 +201,7 @@ namespace OctoshiftCLI.Tests
             var orgId = Guid.NewGuid().ToString();
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(orgId);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(orgId);
 
             var octologgerMock = TestHelpers.CreateMock<OctoLogger>();
 
@@ -216,10 +216,10 @@ namespace OctoshiftCLI.Tests
             await reclaimService.ReclaimMannequins(csvContent, TARGET_ORG, false);
 
             // Assert
-            mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG), Times.Once);
-            mockGithubApi.Verify(m => m.GetMannequins(orgId), Times.Once);
-            mockGithubApi.Verify(x => x.ReclaimMannequin(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            mockGithubApi.Verify(x => x.GetUserId(It.IsAny<string>()), Times.Never);
+            mockGithubApi.Verify(m => m.GetOrganizationIdAsync(TARGET_ORG), Times.Once);
+            mockGithubApi.Verify(m => m.GetMannequinsAsync(orgId), Times.Once);
+            mockGithubApi.Verify(x => x.ReclaimMannequinAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            mockGithubApi.Verify(x => x.GetUserIdAsync(It.IsAny<string>()), Times.Never);
             octologgerMock.Verify(m => m.LogError($"Invalid line: \"mona,,\". Mannequin Id is not defined. Will ignore it."), Times.Once);
             mockGithubApi.VerifyNoOtherCalls();
         }
@@ -259,10 +259,10 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(orgId);
-            mockGithubApi.Setup(x => x.GetMannequins(orgId).Result).Returns(mannequinsResponse);
-            mockGithubApi.Setup(x => x.GetUserId(reclaimantLogin).Result).Returns(reclaimantId);
-            mockGithubApi.Setup(x => x.ReclaimMannequin(orgId, mannequinId, reclaimantId).Result).Returns(reclaimMannequinResponse);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(orgId);
+            mockGithubApi.Setup(x => x.GetMannequinsAsync(orgId).Result).Returns(mannequinsResponse);
+            mockGithubApi.Setup(x => x.GetUserIdAsync(reclaimantLogin).Result).Returns(reclaimantId);
+            mockGithubApi.Setup(x => x.ReclaimMannequinAsync(orgId, mannequinId, reclaimantId).Result).Returns(reclaimMannequinResponse);
 
             var reclaimService = new ReclaimService(mockGithubApi.Object, TestHelpers.CreateMock<OctoLogger>().Object);
 
@@ -275,10 +275,10 @@ namespace OctoshiftCLI.Tests
             await reclaimService.ReclaimMannequins(csvContent, TARGET_ORG, false);
 
             // Assert
-            mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG), Times.Once);
-            mockGithubApi.Verify(m => m.GetMannequins(orgId), Times.Once);
-            mockGithubApi.Verify(x => x.ReclaimMannequin(orgId, mannequinId, reclaimantId), Times.Once);
-            mockGithubApi.Verify(x => x.GetUserId(reclaimantLogin), Times.Once);
+            mockGithubApi.Verify(m => m.GetOrganizationIdAsync(TARGET_ORG), Times.Once);
+            mockGithubApi.Verify(m => m.GetMannequinsAsync(orgId), Times.Once);
+            mockGithubApi.Verify(x => x.ReclaimMannequinAsync(orgId, mannequinId, reclaimantId), Times.Once);
+            mockGithubApi.Verify(x => x.GetUserIdAsync(reclaimantLogin), Times.Once);
             mockGithubApi.VerifyNoOtherCalls();
         }
 
@@ -327,12 +327,12 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(orgId);
-            mockGithubApi.Setup(x => x.GetMannequins(orgId).Result).Returns(mannequinsResponse);
-            mockGithubApi.Setup(x => x.GetUserId(reclaimantLogin).Result).Returns(reclaimantId);
-            mockGithubApi.Setup(x => x.GetUserId(reclaimantLogin2).Result).Returns(reclaimantId2);
-            mockGithubApi.Setup(x => x.ReclaimMannequin(orgId, mannequinId, reclaimantId).Result).Returns(reclaimMannequinResponse);
-            mockGithubApi.Setup(x => x.ReclaimMannequin(orgId, mannequinId2, reclaimantId2).Result).Returns(reclaimMannequinResponse2);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(orgId);
+            mockGithubApi.Setup(x => x.GetMannequinsAsync(orgId).Result).Returns(mannequinsResponse);
+            mockGithubApi.Setup(x => x.GetUserIdAsync(reclaimantLogin).Result).Returns(reclaimantId);
+            mockGithubApi.Setup(x => x.GetUserIdAsync(reclaimantLogin2).Result).Returns(reclaimantId2);
+            mockGithubApi.Setup(x => x.ReclaimMannequinAsync(orgId, mannequinId, reclaimantId).Result).Returns(reclaimMannequinResponse);
+            mockGithubApi.Setup(x => x.ReclaimMannequinAsync(orgId, mannequinId2, reclaimantId2).Result).Returns(reclaimMannequinResponse2);
 
             var reclaimService = new ReclaimService(mockGithubApi.Object, TestHelpers.CreateMock<OctoLogger>().Object);
 
@@ -348,13 +348,13 @@ namespace OctoshiftCLI.Tests
             await reclaimService.ReclaimMannequins(csvContent, TARGET_ORG, false);
 
             // Assert
-            mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG), Times.Once);
-            mockGithubApi.Verify(m => m.GetMannequins(orgId), Times.Once);
-            mockGithubApi.Verify(x => x.ReclaimMannequin(orgId, mannequinId, reclaimantId), Times.Once);
-            mockGithubApi.Verify(x => x.ReclaimMannequin(orgId, mannequinId2, reclaimantId2), Times.Once);
-            mockGithubApi.Verify(x => x.GetUserId(reclaimantLogin), Times.Once);
-            mockGithubApi.Verify(x => x.GetUserId(reclaimantLogin2), Times.Once);
-            mockGithubApi.Verify(x => x.GetUserId(reclaimantLogin2), Times.Once);
+            mockGithubApi.Verify(m => m.GetOrganizationIdAsync(TARGET_ORG), Times.Once);
+            mockGithubApi.Verify(m => m.GetMannequinsAsync(orgId), Times.Once);
+            mockGithubApi.Verify(x => x.ReclaimMannequinAsync(orgId, mannequinId, reclaimantId), Times.Once);
+            mockGithubApi.Verify(x => x.ReclaimMannequinAsync(orgId, mannequinId2, reclaimantId2), Times.Once);
+            mockGithubApi.Verify(x => x.GetUserIdAsync(reclaimantLogin), Times.Once);
+            mockGithubApi.Verify(x => x.GetUserIdAsync(reclaimantLogin2), Times.Once);
+            mockGithubApi.Verify(x => x.GetUserIdAsync(reclaimantLogin2), Times.Once);
             mockGithubApi.VerifyNoOtherCalls();
         }
 
@@ -401,11 +401,11 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(orgId);
-            mockGithubApi.Setup(x => x.GetMannequins(orgId).Result).Returns(mannequinsResponse);
-            mockGithubApi.Setup(x => x.GetUserId(reclaimantLogin).Result).Returns(reclaimantId);
-            mockGithubApi.Setup(x => x.ReclaimMannequin(orgId, mannequinId, reclaimantId).Result).Returns(reclaimMannequinResponse);
-            mockGithubApi.Setup(x => x.ReclaimMannequin(orgId, mannequinId2, reclaimantId).Result).Returns(reclaimMannequinResponse2);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(orgId);
+            mockGithubApi.Setup(x => x.GetMannequinsAsync(orgId).Result).Returns(mannequinsResponse);
+            mockGithubApi.Setup(x => x.GetUserIdAsync(reclaimantLogin).Result).Returns(reclaimantId);
+            mockGithubApi.Setup(x => x.ReclaimMannequinAsync(orgId, mannequinId, reclaimantId).Result).Returns(reclaimMannequinResponse);
+            mockGithubApi.Setup(x => x.ReclaimMannequinAsync(orgId, mannequinId2, reclaimantId).Result).Returns(reclaimMannequinResponse2);
 
             var reclaimService = new ReclaimService(mockGithubApi.Object, TestHelpers.CreateMock<OctoLogger>().Object);
 
@@ -419,11 +419,11 @@ namespace OctoshiftCLI.Tests
             await reclaimService.ReclaimMannequins(csvContent, TARGET_ORG, false);
 
             // Assert
-            mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG), Times.Once);
-            mockGithubApi.Verify(m => m.GetMannequins(orgId), Times.Once);
-            mockGithubApi.Verify(x => x.ReclaimMannequin(orgId, mannequinId, reclaimantId), Times.Once);
-            mockGithubApi.Verify(x => x.ReclaimMannequin(orgId, mannequinId2, reclaimantId), Times.Once);
-            mockGithubApi.Verify(x => x.GetUserId(reclaimantLogin), Times.Exactly(2));
+            mockGithubApi.Verify(m => m.GetOrganizationIdAsync(TARGET_ORG), Times.Once);
+            mockGithubApi.Verify(m => m.GetMannequinsAsync(orgId), Times.Once);
+            mockGithubApi.Verify(x => x.ReclaimMannequinAsync(orgId, mannequinId, reclaimantId), Times.Once);
+            mockGithubApi.Verify(x => x.ReclaimMannequinAsync(orgId, mannequinId2, reclaimantId), Times.Once);
+            mockGithubApi.Verify(x => x.GetUserIdAsync(reclaimantLogin), Times.Exactly(2));
             mockGithubApi.VerifyNoOtherCalls();
         }
 
@@ -451,8 +451,8 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(orgId);
-            mockGithubApi.Setup(x => x.GetMannequins(orgId).Result).Returns(mannequinsResponse);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(orgId);
+            mockGithubApi.Setup(x => x.GetMannequinsAsync(orgId).Result).Returns(mannequinsResponse);
 
             var octologgerMock = TestHelpers.CreateMock<OctoLogger>();
 
@@ -467,10 +467,10 @@ namespace OctoshiftCLI.Tests
             await reclaimService.ReclaimMannequins(csvContent, TARGET_ORG, false);
 
             // Assert
-            mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG), Times.Once);
-            mockGithubApi.Verify(m => m.GetMannequins(orgId), Times.Once);
-            mockGithubApi.Verify(x => x.ReclaimMannequin(orgId, mannequinId, reclaimantId), Times.Never);
-            mockGithubApi.Verify(x => x.GetUserId(reclaimantLogin), Times.Never);
+            mockGithubApi.Verify(m => m.GetOrganizationIdAsync(TARGET_ORG), Times.Once);
+            mockGithubApi.Verify(m => m.GetMannequinsAsync(orgId), Times.Once);
+            mockGithubApi.Verify(x => x.ReclaimMannequinAsync(orgId, mannequinId, reclaimantId), Times.Never);
+            mockGithubApi.Verify(x => x.GetUserIdAsync(reclaimantLogin), Times.Never);
             octologgerMock.Verify(x => x.LogError($"{mannequinLogin} is already claimed. Skipping (use force if you want to reclaim)"), Times.Once);
             mockGithubApi.VerifyNoOtherCalls();
         }
@@ -487,8 +487,8 @@ namespace OctoshiftCLI.Tests
             var mannequinsResponse = Array.Empty<Mannequin>();
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(orgId);
-            mockGithubApi.Setup(x => x.GetMannequins(orgId).Result).Returns(mannequinsResponse);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(orgId);
+            mockGithubApi.Setup(x => x.GetMannequinsAsync(orgId).Result).Returns(mannequinsResponse);
 
             var octologgerMock = TestHelpers.CreateMock<OctoLogger>();
 
@@ -503,10 +503,10 @@ namespace OctoshiftCLI.Tests
             await reclaimService.ReclaimMannequins(csvContent, TARGET_ORG, false);
 
             // Assert
-            mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG), Times.Once);
-            mockGithubApi.Verify(m => m.GetMannequins(orgId), Times.Once);
-            mockGithubApi.Verify(x => x.ReclaimMannequin(orgId, mannequinId, reclaimantId), Times.Never);
-            mockGithubApi.Verify(x => x.GetUserId(reclaimantLogin), Times.Never);
+            mockGithubApi.Verify(m => m.GetOrganizationIdAsync(TARGET_ORG), Times.Once);
+            mockGithubApi.Verify(m => m.GetMannequinsAsync(orgId), Times.Once);
+            mockGithubApi.Verify(x => x.ReclaimMannequinAsync(orgId, mannequinId, reclaimantId), Times.Never);
+            mockGithubApi.Verify(x => x.GetUserIdAsync(reclaimantLogin), Times.Never);
             octologgerMock.Verify(x => x.LogError($"Mannequin {mannequinLogin} not found. Skipping."), Times.Once);
             mockGithubApi.VerifyNoOtherCalls();
         }
@@ -525,9 +525,9 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(orgId);
-            mockGithubApi.Setup(x => x.GetMannequins(orgId).Result).Returns(mannequinsResponse);
-            mockGithubApi.Setup(x => x.GetUserId(reclaimantLogin)).Returns(Task.FromResult<string>(null));
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(orgId);
+            mockGithubApi.Setup(x => x.GetMannequinsAsync(orgId).Result).Returns(mannequinsResponse);
+            mockGithubApi.Setup(x => x.GetUserIdAsync(reclaimantLogin)).Returns(Task.FromResult<string>(null));
 
             var octologgerMock = TestHelpers.CreateMock<OctoLogger>();
 
@@ -542,10 +542,10 @@ namespace OctoshiftCLI.Tests
             await reclaimService.ReclaimMannequins(csvContent, TARGET_ORG, false);
 
             // Assert
-            mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG), Times.Once);
-            mockGithubApi.Verify(m => m.GetMannequins(orgId), Times.Once);
-            mockGithubApi.Verify(x => x.ReclaimMannequin(orgId, mannequinId, reclaimantId), Times.Never);
-            mockGithubApi.Verify(x => x.GetUserId(reclaimantLogin), Times.Once);
+            mockGithubApi.Verify(m => m.GetOrganizationIdAsync(TARGET_ORG), Times.Once);
+            mockGithubApi.Verify(m => m.GetMannequinsAsync(orgId), Times.Once);
+            mockGithubApi.Verify(x => x.ReclaimMannequinAsync(orgId, mannequinId, reclaimantId), Times.Never);
+            mockGithubApi.Verify(x => x.GetUserIdAsync(reclaimantLogin), Times.Once);
             octologgerMock.Verify(x => x.LogError($"Claimant \"{reclaimantLogin}\" not found. Will ignore it."), Times.Once);
             mockGithubApi.VerifyNoOtherCalls();
         }
@@ -591,11 +591,11 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
-            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
-            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
-            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId2, targetUserId).Result).Returns(reclaimMannequinResponse2);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithub.Setup(x => x.GetUserIdAsync(targetUser).Result).Returns(targetUserId);
+            mockGithub.Setup(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
+            mockGithub.Setup(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId2, targetUserId).Result).Returns(reclaimMannequinResponse2);
 
             var reclaimService = new ReclaimService(mockGithub.Object, TestHelpers.CreateMock<OctoLogger>().Object);
 
@@ -603,9 +603,9 @@ namespace OctoshiftCLI.Tests
             await reclaimService.ReclaimMannequin(mannequinUser, null, targetUser, githubOrg, false);
 
             // Assert
-            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId), Times.Once);
-            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId2, targetUserId), Times.Once);
-            mockGithub.Verify(x => x.GetUserId(targetUser), Times.Once);
+            mockGithub.Verify(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId), Times.Once);
+            mockGithub.Verify(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId2, targetUserId), Times.Once);
+            mockGithub.Verify(x => x.GetUserIdAsync(targetUser), Times.Once);
         }
 
         [Fact]
@@ -635,17 +635,17 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
-            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
-            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithub.Setup(x => x.GetUserIdAsync(targetUser).Result).Returns(targetUserId);
+            mockGithub.Setup(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
 
             var reclaimService = new ReclaimService(mockGithub.Object, TestHelpers.CreateMock<OctoLogger>().Object);
 
             // Act
             await reclaimService.ReclaimMannequin(mannequinUser, null, targetUser, githubOrg, false);
 
-            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId), Times.Once);
+            mockGithub.Verify(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId), Times.Once);
         }
 
         [Fact]
@@ -676,17 +676,17 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
-            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
-            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithub.Setup(x => x.GetUserIdAsync(targetUser).Result).Returns(targetUserId);
+            mockGithub.Setup(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
 
             var reclaimService = new ReclaimService(mockGithub.Object, TestHelpers.CreateMock<OctoLogger>().Object);
 
             // Act
             await reclaimService.ReclaimMannequin(mannequinUser, null, targetUser, githubOrg, false);
 
-            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId), Times.Once);
+            mockGithub.Verify(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId), Times.Once);
         }
 
         [Fact]
@@ -729,19 +729,19 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
-            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
-            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
-            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId2, targetUserId).Result).Returns(reclaimMannequinResponse2);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithub.Setup(x => x.GetUserIdAsync(targetUser).Result).Returns(targetUserId);
+            mockGithub.Setup(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
+            mockGithub.Setup(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId2, targetUserId).Result).Returns(reclaimMannequinResponse2);
 
             var reclaimService = new ReclaimService(mockGithub.Object, TestHelpers.CreateMock<OctoLogger>().Object);
 
             // Act
             await reclaimService.ReclaimMannequin(mannequinUser, mannequinUserId, targetUser, githubOrg, false);
 
-            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId), Times.Once);
-            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId2, targetUserId), Times.Never);
+            mockGithub.Verify(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId), Times.Once);
+            mockGithub.Verify(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId2, targetUserId), Times.Never);
         }
 
 
@@ -774,17 +774,17 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
-            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
-            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithub.Setup(x => x.GetUserIdAsync(targetUser).Result).Returns(targetUserId);
+            mockGithub.Setup(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
 
             var reclaimService = new ReclaimService(mockGithub.Object, TestHelpers.CreateMock<OctoLogger>().Object);
 
             // Act
             await reclaimService.ReclaimMannequin(mannequinUser, mannequinUserId, targetUser, githubOrg, true);
 
-            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId), Times.Once);
+            mockGithub.Verify(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId), Times.Once);
         }
 
         [Fact]
@@ -818,10 +818,10 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
-            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
-            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, null, targetUserId).Result).Returns(reclaimMannequinResponse);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithub.Setup(x => x.GetUserIdAsync(targetUser).Result).Returns(targetUserId);
+            mockGithub.Setup(x => x.ReclaimMannequinAsync(githubOrgId, null, targetUserId).Result).Returns(reclaimMannequinResponse);
 
             var reclaimService = new ReclaimService(mockGithub.Object, TestHelpers.CreateMock<OctoLogger>().Object);
 
@@ -830,7 +830,7 @@ namespace OctoshiftCLI.Tests
                 .Should().ThrowAsync<OctoshiftCliException>();
             exception.WithMessage("User mona is already mapped to a user. Use the force option if you want to reclaim the mannequin again.");
 
-            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId), Times.Never);
+            mockGithub.Verify(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId), Times.Never);
         }
 
         [Fact]
@@ -850,8 +850,8 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
@@ -863,8 +863,8 @@ namespace OctoshiftCLI.Tests
                 .Invoking(async () => await reclaimService.ReclaimMannequin(mannequinUser, null, targetUser, githubOrg, false))
                 .Should().ThrowAsync<OctoshiftCliException>();
 
-            mockGithub.Verify(x => x.GetUserId(targetUser), Times.Never());
-            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId), Times.Never());
+            mockGithub.Verify(x => x.GetUserIdAsync(targetUser), Times.Never());
+            mockGithub.Verify(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId), Times.Never());
             exception.WithMessage("User mona is already mapped to a user. Use the force option if you want to reclaim the mannequin again.");
         }
 
@@ -904,17 +904,17 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
-            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
-            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithub.Setup(x => x.GetUserIdAsync(targetUser).Result).Returns(targetUserId);
+            mockGithub.Setup(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
 
             var reclaimService = new ReclaimService(mockGithub.Object, TestHelpers.CreateMock<OctoLogger>().Object);
 
             // Act
             await reclaimService.ReclaimMannequin(mannequinUser, null, targetUser, githubOrg, true);
 
-            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId));
+            mockGithub.Verify(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId));
         }
 
         [Fact]
@@ -948,10 +948,10 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
-            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
-            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithub.Setup(x => x.GetUserIdAsync(targetUser).Result).Returns(targetUserId);
+            mockGithub.Setup(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
@@ -1015,11 +1015,11 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
-            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
-            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
-            mockGithub.Setup(x => x.ReclaimMannequin(githubOrgId, mannequinUserId2, targetUserId).Result).Returns(reclaimMannequinResponse2);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithub.Setup(x => x.GetUserIdAsync(targetUser).Result).Returns(targetUserId);
+            mockGithub.Setup(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId).Result).Returns(reclaimMannequinResponse);
+            mockGithub.Setup(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId2, targetUserId).Result).Returns(reclaimMannequinResponse2);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(null, null)).Returns(mockGithub.Object);
@@ -1034,8 +1034,8 @@ namespace OctoshiftCLI.Tests
                 .Should().ThrowAsync<OctoshiftCliException>();
             exception.WithMessage("Failed to reclaim mannequin(s).");
 
-            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId), Times.Once);
-            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId2, targetUserId), Times.Once);
+            mockGithub.Verify(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId), Times.Once);
+            mockGithub.Verify(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId2, targetUserId), Times.Once);
 
             octologgerMock.Verify(m => m.LogError($"Failed to reclaim {mannequinUser} ({mannequinUserId}) to {targetUser} ({targetUserId}) Reason: {failureMessage}"), Times.Once);
         }
@@ -1053,9 +1053,9 @@ namespace OctoshiftCLI.Tests
             var mannequinsResponse = Array.Empty<Mannequin>();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
-            mockGithub.Setup(x => x.GetUserId(targetUser).Result).Returns(targetUserId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithub.Setup(x => x.GetUserIdAsync(targetUser).Result).Returns(targetUserId);
 
             var reclaimService = new ReclaimService(mockGithub.Object, TestHelpers.CreateMock<OctoLogger>().Object);
 
@@ -1064,8 +1064,8 @@ namespace OctoshiftCLI.Tests
                 .Invoking(async () => await reclaimService.ReclaimMannequin(mannequinUser, null, targetUser, githubOrg, false))
                 .Should().ThrowAsync<OctoshiftCliException>();
 
-            mockGithub.Verify(x => x.ReclaimMannequin(githubOrgId, mannequinUserId, targetUserId), Times.Never());
-            mockGithub.Verify(x => x.GetUserId(targetUser), Times.Never());
+            mockGithub.Verify(x => x.ReclaimMannequinAsync(githubOrgId, mannequinUserId, targetUserId), Times.Never());
+            mockGithub.Verify(x => x.GetUserIdAsync(targetUser), Times.Never());
         }
 
         [Fact]
@@ -1081,9 +1081,9 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
-            mockGithub.Setup(x => x.GetUserId(targetUser)).Returns(Task.FromResult<string>(null));
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithub.Setup(x => x.GetUserIdAsync(targetUser)).Returns(Task.FromResult<string>(null));
 
             var reclaimService = new ReclaimService(mockGithub.Object, TestHelpers.CreateMock<OctoLogger>().Object);
 
@@ -1094,7 +1094,7 @@ namespace OctoshiftCLI.Tests
 
             exception.WithMessage($"Target user {targetUser} not found.");
 
-            mockGithub.Verify(x => x.GetUserId(targetUser), Times.Once());
+            mockGithub.Verify(x => x.GetUserIdAsync(targetUser), Times.Once());
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
@@ -35,14 +35,14 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var role = "maintain";
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetTeamSlug(githubOrg, team)).ReturnsAsync(teamSlug);
+            mockGithub.Setup(x => x.GetTeamSlugAsync(githubOrg, team)).ReturnsAsync(teamSlug);
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
 
             var command = new AddTeamToRepoCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, githubRepo, team, role);
 
-            mockGithub.Verify(x => x.AddTeamToRepo(githubOrg, githubRepo, teamSlug, role));
+            mockGithub.Verify(x => x.AddTeamToRepoAsync(githubOrg, githubRepo, teamSlug, role));
         }
 
         [Fact]
@@ -79,7 +79,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var args = new string[] { "add-team-to-repo", "--github-org", githubOrg, "--github-repo", githubRepo, "--team", team, "--role", role };
             await root.InvokeAsync(args);
 
-            mockGithub.Verify(x => x.AddTeamToRepo(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            mockGithub.Verify(x => x.AddTeamToRepoAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ConfigureAutoLinkCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ConfigureAutoLinkCommandTests.cs
@@ -37,7 +37,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var urlTemplate = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/".Replace(" ", "%20");
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetAutoLinks(It.IsAny<string>(), It.IsAny<string>()))
+            mockGithub.Setup(x => x.GetAutoLinksAsync(It.IsAny<string>(), It.IsAny<string>()))
                       .ReturnsAsync(new List<(int Id, string KeyPrefix, string UrlTemplate)>());
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
@@ -45,8 +45,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new ConfigureAutoLinkCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, githubRepo, adoOrg, adoTeamProject);
 
-            mockGithub.Verify(x => x.DeleteAutoLink(githubOrg, githubRepo, 1), Times.Never);
-            mockGithub.Verify(x => x.AddAutoLink(githubOrg, githubRepo, keyPrefix, urlTemplate));
+            mockGithub.Verify(x => x.DeleteAutoLinkAsync(githubOrg, githubRepo, 1), Times.Never);
+            mockGithub.Verify(x => x.AddAutoLinkAsync(githubOrg, githubRepo, keyPrefix, urlTemplate));
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             const string githubPat = "github-pat";
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetAutoLinks(It.IsAny<string>(), It.IsAny<string>()))
+            mockGithub.Setup(x => x.GetAutoLinksAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new List<(int Id, string KeyPrefix, string UrlTemplate)>());
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(mockGithub.Object);
@@ -77,7 +77,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var urlTemplate = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/".Replace(" ", "%20");
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetAutoLinks(It.IsAny<string>(), It.IsAny<string>()))
+            mockGithub.Setup(x => x.GetAutoLinksAsync(It.IsAny<string>(), It.IsAny<string>()))
                       .Returns(Task.FromResult(new List<(int Id, string KeyPrefix, string UrlTemplate)>
                       {
                           (1, keyPrefix, urlTemplate),
@@ -93,8 +93,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new ConfigureAutoLinkCommand(mockLogger.Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, githubRepo, adoOrg, adoTeamProject);
 
-            mockGithub.Verify(x => x.DeleteAutoLink(githubOrg, githubRepo, 1), Times.Never);
-            mockGithub.Verify(x => x.AddAutoLink(githubOrg, githubRepo, keyPrefix, urlTemplate), Times.Never);
+            mockGithub.Verify(x => x.DeleteAutoLinkAsync(githubOrg, githubRepo, 1), Times.Never);
+            mockGithub.Verify(x => x.AddAutoLinkAsync(githubOrg, githubRepo, keyPrefix, urlTemplate), Times.Never);
             actualLogOutput.Should().Contain($"Autolink reference already exists for key_prefix: '{keyPrefix}'. No operation will be performed");
         }
 
@@ -109,7 +109,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var urlTemplate = $"https://dev.azure.com/{adoOrg}/{adoTeamProject}/_workitems/edit/<num>/".Replace(" ", "%20");
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetAutoLinks(It.IsAny<string>(), It.IsAny<string>()))
+            mockGithub.Setup(x => x.GetAutoLinksAsync(It.IsAny<string>(), It.IsAny<string>()))
                       .ReturnsAsync(new List<(int Id, string KeyPrefix, string UrlTemplate)>
                       {
                           (1, keyPrefix, "SomethingElse"),
@@ -125,8 +125,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new ConfigureAutoLinkCommand(mockLogger.Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, githubRepo, adoOrg, adoTeamProject);
 
-            mockGithub.Verify(x => x.DeleteAutoLink(githubOrg, githubRepo, 1));
-            mockGithub.Verify(x => x.AddAutoLink(githubOrg, githubRepo, keyPrefix, urlTemplate));
+            mockGithub.Verify(x => x.DeleteAutoLinkAsync(githubOrg, githubRepo, 1));
+            mockGithub.Verify(x => x.AddAutoLinkAsync(githubOrg, githubRepo, keyPrefix, urlTemplate));
             actualLogOutput.Should().Contain($"Autolink reference already exists for key_prefix: '{keyPrefix}', but the url template is incorrect");
             actualLogOutput.Should().Contain($"Deleting existing Autolink reference for key_prefix: '{keyPrefix}' before creating a new Autolink reference");
         }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/CreateTeamCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/CreateTeamCommandTests.cs
@@ -35,10 +35,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var teamSlug = "foo-slug";
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetTeamMembers(githubOrg, teamSlug).Result).Returns(teamMembers);
-            mockGithub.Setup(x => x.GetIdpGroupId(githubOrg, idpGroup).Result).Returns(idpGroupId);
-            mockGithub.Setup(x => x.GetTeamSlug(githubOrg, teamName).Result).Returns(teamSlug);
-            mockGithub.Setup(x => x.GetTeams(githubOrg).Result).Returns(new List<string>());
+            mockGithub.Setup(x => x.GetTeamMembersAsync(githubOrg, teamSlug).Result).Returns(teamMembers);
+            mockGithub.Setup(x => x.GetIdpGroupIdAsync(githubOrg, idpGroup).Result).Returns(idpGroupId);
+            mockGithub.Setup(x => x.GetTeamSlugAsync(githubOrg, teamName).Result).Returns(teamSlug);
+            mockGithub.Setup(x => x.GetTeamsAsync(githubOrg).Result).Returns(new List<string>());
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
@@ -46,10 +46,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new CreateTeamCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, teamName, idpGroup);
 
-            mockGithub.Verify(x => x.CreateTeam(githubOrg, teamName));
-            mockGithub.Verify(x => x.RemoveTeamMember(githubOrg, teamSlug, teamMembers[0]));
-            mockGithub.Verify(x => x.RemoveTeamMember(githubOrg, teamSlug, teamMembers[1]));
-            mockGithub.Verify(x => x.AddEmuGroupToTeam(githubOrg, teamSlug, idpGroupId));
+            mockGithub.Verify(x => x.CreateTeamAsync(githubOrg, teamName));
+            mockGithub.Verify(x => x.RemoveTeamMemberAsync(githubOrg, teamSlug, teamMembers[0]));
+            mockGithub.Verify(x => x.RemoveTeamMemberAsync(githubOrg, teamSlug, teamMembers[1]));
+            mockGithub.Verify(x => x.AddEmuGroupToTeamAsync(githubOrg, teamSlug, idpGroupId));
         }
 
         [Fact]
@@ -78,10 +78,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var teamSlug = "foo-slug";
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetTeamMembers(githubOrg, teamSlug).Result).Returns(teamMembers);
-            mockGithub.Setup(x => x.GetIdpGroupId(githubOrg, idpGroup).Result).Returns(idpGroupId);
-            mockGithub.Setup(x => x.GetTeamSlug(githubOrg, teamName).Result).Returns(teamSlug);
-            mockGithub.Setup(x => x.GetTeams(githubOrg).Result).Returns(new List<string> { teamName });
+            mockGithub.Setup(x => x.GetTeamMembersAsync(githubOrg, teamSlug).Result).Returns(teamMembers);
+            mockGithub.Setup(x => x.GetIdpGroupIdAsync(githubOrg, idpGroup).Result).Returns(idpGroupId);
+            mockGithub.Setup(x => x.GetTeamSlugAsync(githubOrg, teamName).Result).Returns(teamSlug);
+            mockGithub.Setup(x => x.GetTeamsAsync(githubOrg).Result).Returns(new List<string> { teamName });
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
@@ -94,10 +94,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new CreateTeamCommand(mockLogger.Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, teamName, idpGroup);
 
-            mockGithub.Verify(x => x.CreateTeam(githubOrg, teamName), Times.Never);
-            mockGithub.Verify(x => x.RemoveTeamMember(githubOrg, teamSlug, teamMembers[0]));
-            mockGithub.Verify(x => x.RemoveTeamMember(githubOrg, teamSlug, teamMembers[1]));
-            mockGithub.Verify(x => x.AddEmuGroupToTeam(githubOrg, teamSlug, idpGroupId));
+            mockGithub.Verify(x => x.CreateTeamAsync(githubOrg, teamName), Times.Never);
+            mockGithub.Verify(x => x.RemoveTeamMemberAsync(githubOrg, teamSlug, teamMembers[0]));
+            mockGithub.Verify(x => x.RemoveTeamMemberAsync(githubOrg, teamSlug, teamMembers[1]));
+            mockGithub.Verify(x => x.AddEmuGroupToTeamAsync(githubOrg, teamSlug, idpGroupId));
             actualLogOutput.Contains($"Team '{teamName}' already exists. New team will not be created");
         }
     }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateReclaimCsvCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateReclaimCsvCommandTests.cs
@@ -39,8 +39,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithubApi.Object);
 
-            mockGithubApi.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithubApi.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(Array.Empty<Mannequin>());
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithubApi.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(Array.Empty<Mannequin>());
 
             var csvContent = "";
 
@@ -94,8 +94,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithubApi.Object);
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithubApi.Object);
 
-            mockGithubApi.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithubApi.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithubApi.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
 
             var csvContent = "";
 
@@ -149,8 +149,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithubApi.Object);
 
-            mockGithubApi.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithubApi.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithubApi.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
 
             var csvContent = "";
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRoleCommandTests.cs
@@ -33,7 +33,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var githubOrgId = Guid.NewGuid().ToString();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
@@ -41,7 +41,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new GrantMigratorRoleCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, actor, actorType);
 
-            mockGithub.Verify(x => x.GrantMigratorRole(githubOrgId, actor, actorType));
+            mockGithub.Verify(x => x.GrantMigratorRoleAsync(githubOrgId, actor, actorType));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
@@ -48,11 +48,11 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var githubPat = Guid.NewGuid().ToString();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetRepos(githubOrg).Result).Returns(new List<string>());
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, null).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.GetReposAsync(githubOrg).Result).Returns(new List<string>());
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.CreateAdoMigrationSourceAsync(githubOrgId, null).Result).Returns(migrationSourceId);
             mockGithub
-                .Setup(x => x.StartMigration(
+                .Setup(x => x.StartMigrationAsync(
                     migrationSourceId,
                     adoRepoUrl,
                     githubOrgId,
@@ -63,7 +63,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
+            mockGithub.Setup(x => x.GetMigrationStateAsync(migrationId).Result).Returns("SUCCEEDED");
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
@@ -97,10 +97,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, wait: false);
 
             // Assert
-            mockGithub.Verify(m => m.GetRepos(githubOrg));
-            mockGithub.Verify(m => m.GetOrganizationId(githubOrg));
-            mockGithub.Verify(m => m.CreateAdoMigrationSource(githubOrgId, null));
-            mockGithub.Verify(m => m.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, adoToken, githubPat, null, null, false));
+            mockGithub.Verify(m => m.GetReposAsync(githubOrg));
+            mockGithub.Verify(m => m.GetOrganizationIdAsync(githubOrg));
+            mockGithub.Verify(m => m.CreateAdoMigrationSourceAsync(githubOrgId, null));
+            mockGithub.Verify(m => m.StartMigrationAsync(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, adoToken, githubPat, null, null, false));
 
             mockLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
             actualLogOutput.Should().Equal(expectedLogOutput);
@@ -123,7 +123,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var githubRepos = new List<string> { githubRepo };
 
             var mockGithub = new Mock<GithubApi>(null, null, null);
-            mockGithub.Setup(x => x.GetRepos(githubOrg).Result).Returns(githubRepos);
+            mockGithub.Setup(x => x.GetReposAsync(githubOrg).Result).Returns(githubRepos);
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
@@ -149,7 +149,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, wait: false);
 
             // Assert
-            mockGithub.Verify(m => m.GetRepos(githubOrg));
+            mockGithub.Verify(m => m.GetReposAsync(githubOrg));
 
             mockLogger.Verify(m => m.LogWarning(It.IsAny<string>()), Times.Exactly(1));
             actualLogOutput.Should().Contain(expectedLogOutput);
@@ -173,10 +173,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var githubPat = Guid.NewGuid().ToString();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, null).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.CreateAdoMigrationSourceAsync(githubOrgId, null).Result).Returns(migrationSourceId);
             mockGithub
-                .Setup(x => x.StartMigration(
+                .Setup(x => x.StartMigrationAsync(
                         migrationSourceId,
                         adoRepoUrl,
                         githubOrgId,
@@ -187,7 +187,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                         null,
                         false).Result)
                 .Returns(migrationId);
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
+            mockGithub.Setup(x => x.GetMigrationStateAsync(migrationId).Result).Returns("SUCCEEDED");
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
@@ -204,7 +204,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 environmentVariableProviderMock.Object);
             await command.Invoke(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, wait: true);
 
-            mockGithub.Verify(x => x.GetMigrationState(migrationId));
+            mockGithub.Verify(x => x.GetMigrationStateAsync(migrationId));
         }
 
         [Fact]
@@ -214,7 +214,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             const string githubPat = "github-pat";
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetMigrationState(It.IsAny<string>()).Result).Returns("SUCCEEDED");
+            mockGithub.Setup(x => x.GetMigrationStateAsync(It.IsAny<string>()).Result).Returns("SUCCEEDED");
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(mockGithub.Object);
 
@@ -241,8 +241,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             const string githubPat = "github-pat";
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetRepos("githubOrg").Result).Returns(new List<string>());
-            mockGithub.Setup(x => x.GetMigrationState(It.IsAny<string>()).Result).Returns("SUCCEEDED");
+            mockGithub.Setup(x => x.GetReposAsync("githubOrg").Result).Returns(new List<string>());
+            mockGithub.Setup(x => x.GetMigrationStateAsync(It.IsAny<string>()).Result).Returns("SUCCEEDED");
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(mockGithub.Object);
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
@@ -33,7 +33,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var githubOrgId = Guid.NewGuid().ToString();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
@@ -41,7 +41,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var command = new RevokeMigratorRoleCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, actor, actorType);
 
-            mockGithub.Verify(x => x.RevokeMigratorRole(githubOrgId, actor, actorType));
+            mockGithub.Verify(x => x.RevokeMigratorRoleAsync(githubOrgId, actor, actorType));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/WaitForMigrationCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/WaitForMigrationCommandTests.cs
@@ -31,7 +31,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             const int waitIntervalInSeconds = 1;
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.SetupSequence(x => x.GetMigrationState(specifiedMigrationId).Result)
+            mockGithubApi.SetupSequence(x => x.GetMigrationStateAsync(specifiedMigrationId).Result)
                 .Returns(RepositoryMigrationStatus.InProgress)
                 .Returns(RepositoryMigrationStatus.InProgress)
                 .Returns(RepositoryMigrationStatus.Succeeded);
@@ -65,7 +65,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(5));
             mockLogger.Verify(m => m.LogSuccess(It.IsAny<string>()), Times.Once);
 
-            mockGithubApi.Verify(m => m.GetMigrationState(specifiedMigrationId), Times.Exactly(3));
+            mockGithubApi.Verify(m => m.GetMigrationStateAsync(specifiedMigrationId), Times.Exactly(3));
 
             actualLogOutput.Should().Equal(expectedLogOutput);
 
@@ -83,8 +83,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             const int waitIntervalInSeconds = 1;
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(m => m.GetMigrationFailureReason(specifiedMigrationId).Result).Returns(failureReason);
-            mockGithubApi.SetupSequence(x => x.GetMigrationState(specifiedMigrationId).Result)
+            mockGithubApi.Setup(m => m.GetMigrationFailureReasonAsync(specifiedMigrationId).Result).Returns(failureReason);
+            mockGithubApi.SetupSequence(x => x.GetMigrationStateAsync(specifiedMigrationId).Result)
                 .Returns(RepositoryMigrationStatus.InProgress)
                 .Returns(RepositoryMigrationStatus.InProgress)
                 .Returns(RepositoryMigrationStatus.Failed);
@@ -122,8 +122,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(5));
             mockLogger.Verify(m => m.LogError(It.IsAny<string>()), Times.Once);
 
-            mockGithubApi.Verify(m => m.GetMigrationState(specifiedMigrationId), Times.Exactly(3));
-            mockGithubApi.Verify(m => m.GetMigrationFailureReason(specifiedMigrationId), Times.Once);
+            mockGithubApi.Verify(m => m.GetMigrationStateAsync(specifiedMigrationId), Times.Exactly(3));
+            mockGithubApi.Verify(m => m.GetMigrationFailureReasonAsync(specifiedMigrationId), Times.Once);
 
             actualLogOutput.Should().Equal(expectedLogOutput);
 
@@ -141,7 +141,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
             mockGithubApi
-                .Setup(x => x.GetMigrationState(specifiedMigrationId).Result)
+                .Setup(x => x.GetMigrationStateAsync(specifiedMigrationId).Result)
                 .Returns(RepositoryMigrationStatus.Succeeded);
 
             var mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateMannequinCsvCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateMannequinCsvCommandTests.cs
@@ -39,8 +39,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var mockTargetGithubApiFactory = new Mock<ITargetGithubApiFactory>();
             mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithubApi.Object);
 
-            mockGithubApi.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithubApi.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(Array.Empty<Mannequin>());
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithubApi.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(Array.Empty<Mannequin>());
 
             var csvContent = "";
 
@@ -93,8 +93,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithubApi.Object);
             mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithubApi.Object);
 
-            mockGithubApi.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithubApi.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithubApi.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
 
             var csvContent = "";
 
@@ -148,8 +148,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var mockTargetGithubApiFactory = new Mock<ITargetGithubApiFactory>();
             mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithubApi.Object);
 
-            mockGithubApi.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            mockGithubApi.Setup(x => x.GetMannequins(githubOrgId).Result).Returns(mannequinsResponse);
+            mockGithubApi.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
+            mockGithubApi.Setup(x => x.GetMannequinsAsync(githubOrgId).Result).Returns(mannequinsResponse);
 
             var csvContent = "";
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -142,7 +142,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             // Arrange
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
             mockGithubApi
-                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .Setup(m => m.GetReposAsync(SOURCE_ORG))
                 .ReturnsAsync(new[] { REPO });
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
@@ -185,7 +185,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             // Arrange
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
             mockGithubApi
-                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .Setup(m => m.GetReposAsync(SOURCE_ORG))
                 .ReturnsAsync(new[] { REPO });
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
@@ -228,7 +228,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             // Arrange
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
             mockGithubApi
-                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .Setup(m => m.GetReposAsync(SOURCE_ORG))
                 .ReturnsAsync(new[] { REPO });
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
@@ -279,7 +279,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
             mockGithubApi
-                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .Setup(m => m.GetReposAsync(SOURCE_ORG))
                 .ReturnsAsync(new[] { repo1, repo2, repo3 });
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
@@ -485,7 +485,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
             mockGithubApi
-                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .Setup(m => m.GetReposAsync(SOURCE_ORG))
                 .ReturnsAsync(new[] { REPO });
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
@@ -537,7 +537,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
             mockGithubApi
-                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .Setup(m => m.GetReposAsync(SOURCE_ORG))
                 .ReturnsAsync(new[] { REPO });
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
@@ -930,7 +930,7 @@ if ($Failed -ne 0) {
             const string repo2 = "FOO-REPO-2";
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(m => m.GetRepos(SOURCE_ORG)).ReturnsAsync(new[] { repo1, repo2 });
+            mockGithubApi.Setup(m => m.GetReposAsync(SOURCE_ORG)).ReturnsAsync(new[] { repo1, repo2 });
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
             mockSourceGithubApiFactory
                 .Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>()))
@@ -1035,7 +1035,7 @@ if ($Failed -ne 0) {
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
             mockGithubApi
-                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .Setup(m => m.GetReposAsync(SOURCE_ORG))
                 .ReturnsAsync(new[] { REPO });
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
@@ -1138,7 +1138,7 @@ if ($Failed -ne 0) {
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
             mockGithubApi
-                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .Setup(m => m.GetReposAsync(SOURCE_ORG))
                 .ReturnsAsync(new[] { REPO });
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
@@ -1314,7 +1314,7 @@ if ($Failed -ne 0) {
             // Arrange
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
             mockGithubApi
-                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .Setup(m => m.GetReposAsync(SOURCE_ORG))
                 .ReturnsAsync(new[] { REPO });
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
@@ -1362,7 +1362,7 @@ if ($Failed -ne 0) {
             // Arrange
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
             mockGithubApi
-                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .Setup(m => m.GetReposAsync(SOURCE_ORG))
                 .ReturnsAsync(new[] { REPO });
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
@@ -1412,7 +1412,7 @@ if ($Failed -ne 0) {
             // Arrange
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
             mockGithubApi
-                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .Setup(m => m.GetReposAsync(SOURCE_ORG))
                 .ReturnsAsync(new[] { REPO });
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
@@ -1459,7 +1459,7 @@ if ($Failed -ne 0) {
         {
             // Arrange
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(m => m.GetRepos(SOURCE_ORG)).ReturnsAsync(new[] { REPO });
+            mockGithubApi.Setup(m => m.GetReposAsync(SOURCE_ORG)).ReturnsAsync(new[] { REPO });
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
             mockSourceGithubApiFactory
                 .Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>()))

--- a/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
@@ -35,7 +35,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var githubOrgId = Guid.NewGuid().ToString();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
@@ -43,7 +43,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var command = new GrantMigratorRoleCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, actor, actorType);
 
-            mockGithub.Verify(x => x.GrantMigratorRole(githubOrgId, actor, actorType));
+            mockGithub.Verify(x => x.GrantMigratorRoleAsync(githubOrgId, actor, actorType));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -64,10 +64,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var migrationId = Guid.NewGuid().ToString();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetRepos(TARGET_ORG).Result).Returns(new List<string>());
-            mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
-            mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false).Result).Returns(migrationId);
+            mockGithub.Setup(x => x.GetReposAsync(TARGET_ORG).Result).Returns(new List<string>());
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSourceAsync(githubOrgId).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.StartMigrationAsync(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false).Result).Returns(migrationId);
 
             var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
             environmentVariableProviderMock.Setup(m => m.SourceGithubPersonalAccessToken()).Returns(sourceGithubPat);
@@ -105,10 +105,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await command.Invoke(args);
 
             // Assert
-            mockGithub.Verify(m => m.GetRepos(TARGET_ORG));
-            mockGithub.Verify(m => m.GetOrganizationId(TARGET_ORG));
-            mockGithub.Verify(m => m.CreateGhecMigrationSource(githubOrgId));
-            mockGithub.Verify(m => m.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false));
+            mockGithub.Verify(m => m.GetReposAsync(TARGET_ORG));
+            mockGithub.Verify(m => m.GetOrganizationIdAsync(TARGET_ORG));
+            mockGithub.Verify(m => m.CreateGhecMigrationSourceAsync(githubOrgId));
+            mockGithub.Verify(m => m.StartMigrationAsync(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false));
 
             mockLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
             actualLogOutput.Should().Equal(expectedLogOutput);
@@ -130,8 +130,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var githubRepos = new List<string> { TARGET_REPO };
 
             var mockGithub = new Mock<GithubApi>(null, null, null);
-            mockGithub.Setup(x => x.GetRepos(TARGET_ORG).Result).Returns(githubRepos);
-            mockGithub.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, "", "", false).Result).Returns(migrationId);
+            mockGithub.Setup(x => x.GetReposAsync(TARGET_ORG).Result).Returns(githubRepos);
+            mockGithub.Setup(x => x.StartMigrationAsync(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, "", "", false).Result).Returns(migrationId);
 
             var environmentVariableProviderMock = new Mock<EnvironmentVariableProvider>(null);
             environmentVariableProviderMock.Setup(m => m.SourceGithubPersonalAccessToken()).Returns(sourceGithubPat);
@@ -161,7 +161,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await command.Invoke(args);
 
             // Assert
-            mockGithub.Verify(m => m.GetRepos(TARGET_ORG));
+            mockGithub.Verify(m => m.GetReposAsync(TARGET_ORG));
 
             mockLogger.Verify(m => m.LogWarning(It.IsAny<string>()), Times.Exactly(1));
             actualLogOutput.Should().Contain(expectedLogWarningOutput);
@@ -180,10 +180,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var migrationId = Guid.NewGuid().ToString();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSourceAsync(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
-                .Setup(x => x.StartMigration(
+                .Setup(x => x.StartMigrationAsync(
                     migrationSourceId,
                     githubRepoUrl,
                     githubOrgId,
@@ -194,7 +194,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
+            mockGithub.Setup(x => x.GetMigrationStateAsync(migrationId).Result).Returns("SUCCEEDED");
 
             var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
             environmentVariableProviderMock.Setup(m => m.SourceGithubPersonalAccessToken()).Returns(sourceGithubPat);
@@ -215,7 +215,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             };
             await command.Invoke(args);
 
-            mockGithub.Verify(x => x.GetMigrationState(migrationId));
+            mockGithub.Verify(x => x.GetMigrationStateAsync(migrationId));
         }
 
         [Fact]
@@ -231,10 +231,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var migrationId = Guid.NewGuid().ToString();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, null).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.CreateAdoMigrationSourceAsync(githubOrgId, null).Result).Returns(migrationSourceId);
             mockGithub
-                .Setup(x => x.StartMigration(
+                .Setup(x => x.StartMigrationAsync(
                     migrationSourceId,
                     adoRepoUrl,
                     githubOrgId,
@@ -245,7 +245,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
+            mockGithub.Setup(x => x.GetMigrationStateAsync(migrationId).Result).Returns("SUCCEEDED");
 
             var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
             environmentVariableProviderMock.Setup(m => m.AdoPersonalAccessToken()).Returns(sourceAdoPat);
@@ -267,7 +267,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             };
             await command.Invoke(args);
 
-            mockGithub.Verify(x => x.GetMigrationState(migrationId));
+            mockGithub.Verify(x => x.GetMigrationStateAsync(migrationId));
         }
 
         [Fact]
@@ -284,10 +284,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var migrationId = Guid.NewGuid().ToString();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateAdoMigrationSource(githubOrgId, adoServerUrl).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.CreateAdoMigrationSourceAsync(githubOrgId, adoServerUrl).Result).Returns(migrationSourceId);
             mockGithub
-                .Setup(x => x.StartMigration(
+                .Setup(x => x.StartMigrationAsync(
                     migrationSourceId,
                     adoRepoUrl,
                     githubOrgId,
@@ -298,7 +298,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
+            mockGithub.Setup(x => x.GetMigrationStateAsync(migrationId).Result).Returns("SUCCEEDED");
 
             var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
             environmentVariableProviderMock.Setup(m => m.AdoPersonalAccessToken()).Returns(sourceAdoPat);
@@ -321,7 +321,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             };
             await command.Invoke(args);
 
-            mockGithub.Verify(x => x.GetMigrationState(migrationId));
+            mockGithub.Verify(x => x.GetMigrationStateAsync(migrationId));
         }
 
         [Fact]
@@ -344,10 +344,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var authenticatedMetadataArchiveUrl = new Uri($"https://example.com/{metadataArchiveId}/authenticated");
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSourceAsync(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
-                .Setup(x => x.StartMigration(
+                .Setup(x => x.StartMigrationAsync(
                     migrationSourceId,
                     githubRepoUrl,
                     githubOrgId,
@@ -358,15 +358,15 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     authenticatedMetadataArchiveUrl.ToString(),
                     false).Result)
                 .Returns(migrationId);
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
+            mockGithub.Setup(x => x.GetMigrationStateAsync(migrationId).Result).Returns("SUCCEEDED");
 
             var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
+            mockGhesGithubApi.Setup(x => x.StartGitArchiveGenerationAsync(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
+            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGenerationAsync(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatusAsync(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatusAsync(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrlAsync(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrlAsync(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
 
             var mockAzureApi = TestHelpers.CreateMock<AzureApi>();
             mockAzureApi.Setup(x => x.DownloadArchive(gitArchiveUrl).Result).Returns(gitArchiveContent);
@@ -401,7 +401,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             };
             await command.Invoke(args);
 
-            mockGithub.Verify(x => x.GetMigrationState(migrationId));
+            mockGithub.Verify(x => x.GetMigrationStateAsync(migrationId));
         }
 
         [Fact]
@@ -435,10 +435,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var metadataArchiveUrl = "https://example.com/metadata_archive.tar.gz";
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSourceAsync(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
-                .Setup(x => x.StartMigration(
+                .Setup(x => x.StartMigrationAsync(
                     migrationSourceId,
                     githubRepoUrl,
                     githubOrgId,
@@ -449,7 +449,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     metadataArchiveUrl,
                     false).Result)
                 .Returns(migrationId);
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
+            mockGithub.Setup(x => x.GetMigrationStateAsync(migrationId).Result).Returns("SUCCEEDED");
 
             var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
             environmentVariableProviderMock.Setup(m => m.SourceGithubPersonalAccessToken()).Returns(sourceGithubPat);
@@ -472,7 +472,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             };
             await command.Invoke(args);
 
-            mockGithub.Verify(x => x.GetMigrationState(migrationId));
+            mockGithub.Verify(x => x.GetMigrationStateAsync(migrationId));
         }
 
         [Fact]
@@ -537,10 +537,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var migrationId = Guid.NewGuid().ToString();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSourceAsync(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
-                .Setup(x => x.StartMigration(
+                .Setup(x => x.StartMigrationAsync(
                     migrationSourceId,
                     githubRepoUrl,
                     githubOrgId,
@@ -551,7 +551,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
+            mockGithub.Setup(x => x.GetMigrationStateAsync(migrationId).Result).Returns("SUCCEEDED");
 
             var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
             environmentVariableProviderMock.Setup(m => m.SourceGithubPersonalAccessToken()).Returns(sourceGithubPat);
@@ -570,7 +570,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             };
             await command.Invoke(args);
 
-            mockGithub.Verify(x => x.GetMigrationState(migrationId));
+            mockGithub.Verify(x => x.GetMigrationStateAsync(migrationId));
         }
 
         [Fact]
@@ -611,10 +611,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var authenticatedMetadataArchiveUrl = new Uri($"https://example.com/{metadataArchiveId}/authenticated");
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSourceAsync(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
-                .Setup(x => x.StartMigration(
+                .Setup(x => x.StartMigrationAsync(
                     migrationSourceId,
                     githubRepoUrl,
                     githubOrgId,
@@ -625,15 +625,15 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     authenticatedMetadataArchiveUrl.ToString(),
                     false).Result)
                 .Returns(migrationId);
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
+            mockGithub.Setup(x => x.GetMigrationStateAsync(migrationId).Result).Returns("SUCCEEDED");
 
             var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
+            mockGhesGithubApi.Setup(x => x.StartGitArchiveGenerationAsync(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
+            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGenerationAsync(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatusAsync(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatusAsync(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrlAsync(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrlAsync(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
 
             var mockAzureApi = TestHelpers.CreateMock<AzureApi>();
             mockAzureApi.Setup(x => x.DownloadArchive(gitArchiveUrl).Result).Returns(gitArchiveContent);
@@ -669,7 +669,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await command.Invoke(args);
 
             mockAzureApiFactory.Verify(x => x.Create(azureConnectionStringEnv));
-            mockGithub.Verify(x => x.GetMigrationState(migrationId));
+            mockGithub.Verify(x => x.GetMigrationStateAsync(migrationId));
         }
 
         [Fact]
@@ -692,10 +692,10 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var authenticatedMetadataArchiveUrl = new Uri($"https://example.com/{metadataArchiveId}/authenticated");
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
-            mockGithub.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(TARGET_ORG).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.CreateGhecMigrationSourceAsync(githubOrgId).Result).Returns(migrationSourceId);
             mockGithub
-                .Setup(x => x.StartMigration(
+                .Setup(x => x.StartMigrationAsync(
                     migrationSourceId,
                     githubRepoUrl,
                     githubOrgId,
@@ -706,15 +706,15 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     authenticatedMetadataArchiveUrl.ToString(),
                     false).Result)
                 .Returns(migrationId);
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
+            mockGithub.Setup(x => x.GetMigrationStateAsync(migrationId).Result).Returns("SUCCEEDED");
 
             var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
+            mockGhesGithubApi.Setup(x => x.StartGitArchiveGenerationAsync(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
+            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGenerationAsync(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatusAsync(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatusAsync(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrlAsync(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrlAsync(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
 
             var mockAzureApi = TestHelpers.CreateMock<AzureApi>();
             mockAzureApi.Setup(x => x.DownloadArchive(gitArchiveUrl).Result).Returns(gitArchiveContent);
@@ -751,7 +751,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await command.Invoke(args);
 
             mockAzureApiFactory.Verify(x => x.CreateClientNoSsl(AZURE_CONNECTION_STRING));
-            mockGithub.Verify(x => x.GetMigrationState(migrationId));
+            mockGithub.Verify(x => x.GetMigrationStateAsync(migrationId));
         }
 
         [Fact]
@@ -761,9 +761,9 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var metadataArchiveId = 2;
 
             var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Failed);
+            mockGhesGithubApi.Setup(x => x.StartGitArchiveGenerationAsync(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
+            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGenerationAsync(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatusAsync(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Failed);
 
             var mockAzureApi = TestHelpers.CreateMock<AzureApi>();
 
@@ -823,8 +823,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             actualLogOutput.Should().NotContain("Since github-target-pat is provided, github-source-pat will also use its value.");
 
             environmentVariableProviderMock.Verify(m => m.AdoPersonalAccessToken(), Times.Never);
-            mockGithub.Verify(m => m.CreateAdoMigrationSource(It.IsAny<string>(), null));
-            mockGithub.Verify(m => m.StartMigration(
+            mockGithub.Verify(m => m.CreateAdoMigrationSourceAsync(It.IsAny<string>(), null));
+            mockGithub.Verify(m => m.StartMigrationAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
@@ -871,8 +871,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             environmentVariableProviderMock.Verify(m => m.SourceGithubPersonalAccessToken(), Times.Never);
             environmentVariableProviderMock.Verify(m => m.TargetGithubPersonalAccessToken(), Times.Never);
-            mockGithub.Verify(m => m.CreateGhecMigrationSource(It.IsAny<string>()));
-            mockGithub.Verify(m => m.StartMigration(
+            mockGithub.Verify(m => m.CreateGhecMigrationSourceAsync(It.IsAny<string>()));
+            mockGithub.Verify(m => m.StartMigrationAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
@@ -891,8 +891,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var environmentVariableProviderMock = TestHelpers.CreateMock<EnvironmentVariableProvider>();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, It.IsAny<int>()).Result).Returns(ArchiveMigrationStatus.Exported);
-            mockGithub.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, It.IsAny<int>()).Result).Returns(ArchiveMigrationStatus.Exported);
+            mockGithub.Setup(x => x.GetArchiveMigrationStatusAsync(SOURCE_ORG, It.IsAny<int>()).Result).Returns(ArchiveMigrationStatus.Exported);
+            mockGithub.Setup(x => x.GetArchiveMigrationStatusAsync(SOURCE_ORG, It.IsAny<int>()).Result).Returns(ArchiveMigrationStatus.Exported);
 
             var mockSourceGithubApiFactory = new Mock<ISourceGithubApiFactory>();
             mockSourceGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), GITHUB_SOURCE_PAT)).Returns(mockGithub.Object);
@@ -930,8 +930,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             environmentVariableProviderMock.Verify(m => m.SourceGithubPersonalAccessToken(), Times.Never);
             environmentVariableProviderMock.Verify(m => m.TargetGithubPersonalAccessToken());
-            mockGithub.Verify(m => m.CreateGhecMigrationSource(It.IsAny<string>()));
-            mockGithub.Verify(m => m.StartMigration(
+            mockGithub.Verify(m => m.CreateGhecMigrationSourceAsync(It.IsAny<string>()));
+            mockGithub.Verify(m => m.StartMigrationAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
@@ -977,8 +977,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             environmentVariableProviderMock.Verify(m => m.SourceGithubPersonalAccessToken(), Times.Never);
             environmentVariableProviderMock.Verify(m => m.TargetGithubPersonalAccessToken(), Times.Never);
-            mockGithub.Verify(m => m.CreateGhecMigrationSource(It.IsAny<string>()));
-            mockGithub.Verify(m => m.StartMigration(
+            mockGithub.Verify(m => m.CreateGhecMigrationSourceAsync(It.IsAny<string>()));
+            mockGithub.Verify(m => m.StartMigrationAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
@@ -1019,7 +1019,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             // Assert
             actualLogOutput.Should().Contain("SKIP RELEASES: true");
 
-            mockGithub.Verify(m => m.StartMigration(
+            mockGithub.Verify(m => m.StartMigrationAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
@@ -1040,7 +1040,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
             mockGithub
-                .Setup(x => x.StartMigration(
+                .Setup(x => x.StartMigrationAsync(
                     It.IsAny<string>(),
                     expectedGithubRepoUrl,
                     It.IsAny<string>(),
@@ -1053,7 +1053,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Returns("migrationId");
 
             var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(It.IsAny<string>(), It.IsAny<int>()).Result).Returns(ArchiveMigrationStatus.Exported);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatusAsync(It.IsAny<string>(), It.IsAny<int>()).Result).Returns(ArchiveMigrationStatus.Exported);
 
             var mockAzureApi = TestHelpers.CreateMock<AzureApi>();
             mockAzureApi.Setup(x => x.UploadToBlob(It.IsAny<string>(), It.IsAny<byte[]>()).Result).Returns(new Uri("https://blob-url"));
@@ -1087,7 +1087,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await command.Invoke(args);
 
             // Assert
-            mockGithub.Verify(m => m.StartMigration(
+            mockGithub.Verify(m => m.StartMigrationAsync(
                 It.IsAny<string>(),
                 expectedGithubRepoUrl,
                 It.IsAny<string>(),
@@ -1108,7 +1108,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
             mockGithub
-                .Setup(x => x.StartMigration(
+                .Setup(x => x.StartMigrationAsync(
                     It.IsAny<string>(),
                     expectedGithubRepoUrl,
                     It.IsAny<string>(),
@@ -1121,7 +1121,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Returns("migrationId");
 
             var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(It.IsAny<string>(), It.IsAny<int>()).Result).Returns(ArchiveMigrationStatus.Exported);
+            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatusAsync(It.IsAny<string>(), It.IsAny<int>()).Result).Returns(ArchiveMigrationStatus.Exported);
 
             var mockAzureApi = TestHelpers.CreateMock<AzureApi>();
             mockAzureApi.Setup(x => x.UploadToBlob(It.IsAny<string>(), It.IsAny<byte[]>()).Result).Returns(new Uri("https://blob-url"));
@@ -1155,7 +1155,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await command.Invoke(args);
 
             // Assert
-            mockGithub.Verify(m => m.StartMigration(
+            mockGithub.Verify(m => m.StartMigrationAsync(
                 It.IsAny<string>(),
                 expectedGithubRepoUrl,
                 It.IsAny<string>(),

--- a/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
@@ -35,7 +35,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var githubOrgId = Guid.NewGuid().ToString();
 
             var mockGithub = TestHelpers.CreateMock<GithubApi>();
-            mockGithub.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+            mockGithub.Setup(x => x.GetOrganizationIdAsync(githubOrg).Result).Returns(githubOrgId);
 
             var mockGithubApiFactory = new Mock<ITargetGithubApiFactory>();
             mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(mockGithub.Object);
@@ -43,7 +43,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var command = new RevokeMigratorRoleCommand(TestHelpers.CreateMock<OctoLogger>().Object, mockGithubApiFactory.Object);
             await command.Invoke(githubOrg, actor, actorType);
 
-            mockGithub.Verify(x => x.RevokeMigratorRole(githubOrgId, actor, actorType));
+            mockGithub.Verify(x => x.RevokeMigratorRoleAsync(githubOrgId, actor, actorType));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/WaitForMigrationCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/WaitForMigrationCommandTests.cs
@@ -31,7 +31,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             const int waitIntervalInSeconds = 1;
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.SetupSequence(x => x.GetMigrationState(specifiedMigrationId).Result)
+            mockGithubApi.SetupSequence(x => x.GetMigrationStateAsync(specifiedMigrationId).Result)
                 .Returns(RepositoryMigrationStatus.InProgress)
                 .Returns(RepositoryMigrationStatus.InProgress)
                 .Returns(RepositoryMigrationStatus.Succeeded);
@@ -65,7 +65,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(5));
             mockLogger.Verify(m => m.LogSuccess(It.IsAny<string>()), Times.Once);
 
-            mockGithubApi.Verify(m => m.GetMigrationState(specifiedMigrationId), Times.Exactly(3));
+            mockGithubApi.Verify(m => m.GetMigrationStateAsync(specifiedMigrationId), Times.Exactly(3));
 
             actualLogOutput.Should().Equal(expectedLogOutput);
 
@@ -82,8 +82,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             const int waitIntervalInSeconds = 1;
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGithubApi.Setup(m => m.GetMigrationFailureReason(specifiedMigrationId).Result).Returns(failureReason);
-            mockGithubApi.SetupSequence(x => x.GetMigrationState(specifiedMigrationId).Result)
+            mockGithubApi.Setup(m => m.GetMigrationFailureReasonAsync(specifiedMigrationId).Result).Returns(failureReason);
+            mockGithubApi.SetupSequence(x => x.GetMigrationStateAsync(specifiedMigrationId).Result)
                 .Returns(RepositoryMigrationStatus.InProgress)
                 .Returns(RepositoryMigrationStatus.InProgress)
                 .Returns(RepositoryMigrationStatus.Failed);
@@ -122,8 +122,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(5));
             mockLogger.Verify(m => m.LogError(It.IsAny<string>()), Times.Once);
 
-            mockGithubApi.Verify(m => m.GetMigrationState(specifiedMigrationId), Times.Exactly(3));
-            mockGithubApi.Verify(m => m.GetMigrationFailureReason(specifiedMigrationId), Times.Once);
+            mockGithubApi.Verify(m => m.GetMigrationStateAsync(specifiedMigrationId), Times.Exactly(3));
+            mockGithubApi.Verify(m => m.GetMigrationFailureReasonAsync(specifiedMigrationId), Times.Once);
 
             actualLogOutput.Should().Equal(expectedLogOutput);
 
@@ -141,7 +141,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             var mockGithubApi = TestHelpers.CreateMock<GithubApi>();
             mockGithubApi
-                .Setup(x => x.GetMigrationState(specifiedMigrationId).Result)
+                .Setup(x => x.GetMigrationStateAsync(specifiedMigrationId).Result)
                 .Returns(RepositoryMigrationStatus.Succeeded);
 
             var mockTargetGithubApiFactory = new Mock<ITargetGithubApiFactory>();

--- a/src/OctoshiftCLI.Tests/gei/GithubApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/GithubApiFactoryTests.cs
@@ -219,7 +219,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             // Act
             ISourceGithubApiFactory factory = new GithubApiFactory(_logger, mockHttpClientFactory.Object, null, null, null);
             var githubApi = factory.Create(null, SOURCE_GH_PAT);
-            await githubApi.DeleteRepo("org", "repo"); // call a simple/random API method just for the sake of verifying the base API url
+            await githubApi.DeleteRepoAsync("org", "repo"); // call a simple/random API method just for the sake of verifying the base API url
 
             // Assert
             handlerMock.Protected().Verify(
@@ -252,7 +252,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             // Act
             ITargetGithubApiFactory factory = new GithubApiFactory(_logger, mockHttpClientFactory.Object, null, null, null);
             var githubApi = factory.Create(null, TARGET_GH_PAT);
-            await githubApi.DeleteRepo("org", "repo"); // call a simple/random API method just for the sake of verifying the base API url
+            await githubApi.DeleteRepoAsync("org", "repo"); // call a simple/random API method just for the sake of verifying the base API url
 
             // Assert
             handlerMock.Protected().Verify(
@@ -285,7 +285,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             // Act
             ISourceGithubApiFactory factory = new GithubApiFactory(_logger, mockHttpClientFactory.Object, null, null, null);
             var githubApi = factory.CreateClientNoSsl(null, SOURCE_GH_PAT);
-            await githubApi.DeleteRepo("org", "repo"); // call a simple/random API method just for the sake of verifying the base API url
+            await githubApi.DeleteRepoAsync("org", "repo"); // call a simple/random API method just for the sake of verifying the base API url
 
             // Assert
             handlerMock.Protected().Verify(

--- a/src/ado2gh/Commands/AddTeamToRepoCommand.cs
+++ b/src/ado2gh/Commands/AddTeamToRepoCommand.cs
@@ -70,8 +70,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             }
 
             var github = _githubApiFactory.Create(personalAccessToken: githubPat);
-            var teamSlug = await github.GetTeamSlug(githubOrg, team);
-            await github.AddTeamToRepo(githubOrg, githubRepo, teamSlug, role);
+            var teamSlug = await github.GetTeamSlugAsync(githubOrg, team);
+            await github.AddTeamToRepoAsync(githubOrg, githubRepo, teamSlug, role);
 
             _log.LogSuccess("Successfully added team to repo");
         }

--- a/src/ado2gh/Commands/ConfigureAutoLinkCommand.cs
+++ b/src/ado2gh/Commands/ConfigureAutoLinkCommand.cs
@@ -74,7 +74,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
 
-            var autoLinks = await githubApi.GetAutoLinks(githubOrg, githubRepo);
+            var autoLinks = await githubApi.GetAutoLinksAsync(githubOrg, githubRepo);
             if (autoLinks.Any(al => al.KeyPrefix == keyPrefix && al.UrlTemplate == urlTemplate))
             {
                 _log.LogSuccess($"Autolink reference already exists for key_prefix: '{keyPrefix}'. No operation will be performed");
@@ -86,10 +86,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 _log.LogInformation($"Autolink reference already exists for key_prefix: '{keyPrefix}', but the url template is incorrect");
                 _log.LogInformation($"Deleting existing Autolink reference for key_prefix: '{keyPrefix}' before creating a new Autolink reference");
-                await githubApi.DeleteAutoLink(githubOrg, githubRepo, autoLink.Id);
+                await githubApi.DeleteAutoLinkAsync(githubOrg, githubRepo, autoLink.Id);
             }
 
-            await githubApi.AddAutoLink(githubOrg, githubRepo, keyPrefix, urlTemplate);
+            await githubApi.AddAutoLinkAsync(githubOrg, githubRepo, keyPrefix, urlTemplate);
 
             _log.LogSuccess("Successfully configured autolink references");
         }

--- a/src/ado2gh/Commands/CreateTeamCommand.cs
+++ b/src/ado2gh/Commands/CreateTeamCommand.cs
@@ -65,19 +65,19 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
 
-            var teams = await githubApi.GetTeams(githubOrg);
+            var teams = await githubApi.GetTeamsAsync(githubOrg);
             if (teams.Contains(teamName))
             {
                 _log.LogSuccess($"Team '{teamName}' already exists - New team will not be created");
             }
             else
             {
-                await githubApi.CreateTeam(githubOrg, teamName);
+                await githubApi.CreateTeamAsync(githubOrg, teamName);
                 _log.LogSuccess("Successfully created team");
             }
 
             // TODO: Can improve perf by capturing slug in the response from CreateTeam or GetTeams
-            var teamSlug = await githubApi.GetTeamSlug(githubOrg, teamName);
+            var teamSlug = await githubApi.GetTeamSlugAsync(githubOrg, teamName);
 
             if (string.IsNullOrWhiteSpace(idpGroup))
             {
@@ -85,16 +85,16 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             }
             else
             {
-                var members = await githubApi.GetTeamMembers(githubOrg, teamSlug);
+                var members = await githubApi.GetTeamMembersAsync(githubOrg, teamSlug);
 
                 foreach (var member in members)
                 {
-                    await githubApi.RemoveTeamMember(githubOrg, teamSlug, member);
+                    await githubApi.RemoveTeamMemberAsync(githubOrg, teamSlug, member);
                 }
 
-                var idpGroupId = await githubApi.GetIdpGroupId(githubOrg, idpGroup);
+                var idpGroupId = await githubApi.GetIdpGroupIdAsync(githubOrg, idpGroup);
 
-                await githubApi.AddEmuGroupToTeam(githubOrg, teamSlug, idpGroupId);
+                await githubApi.AddEmuGroupToTeamAsync(githubOrg, teamSlug, idpGroupId);
 
                 _log.LogSuccess("Successfully linked team to Idp group");
             }

--- a/src/ado2gh/Commands/GenerateMannequinCsvCommand.cs
+++ b/src/ado2gh/Commands/GenerateMannequinCsvCommand.cs
@@ -84,8 +84,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
 
-            var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
-            var mannequins = await githubApi.GetMannequins(githubOrgId);
+            var githubOrgId = await githubApi.GetOrganizationIdAsync(githubOrg);
+            var mannequins = await githubApi.GetMannequinsAsync(githubOrgId);
 
             _log.LogInformation($"    # Mannequins Found: {mannequins.Count()}");
             _log.LogInformation($"    # Mannequins Previously Reclaimed: {mannequins.Count(x => x.MappedUser is not null)}");

--- a/src/ado2gh/Commands/GrantMigratorRoleCommand.cs
+++ b/src/ado2gh/Commands/GrantMigratorRoleCommand.cs
@@ -76,8 +76,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             }
 
             var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
-            var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
-            var success = await githubApi.GrantMigratorRole(githubOrgId, actor, actorType);
+            var githubOrgId = await githubApi.GetOrganizationIdAsync(githubOrg);
+            var success = await githubApi.GrantMigratorRoleAsync(githubOrgId, actor, actorType);
 
             if (success)
             {

--- a/src/ado2gh/Commands/MigrateRepoCommand.cs
+++ b/src/ado2gh/Commands/MigrateRepoCommand.cs
@@ -121,9 +121,9 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             var adoRepoUrl = GetAdoRepoUrl(adoOrg, adoTeamProject, adoRepo);
 
             adoPat ??= _environmentVariableProvider.AdoPersonalAccessToken();
-            var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
-            var migrationSourceId = await githubApi.CreateAdoMigrationSource(githubOrgId, null);
-            var migrationId = await githubApi.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, adoPat, githubPat);
+            var githubOrgId = await githubApi.GetOrganizationIdAsync(githubOrg);
+            var migrationSourceId = await githubApi.CreateAdoMigrationSourceAsync(githubOrgId, null);
+            var migrationId = await githubApi.StartMigrationAsync(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, adoPat, githubPat);
 
             if (!wait)
             {
@@ -131,20 +131,20 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                 return;
             }
 
-            var migrationState = await githubApi.GetMigrationState(migrationId);
+            var migrationState = await githubApi.GetMigrationStateAsync(migrationId);
 
             while (migrationState.Trim().ToUpper() is "IN_PROGRESS" or "QUEUED")
             {
                 _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. Waiting 10 seconds...");
                 await Task.Delay(10000);
-                migrationState = await githubApi.GetMigrationState(migrationId);
+                migrationState = await githubApi.GetMigrationStateAsync(migrationId);
             }
 
             if (migrationState.Trim().ToUpper() == "FAILED")
             {
                 _log.LogError($"Migration Failed. Migration ID: {migrationId}");
 
-                var failureReason = await githubApi.GetMigrationFailureReason(migrationId);
+                var failureReason = await githubApi.GetMigrationFailureReasonAsync(migrationId);
                 throw new OctoshiftCliException(failureReason);
             }
 
@@ -153,7 +153,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
         private async Task<bool> RepoExists(GithubApi githubApi, string org, string repo)
         {
-            var repos = await githubApi.GetRepos(org);
+            var repos = await githubApi.GetReposAsync(org);
             return repos.Contains(repo, StringComparer.OrdinalIgnoreCase);
         }
 

--- a/src/ado2gh/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/ado2gh/Commands/RevokeMigratorRoleCommand.cs
@@ -76,8 +76,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             }
 
             var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
-            var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
-            var success = await githubApi.RevokeMigratorRole(githubOrgId, actor, actorType);
+            var githubOrgId = await githubApi.GetOrganizationIdAsync(githubOrg);
+            var success = await githubApi.RevokeMigratorRoleAsync(githubOrgId, actor, actorType);
 
             if (success)
             {

--- a/src/ado2gh/Commands/WaitForMigrationCommand.cs
+++ b/src/ado2gh/Commands/WaitForMigrationCommand.cs
@@ -55,11 +55,11 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             while (true)
             {
-                var specifiedMigrationState = await githubApi.GetMigrationState(migrationId);
+                var specifiedMigrationState = await githubApi.GetMigrationStateAsync(migrationId);
                 switch (specifiedMigrationState)
                 {
                     case RepositoryMigrationStatus.Failed:
-                        var failureReason = await githubApi.GetMigrationFailureReason(migrationId);
+                        var failureReason = await githubApi.GetMigrationFailureReasonAsync(migrationId);
                         _log.LogError($"Migration failed for migration {migrationId}");
                         throw new OctoshiftCliException(failureReason);
                     case RepositoryMigrationStatus.Succeeded:

--- a/src/gei/Commands/GenerateMannequinCsvCommand.cs
+++ b/src/gei/Commands/GenerateMannequinCsvCommand.cs
@@ -84,8 +84,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             var githubApi = _targetGithubApiFactory.Create(targetPersonalAccessToken: githubTargetPat);
 
-            var githubOrgId = await githubApi.GetOrganizationId(githubTargetOrg);
-            var mannequins = await githubApi.GetMannequins(githubOrgId);
+            var githubOrgId = await githubApi.GetOrganizationIdAsync(githubTargetOrg);
+            var mannequins = await githubApi.GetMannequinsAsync(githubOrgId);
 
             _log.LogInformation($"    # Mannequins Found: {mannequins.Count()}");
             _log.LogInformation($"    # Mannequins Previously Reclaimed: {mannequins.Count(x => x.MappedUser is not null)}");

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -252,7 +252,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             }
 
             _log.LogInformation($"GITHUB ORG: {githubOrg}");
-            var repos = await github.GetRepos(githubOrg);
+            var repos = await github.GetReposAsync(githubOrg);
 
             foreach (var repo in repos)
             {

--- a/src/gei/Commands/GrantMigratorRoleCommand.cs
+++ b/src/gei/Commands/GrantMigratorRoleCommand.cs
@@ -75,8 +75,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             }
 
             var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubTargetPat);
-            var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
-            var success = await githubApi.GrantMigratorRole(githubOrgId, actor, actorType);
+            var githubOrgId = await githubApi.GetOrganizationIdAsync(githubOrg);
+            var success = await githubApi.GrantMigratorRoleAsync(githubOrgId, actor, actorType);
 
             if (success)
             {

--- a/src/gei/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/gei/Commands/RevokeMigratorRoleCommand.cs
@@ -76,8 +76,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             }
 
             var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubTargetPat);
-            var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
-            var success = await githubApi.RevokeMigratorRole(githubOrgId, actor, actorType);
+            var githubOrgId = await githubApi.GetOrganizationIdAsync(githubOrg);
+            var success = await githubApi.RevokeMigratorRoleAsync(githubOrgId, actor, actorType);
 
             if (success)
             {

--- a/src/gei/Commands/WaitForMigrationCommand.cs
+++ b/src/gei/Commands/WaitForMigrationCommand.cs
@@ -56,11 +56,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             while (true)
             {
-                var specifiedMigrationState = await githubApi.GetMigrationState(migrationId);
+                var specifiedMigrationState = await githubApi.GetMigrationStateAsync(migrationId);
                 switch (specifiedMigrationState)
                 {
                     case RepositoryMigrationStatus.Failed:
-                        var failureReason = await githubApi.GetMigrationFailureReason(migrationId);
+                        var failureReason = await githubApi.GetMigrationFailureReasonAsync(migrationId);
                         _log.LogError($"Migration failed for migration {migrationId}");
                         throw new OctoshiftCliException(failureReason);
                     case RepositoryMigrationStatus.Succeeded:


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [X] Did you write/update appropriate tests
- [X] Release notes updated (if appropriate)
- [X] Appropriate logging output
- [X] Issue linked
- [X] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->

### Explanation / Reason behind this PR
Currently there's a mix usage of the `Async` suffix across the codebase on asynchronous methods. This PR doesn't change any logic, it's only an attempt to get more consistency across the codebase.

### Further Details
While I was studying this solution, I did some improvements that you may want to benefit from. If it doesn't add value to your project feel free to close the PR 👍 