### PR TITLE
roll back async change

### DIFF
--- a/src/ado2gh/Commands/LockRepoCommand.cs
+++ b/src/ado2gh/Commands/LockRepoCommand.cs
@@ -64,11 +64,8 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             var ado = _adoApiFactory.Create(adoPat);
 
-            var teamProjectIdTask = ado.GetTeamProjectId(adoOrg, adoTeamProject);
-            var repoIdTask = ado.GetRepoId(adoOrg, adoTeamProject, adoRepo);
-
-            var teamProjectId = await teamProjectIdTask;
-            var repoId = await repoIdTask;
+            var teamProjectId = await ado.GetTeamProjectId(adoOrg, adoTeamProject);
+            var repoId = await ado.GetRepoId(adoOrg, adoTeamProject, adoRepo);
 
             var identityDescriptor = await ado.GetIdentityDescriptor(adoOrg, teamProjectId, "Project Valid Users");
             await ado.LockRepo(adoOrg, teamProjectId, repoId, identityDescriptor);


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

The change yesterday to optimize a couple of async calls in `lock-repo` (#390 ) appears to have caused a bug that sometimes crashes the logger when calling `lock-repo` (example here: https://github.com/github/gh-gei/runs/6512019217?check_suite_focus=true#step:16:210).

We should probably improve our logger to be more resilient. But for now I'm going to roll back this change.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->