### PR TITLE
hide download-logs command

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,0 @@
-- Add `download-logs` command to download migration logs

--- a/src/ado2gh/Commands/DownloadLogsCommand.cs
+++ b/src/ado2gh/Commands/DownloadLogsCommand.cs
@@ -28,6 +28,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _httpDownloadService = httpDownloadService;
 
             Description = "Downloads migration logs for migrations.";
+            IsHidden = true;
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/gei/Commands/DownloadLogsCommand.cs
+++ b/src/gei/Commands/DownloadLogsCommand.cs
@@ -28,6 +28,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             _httpDownloadService = httpDownloadService;
 
             Description = "Downloads migration logs for migrations.";
+            IsHidden = true;
 
             var githubTargetOrg = new Option<string>("--github-target-org")
             {


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

The octoshift backend in production doesn't have this feature turned on yet. So making this command hidden for now until the backend in production is updated.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->