### PR TITLE
tests: Remove duplicated lines from GithubApiTests

### DIFF
--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -18,6 +18,9 @@ namespace OctoshiftCLI.Tests
     {
         private const string Api_Url = $"https://api.github.com";
         private readonly RetryPolicy _retryPolicy = new RetryPolicy(TestHelpers.CreateMock<OctoLogger>().Object);
+        private readonly Mock<GithubClient> _githubClientMock;
+
+        public GithubApiTests() => _githubClientMock = TestHelpers.CreateMock<GithubClient>();
 
         [Fact]
         public async Task AddAutoLink_Calls_The_Right_Endpoint_With_Payload()
@@ -39,14 +42,12 @@ namespace OctoshiftCLI.Tests
                 url_template = urlTemplate.Replace(" ", "%20")
             };
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.AddAutoLink(org, repo, keyPrefix, urlTemplate);
 
             // Assert
-            githubClientMock.Verify(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
+            _githubClientMock.Verify(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
         }
 
         [Fact]
@@ -69,14 +70,12 @@ namespace OctoshiftCLI.Tests
                 url_template = urlTemplate.Replace(" ", "%20")
             };
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.AddAutoLink(org, repo, keyPrefix, urlTemplate);
 
             // Assert
-            githubClientMock.Verify(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
+            _githubClientMock.Verify(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
         }
 
         [Fact]
@@ -88,14 +87,14 @@ namespace OctoshiftCLI.Tests
 
             var url = $"https://api.github.com/repos/{org}/{repo}/autolinks";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock.Setup(x => x.GetAllAsync(It.IsAny<string>())).Returns(AsyncEnumerable.Empty<JToken>());
+            _githubClientMock.Setup(x => x.GetAllAsync(It.IsAny<string>())).Returns(AsyncEnumerable.Empty<JToken>());
+
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.GetAutoLinks(org, repo);
 
             // Assert
-            githubClientMock.Verify(m => m.GetAllAsync(url));
+            _githubClientMock.Verify(m => m.GetAllAsync(url));
         }
 
         [Fact]
@@ -108,13 +107,12 @@ namespace OctoshiftCLI.Tests
 
             var url = $"https://api.github.com/repos/{org}/{repo}/autolinks/{autoLinkId}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.DeleteAutoLink(org, repo, autoLinkId);
 
             // Assert
-            githubClientMock.Verify(m => m.DeleteAsync(url));
+            _githubClientMock.Verify(m => m.DeleteAsync(url));
         }
 
         [Fact]
@@ -130,13 +128,12 @@ namespace OctoshiftCLI.Tests
             const string teamId = "TEAM_ID";
             var response = $"{{\"id\": \"{teamId}\"}}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var result = await githubApi.CreateTeam(org, teamName);
 
             // Assert
@@ -164,13 +161,12 @@ namespace OctoshiftCLI.Tests
                 new { id = 4, name = team4 }
             }.ToAsyncJTokenEnumerable();
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.GetAllAsync(url))
                 .Returns(teamsResult);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var result = (await githubApi.GetTeams(org)).ToArray();
 
             // Assert
@@ -228,13 +224,12 @@ namespace OctoshiftCLI.Tests
                 await Task.CompletedTask;
             }
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.GetAllAsync(url))
                 .Returns(GetAllPages);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var result = (await githubApi.GetTeamMembers(org, teamName)).ToArray();
 
             // Assert
@@ -251,8 +246,7 @@ namespace OctoshiftCLI.Tests
 
             var url = $"https://api.github.com/orgs/{org}/teams/{teamName}/members?per_page=100";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .SetupSequence(m => m.GetAllAsync(url))
                 .Throws(new HttpRequestException(null, null, statusCode: HttpStatusCode.NotFound))
                 .Throws(new HttpRequestException(null, null, statusCode: HttpStatusCode.NotFound))
@@ -262,7 +256,7 @@ namespace OctoshiftCLI.Tests
                 }.ToAsyncJTokenEnumerable());
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var result = (await githubApi.GetTeamMembers(org, teamName)).ToArray();
 
             // Assert
@@ -317,13 +311,12 @@ namespace OctoshiftCLI.Tests
                 await Task.CompletedTask;
             }
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.GetAllAsync(url))
                 .Returns(GetAllPages);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var result = (await githubApi.GetRepos(org)).ToArray();
 
             // Assert
@@ -341,15 +334,14 @@ namespace OctoshiftCLI.Tests
 
             var url = $"https://api.github.com/orgs/{org}/teams/{teamName}/memberships/{member}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock.Setup(m => m.DeleteAsync(url));
+            _githubClientMock.Setup(m => m.DeleteAsync(url));
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.RemoveTeamMember(org, teamName, member);
 
             // Assert
-            githubClientMock.Verify(m => m.DeleteAsync(url));
+            _githubClientMock.Verify(m => m.DeleteAsync(url));
         }
 
         [Fact]
