### PR TITLE
fix: Take advantage of asynchronous code on LockRepoCommand

### DIFF
--- a/src/ado2gh/Commands/LockRepoCommand.cs
+++ b/src/ado2gh/Commands/LockRepoCommand.cs
@@ -64,8 +64,12 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             var ado = _adoApiFactory.Create(adoPat);
 
-            var teamProjectId = await ado.GetTeamProjectId(adoOrg, adoTeamProject);
-            var repoId = await ado.GetRepoId(adoOrg, adoTeamProject, adoRepo);
+            var teamProjectIdTask = ado.GetTeamProjectId(adoOrg, adoTeamProject);
+            var repoIdTask = ado.GetRepoId(adoOrg, adoTeamProject, adoRepo);
+
+            var teamProjectId = await teamProjectIdTask;
+            var repoId = await repoIdTask;
+
             var identityDescriptor = await ado.GetIdentityDescriptor(adoOrg, teamProjectId, "Project Valid Users");
             await ado.LockRepo(adoOrg, teamProjectId, repoId, identityDescriptor);
 


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [X] Did you write/update appropriate tests
- [X] Release notes updated (if appropriate)
- [X] Appropriate logging output
- [X] Issue linked
- [X] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->

### Explanation / Reason behind this PR
We can take advantage of asynchronous programming and, since getting team project id and repo id are idempotent, we can paralyze those calls.

### Further Details
While I was studying this solution, I did some improvements that you may want to benefit from. If it doesn't add value to your project feel free to close the PR 👍 