### PR TITLE
added urls to all the csvs

### DIFF
--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
@@ -100,7 +100,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockOrgsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedOrgsCsv);
             _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(ADO_PIPELINES)).Returns(expectedTeamProjectsCsv);
             _mockReposCsvGenerator.Setup(m => m.Generate(ADO_PIPELINES)).Returns(expectedReposCsv);
-            _mockPipelinesCsvGenerator.Setup(m => m.Generate(ADO_PIPELINES)).Returns(expectedPipelinesCsv);
+            _mockPipelinesCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedPipelinesCsv);
 
             await _command.Invoke(null, null);
 
@@ -128,7 +128,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockOrgsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedOrgsCsv);
             _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(ADO_PIPELINES)).Returns(expectedTeamProjectsCsv);
             _mockReposCsvGenerator.Setup(m => m.Generate(ADO_PIPELINES)).Returns(expectedReposCsv);
-            _mockPipelinesCsvGenerator.Setup(m => m.Generate(ADO_PIPELINES)).Returns(expectedPipelinesCsv);
+            _mockPipelinesCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedPipelinesCsv);
 
             await _command.Invoke(ADO_ORG, null);
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/OrgsCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/OrgsCsvGeneratorServiceTests.cs
@@ -10,7 +10,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 {
     public class OrgsCsvGeneratorServiceTests
     {
-        private const string CSV_HEADER = "name,owner,teamproject-count,repo-count,pipeline-count";
+        private const string CSV_HEADER = "name,url,owner,teamproject-count,repo-count,pipeline-count";
 
         [Fact]
         public async Task Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
@@ -37,7 +37,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             // Assert
             var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            expected += $"{org},{ownerName} ({ownerEmail}),1,1,1{Environment.NewLine}";
+            expected += $"{org},https://dev.azure.com/{org},{ownerName} ({ownerEmail}),1,1,1{Environment.NewLine}";
 
             result.Should().Be(expected);
         }

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
+using Moq;
 using OctoshiftCLI.AdoToGithub;
 using Xunit;
 
@@ -8,39 +10,43 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 {
     public class PipelinesCsvGeneratorServiceTests
     {
-        private const string CSV_HEADER = "org,teamproject,repo,pipeline";
+        private const string CSV_HEADER = "org,teamproject,repo,pipeline,url";
 
         [Fact]
-        public void Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
+        public async Task Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
         {
             // Arrange
             var org = "my-org";
             var teamProject = "foo-tp";
             var repo = "foo-repo";
             var pipeline = "foo-pipeline";
+            var pipelineId = 23;
             var pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
                 { { org, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
                              { { teamProject, new Dictionary<string, IEnumerable<string>>()
                                                    { { repo, new List<string>()
                                                                  { pipeline } } } } } } };
 
+            var mockAdoApi = TestHelpers.CreateMock<AdoApi>();
+            mockAdoApi.Setup(m => m.GetPipelineId(org, teamProject, pipeline)).ReturnsAsync(pipelineId);
+
             // Act
             var service = new PipelinesCsvGeneratorService();
-            var result = service.Generate(pipelines);
+            var result = await service.Generate(mockAdoApi.Object, pipelines);
 
             // Assert
             var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            expected += $"{org},{teamProject},{repo},{pipeline}{Environment.NewLine}";
+            expected += $"{org},{teamProject},{repo},{pipeline},https://dev.azure.com/{org}/{teamProject}/_build?definitionId={pipelineId}{Environment.NewLine}";
 
             result.Should().Be(expected);
         }
 
         [Fact]
-        public void Generate_Should_Return_Correct_Csv_When_Passed_Null_Orgs()
+        public async Task Generate_Should_Return_Correct_Csv_When_Passed_Null_Orgs()
         {
             // Act
             var service = new PipelinesCsvGeneratorService();
-            var result = service.Generate(null);
+            var result = await service.Generate(null, null);
 
             // Assert
             var expected = $"{CSV_HEADER}{Environment.NewLine}";

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
@@ -8,15 +8,15 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 {
     public class ReposCsvGeneratorServiceTests
     {
-        private const string CSV_HEADER = "org,teamproject,repo,pipeline-count";
+        private const string CSV_HEADER = "org,teamproject,repo,url,pipeline-count";
 
         [Fact]
         public void Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
         {
             // Arrange
-            var org = "my-org";
-            var teamProject = "foo-tp";
-            var repo = "foo-repo";
+            var org = "my org";
+            var teamProject = "foo tp";
+            var repo = "foo repo";
             var pipeline = "foo-pipeline";
             var pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
                 { { org, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
@@ -30,7 +30,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             // Assert
             var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            expected += $"{org},{teamProject},{repo},1{Environment.NewLine}";
+            expected += $"{org},{teamProject},{repo},https://dev.azure.com/my%20org/foo%20tp/_git/foo%20repo,1{Environment.NewLine}";
 
             result.Should().Be(expected);
         }

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/TeamProjectsCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/TeamProjectsCsvGeneratorServiceTests.cs
@@ -8,7 +8,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 {
     public class TeamProjectsCsvGeneratorServiceTests
     {
-        private const string CSV_HEADER = "org,teamproject,repo-count,pipeline-count";
+        private const string CSV_HEADER = "org,teamproject,url,repo-count,pipeline-count";
 
         [Fact]
         public void Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
@@ -30,7 +30,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             // Assert
             var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            expected += $"{org},{teamProject},1,1{Environment.NewLine}";
+            expected += $"{org},{teamProject},https://dev.azure.com/{org}/{teamProject},1,1{Environment.NewLine}";
 
             result.Should().Be(expected);
         }

--- a/src/ado2gh/Commands/InventoryReportCommand.cs
+++ b/src/ado2gh/Commands/InventoryReportCommand.cs
@@ -89,7 +89,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             var orgsCsvText = await _orgsCsvGenerator.Generate(ado, pipelines);
             var teamProjectsCsvText = _teamProjectsCsvGenerator.Generate(pipelines);
             var reposCsvText = _reposCsvGenerator.Generate(pipelines);
-            var pipelinesCsvText = _pipelinesCsvGenerator.Generate(pipelines);
+            var pipelinesCsvText = await _pipelinesCsvGenerator.Generate(ado, pipelines);
 
             await WriteToFile("orgs.csv", orgsCsvText);
             _log.LogSuccess("orgs.csv generated");

--- a/src/ado2gh/Services/OrgsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/OrgsCsvGeneratorService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace OctoshiftCLI.AdoToGithub
 {

--- a/src/ado2gh/Services/OrgsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/OrgsCsvGeneratorService.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace OctoshiftCLI.AdoToGithub
 {
@@ -13,7 +15,7 @@ namespace OctoshiftCLI.AdoToGithub
         {
             var result = new StringBuilder();
 
-            result.AppendLine("name,owner,teamproject-count,repo-count,pipeline-count");
+            result.AppendLine("name,url,owner,teamproject-count,repo-count,pipeline-count");
 
             if (ado != null && pipelines != null)
             {
@@ -23,8 +25,9 @@ namespace OctoshiftCLI.AdoToGithub
                     var teamProjectCount = pipelines[org].Count;
                     var repoCount = pipelines[org].Sum(tp => tp.Value.Count);
                     var pipelineCount = pipelines[org].Sum(tp => tp.Value.Sum(repo => repo.Value.Count()));
+                    var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}";
 
-                    result.AppendLine($"{org},{owner},{teamProjectCount},{repoCount},{pipelineCount}");
+                    result.AppendLine($"{org},{url},{owner},{teamProjectCount},{repoCount},{pipelineCount}");
                 }
             }
 

--- a/src/ado2gh/Services/PipelinesCsvGeneratorService.cs
+++ b/src/ado2gh/Services/PipelinesCsvGeneratorService.cs
@@ -1,17 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace OctoshiftCLI.AdoToGithub
 {
     public class PipelinesCsvGeneratorService
     {
-        public virtual string Generate(IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> pipelines)
+        public virtual async Task<string> Generate(AdoApi ado, IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> pipelines)
         {
             var result = new StringBuilder();
 
-            result.AppendLine("org,teamproject,repo,pipeline");
+            result.AppendLine("org,teamproject,repo,pipeline,url");
 
-            if (pipelines != null)
+            if (ado != null & pipelines != null)
             {
                 foreach (var org in pipelines.Keys)
                 {
@@ -21,7 +23,9 @@ namespace OctoshiftCLI.AdoToGithub
                         {
                             foreach (var pipeline in pipelines[org][teamProject][repo])
                             {
-                                result.AppendLine($"{org},{teamProject},{repo},{pipeline}");
+                                var pipelineId = await ado.GetPipelineId(org, teamProject, pipeline);
+                                var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}/_build?definitionId={pipelineId}";
+                                result.AppendLine($"{org},{teamProject},{repo},{pipeline},{url}");
                             }
                         }
                     }

--- a/src/ado2gh/Services/ReposCsvGeneratorService.cs
+++ b/src/ado2gh/Services/ReposCsvGeneratorService.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Web;
 
 namespace OctoshiftCLI.AdoToGithub
 {
@@ -10,7 +12,7 @@ namespace OctoshiftCLI.AdoToGithub
         {
             var result = new StringBuilder();
 
-            result.AppendLine("org,teamproject,repo,pipeline-count");
+            result.AppendLine("org,teamproject,repo,url,pipeline-count");
 
             if (pipelines != null)
             {
@@ -20,8 +22,9 @@ namespace OctoshiftCLI.AdoToGithub
                     {
                         foreach (var repo in pipelines[org][teamProject].Keys)
                         {
+                            var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}/_git/{Uri.EscapeDataString(repo)}";
                             var pipelineCount = pipelines[org][teamProject][repo].Count();
-                            result.AppendLine($"{org},{teamProject},{repo},{pipelineCount}");
+                            result.AppendLine($"{org},{teamProject},{repo},{url},{pipelineCount}");
                         }
                     }
                 }

--- a/src/ado2gh/Services/ReposCsvGeneratorService.cs
+++ b/src/ado2gh/Services/ReposCsvGeneratorService.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Web;
 
 namespace OctoshiftCLI.AdoToGithub
 {

--- a/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Web;
 
 namespace OctoshiftCLI.AdoToGithub
 {

--- a/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Web;
 
 namespace OctoshiftCLI.AdoToGithub
 {
@@ -10,7 +12,7 @@ namespace OctoshiftCLI.AdoToGithub
         {
             var result = new StringBuilder();
 
-            result.AppendLine("org,teamproject,repo-count,pipeline-count");
+            result.AppendLine("org,teamproject,url,repo-count,pipeline-count");
 
             if (pipelines != null)
             {
@@ -20,7 +22,8 @@ namespace OctoshiftCLI.AdoToGithub
                     {
                         var repoCount = pipelines[org][teamProject].Count;
                         var pipelineCount = pipelines[org][teamProject].Sum(repo => repo.Value.Count());
-                        result.AppendLine($"{org},{teamProject},{repoCount},{pipelineCount}");
+                        var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}";
+                        result.AppendLine($"{org},{teamProject},{url},{repoCount},{pipelineCount}");
                     }
                 }
             }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Issue #404 

Add a url field to orgs.csv, teamprojects.csv, repos.csv and pipelines.csv

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->