@@ -368,14 +360,12 @@ namespace OctoshiftCLI.Tests
                 groups = new[] { new { group_id = groupId, group_name = groupName, group_description = groupDesc } }
             };
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.AddTeamSync(org, teamName, groupId, groupName, groupDesc);
 
             // Assert
-            githubClientMock.Verify(m => m.PatchAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
+            _githubClientMock.Verify(m => m.PatchAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
         }
 
         [Fact]
@@ -390,14 +380,12 @@ namespace OctoshiftCLI.Tests
             var url = $"https://api.github.com/orgs/{org}/teams/{teamName}/repos/{org}/{repo}";
             var payload = new { permission = role };
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.AddTeamToRepo(org, repo, teamName, role);
 
             // Assert
-            githubClientMock.Verify(m => m.PutAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
+            _githubClientMock.Verify(m => m.PutAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
         }
 
         [Fact]
@@ -423,13 +411,12 @@ namespace OctoshiftCLI.Tests
                     }} 
             }}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var result = await githubApi.GetOrganizationId(org);
 
             // Assert
@@ -461,13 +448,12 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var expectedMigrationSourceId = await githubApi.CreateAdoMigrationSource(orgId, null);
 
             // Assert
@@ -500,13 +486,12 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var expectedMigrationSourceId = await githubApi.CreateAdoMigrationSource(orgId, adoServerUrl);
 
             // Assert
@@ -538,13 +523,12 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var expectedMigrationSourceId = await githubApi.CreateGhecMigrationSource(orgId);
 
             // Assert
@@ -642,13 +626,12 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var expectedRepositoryMigrationId = await githubApi.StartMigration(migrationSourceId, adoRepoUrl, orgId, repo, sourceToken, targetToken, gitArchiveUrl, metadataArchiveUrl);
 
             // Assert
@@ -681,13 +664,12 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var expectedMigrationState = await githubApi.GetMigrationState(migrationId);
 
             // Assert
@@ -720,15 +702,14 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .SetupSequence(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .Throws(new HttpRequestException(null, null, statusCode: HttpStatusCode.BadGateway))
                 .Throws(new HttpRequestException(null, null, statusCode: HttpStatusCode.BadGateway))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var expectedMigrationState = await githubApi.GetMigrationState(migrationId);
 
             // Assert
@@ -761,13 +742,12 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var expectedFailureReason = await githubApi.GetMigrationFailureReason(migrationId);
 
             // Assert
@@ -800,15 +780,14 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .SetupSequence(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .Throws(new HttpRequestException(null, null, statusCode: HttpStatusCode.BadGateway))
                 .Throws(new HttpRequestException(null, null, statusCode: HttpStatusCode.BadGateway))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var expectedFailureReason = await githubApi.GetMigrationFailureReason(migrationId);
 
             // Assert
@@ -840,13 +819,12 @@ namespace OctoshiftCLI.Tests
                 ]
             }}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.GetAsync(url))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var actualGroupId = await githubApi.GetIdpGroupId(org, groupName);
 
             // Assert
@@ -881,13 +859,12 @@ namespace OctoshiftCLI.Tests
                 }
             }.ToAsyncJTokenEnumerable();
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.GetAllAsync(url))
                 .Returns(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var actualTeamSlug = await githubApi.GetTeamSlug(org, teamName);
 
             // Assert
@@ -905,14 +882,12 @@ namespace OctoshiftCLI.Tests
             var url = $"https://api.github.com/orgs/{org}/teams/{teamSlug}/external-groups";
             var payload = new { group_id = groupId };
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.AddEmuGroupToTeam(org, teamSlug, groupId);
 
             // Assert
-            githubClientMock.Verify(m => m.PatchAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
+            _githubClientMock.Verify(m => m.PatchAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
         }
 
         [Fact]
@@ -939,13 +914,12 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var actualSuccessState = await githubApi.GrantMigratorRole(org, actor, actorType);
 
             // Assert
@@ -967,13 +941,12 @@ namespace OctoshiftCLI.Tests
                 $",\"variables\":{{\"organizationId\":\"{org}\",\"actor\":\"{actor}\",\"actor_type\":\"{actorType}\"}}," +
                 "\"operationName\":\"grantMigratorRole\"}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .Throws<HttpRequestException>();
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var actualSuccessState = await githubApi.GrantMigratorRole(org, actor, actorType);
 
             // Assert
@@ -1004,13 +977,12 @@ namespace OctoshiftCLI.Tests
                 }}
             }}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var actualSuccessState = await githubApi.RevokeMigratorRole(org, actor, actorType);
 
             // Assert
@@ -1032,13 +1004,12 @@ namespace OctoshiftCLI.Tests
                 $",\"variables\":{{\"organizationId\":\"{org}\",\"actor\":\"{actor}\",\"actor_type\":\"{actorType}\"}}," +
                 "\"operationName\":\"revokeMigratorRole\"}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .Throws<HttpRequestException>();
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var actualSuccessState = await githubApi.RevokeMigratorRole(org, actor, actorType);
 
             // Assert
@@ -1054,14 +1025,12 @@ namespace OctoshiftCLI.Tests
 
             var url = $"https://api.github.com/repos/{org}/{repo}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             await githubApi.DeleteRepo(org, repo);
 
             // Assert
-            githubClientMock.Verify(m => m.DeleteAsync(url));
+            _githubClientMock.Verify(m => m.DeleteAsync(url));
         }
 
         [Fact]
@@ -1133,8 +1102,7 @@ namespace OctoshiftCLI.Tests
                 createdAt = DateTime.UtcNow
             };
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostGraphQLWithPaginationAsync(
                     url,
                     It.Is<object>(x => Compact(x.ToJson()) == Compact(payload)),
@@ -1151,7 +1119,7 @@ namespace OctoshiftCLI.Tests
                 }.ToAsyncEnumerable());
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var migrationStates = (await githubApi.GetMigrationStates(orgId)).ToArray();
 
             // Assert
@@ -1188,13 +1156,12 @@ namespace OctoshiftCLI.Tests
                     }} 
             }}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var result = await githubApi.GetUserId(login);
 
             // Assert
@@ -1232,13 +1199,12 @@ namespace OctoshiftCLI.Tests
 	            ]
             }";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload)))
                 .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var result = await githubApi.GetUserId(login);
 
             // Assert
@@ -1311,15 +1277,13 @@ namespace OctoshiftCLI.Tests
                 }
             };
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url,
                 It.Is<object>(x => Compact(x.ToJson()) == Compact(payload))))
                     .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var result = await githubApi.ReclaimMannequin(orgId, mannequinId, targetUserId);
 
             // Assert
@@ -1357,8 +1321,7 @@ namespace OctoshiftCLI.Tests
             }""" +
     $",\"variables\":{{\"id\":\"{orgId}\"}}}}";
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostGraphQLWithPaginationAsync(
                     url,
                     It.Is<object>(x => Compact(x.ToJson()) == Compact(payload)),
@@ -1369,7 +1332,7 @@ namespace OctoshiftCLI.Tests
                     .Returns(Array.Empty<JToken>().ToAsyncEnumerable());
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var result = await githubApi.GetMannequins(orgId);
 
             // Assert
@@ -1426,8 +1389,7 @@ namespace OctoshiftCLI.Tests
                 }
             };
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostGraphQLWithPaginationAsync(
                     url,
                     It.Is<object>(x => Compact(x.ToJson()) == Compact(payload)),
@@ -1442,7 +1404,7 @@ namespace OctoshiftCLI.Tests
                         }.ToAsyncEnumerable());
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var result = await githubApi.GetMannequins(orgId);
 
             // Assert
@@ -1527,15 +1489,13 @@ namespace OctoshiftCLI.Tests
                 }
             };
 
-            var githubClientMock = TestHelpers.CreateMock<GithubClient>();
-
-            githubClientMock
+            _githubClientMock
                 .Setup(m => m.PostAsync(url,
                 It.Is<object>(x => Compact(x.ToJson()) == Compact(payload))))
                     .ReturnsAsync(response);
 
             // Act
-            var githubApi = new GithubApi(githubClientMock.Object, Api_Url, _retryPolicy);
+            var githubApi = new GithubApi(_githubClientMock.Object, Api_Url, _retryPolicy);
             var result = await githubApi.ReclaimMannequin(orgId, mannequinId, targetUserId);
 
             // Assert

--- a/src/OctoshiftCLI.Tests/TestExtensionMethods.cs
+++ b/src/OctoshiftCLI.Tests/TestExtensionMethods.cs
@@ -6,6 +6,7 @@ namespace OctoshiftCLI.Tests
 {
     public static class TestExtensionMethods
     {
-        public static IAsyncEnumerable<JToken> ToAsyncJTokenEnumerable<T>(this IEnumerable<T> list) => list.Select(x => JToken.FromObject(x)).ToAsyncEnumerable();
+        public static IAsyncEnumerable<JToken> ToAsyncJTokenEnumerable<T>(this IEnumerable<T> list)
+            => list.Select(x => JToken.FromObject(x)).ToAsyncEnumerable();
     }
 }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [X] Did you write/update appropriate tests
- [X] Release notes updated (if appropriate)
- [X] Appropriate logging output
- [ ] Issue linked
- [X] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->

### Explanation / Reason behind this PR
Removed duplicated lines while arranging, taking advantage of the ctor to instantiate GithubClient's mock.

### Further Details
While I was studying this solution, I did some improvements that you may want to benefit from. If it doesn't add value to your project feel free to close the PR 👍 