### PR TITLE
Use portable shebangs in PowerShell scripts

### DIFF
--- a/publish.ps1
+++ b/publish.ps1
@@ -1,3 +1,5 @@
+#!/usr/bin/env pwsh
+
 $AssemblyVersion = "9.9"
 
 if ((Test-Path env:CLI_VERSION) -And $env:CLI_VERSION.StartsWith("refs/tags/v")) {

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -134,7 +134,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await _command.Invoke(args);
 
             // Assert
-            _scriptOutput.Should().StartWith("#!/usr/bin/pwsh");
+            _scriptOutput.Should().StartWith("#!/usr/bin/env pwsh");
         }
 
         [Fact]
@@ -582,7 +582,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await _command.Invoke(args);
 
             // Assert
-            _scriptOutput.Should().StartWith("#!/usr/bin/pwsh");
+            _scriptOutput.Should().StartWith("#!/usr/bin/env pwsh");
         }
 
         [Fact]
@@ -596,7 +596,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
 
             var expected = new StringBuilder();
-            expected.AppendLine("#!/usr/bin/pwsh");
+            expected.AppendLine("#!/usr/bin/env pwsh");
             expected.AppendLine();
             expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
             expected.AppendLine(@"
@@ -725,7 +725,7 @@ if ($Failed -ne 0) {
             _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
 
             var expected = new StringBuilder();
-            expected.AppendLine("#!/usr/bin/pwsh");
+            expected.AppendLine("#!/usr/bin/env pwsh");
             expected.AppendLine();
             expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
             expected.AppendLine(@"
@@ -863,7 +863,7 @@ if ($Failed -ne 0) {
             _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
 
             var expected = new StringBuilder();
-            expected.AppendLine("#!/usr/bin/pwsh");
+            expected.AppendLine("#!/usr/bin/env pwsh");
             expected.AppendLine();
             expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
             expected.AppendLine(@"

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -176,7 +176,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await command.Invoke(args);
 
             // Assert
-            script.Should().StartWith("#!/usr/bin/pwsh");
+            script.Should().StartWith("#!/usr/bin/env pwsh");
         }
 
         [Fact]
@@ -219,7 +219,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await command.Invoke(args);
 
             // Assert
-            script.Should().StartWith("#!/usr/bin/pwsh");
+            script.Should().StartWith("#!/usr/bin/env pwsh");
         }
 
         [Fact]
@@ -849,7 +849,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             };
 
             var expected = new StringBuilder();
-            expected.AppendLine("#!/usr/bin/pwsh");
+            expected.AppendLine("#!/usr/bin/env pwsh");
             expected.AppendLine();
             expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
             expected.AppendLine(@"
@@ -955,7 +955,7 @@ if ($Failed -ne 0) {
             };
 
             var expected = new StringBuilder();
-            expected.AppendLine("#!/usr/bin/pwsh");
+            expected.AppendLine("#!/usr/bin/env pwsh");
             expected.AppendLine();
             expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
             expected.AppendLine(@"
@@ -1062,7 +1062,7 @@ if ($Failed -ne 0) {
             };
 
             var expected = new StringBuilder();
-            expected.AppendLine("#!/usr/bin/pwsh");
+            expected.AppendLine("#!/usr/bin/env pwsh");
             expected.AppendLine();
             expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
             expected.AppendLine(@"
@@ -1165,7 +1165,7 @@ if ($Failed -ne 0) {
             };
 
             var expected = new StringBuilder();
-            expected.AppendLine("#!/usr/bin/pwsh");
+            expected.AppendLine("#!/usr/bin/env pwsh");
             expected.AppendLine();
             expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
             expected.AppendLine(@"

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -575,7 +575,7 @@ if ($Failed -ne 0) {
 
         private string VersionComment => $"# =========== Created with CLI version {_versionProvider.GetCurrentVersion()} ===========";
 
-        private const string PWSH_SHEBANG = "#!/usr/bin/pwsh";
+        private const string PWSH_SHEBANG = "#!/usr/bin/env pwsh";
 
         private const string EXEC_FUNCTION_BLOCK = @"
 function Exec {

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -543,7 +543,7 @@ if ($Failed -ne 0) {
 
         private string VersionComment => $"# =========== Created with CLI version {_versionProvider.GetCurrentVersion()} ===========";
 
-        private const string PWSH_SHEBANG = "#!/usr/bin/pwsh";
+        private const string PWSH_SHEBANG = "#!/usr/bin/env pwsh";
 
         private const string EXEC_FUNCTION_BLOCK = @"
 function Exec {


### PR DESCRIPTION
Closes https://github.com/github/gh-gei/issues/407!
Related to https://github.com/github/gh-gei/issues/279.
Related to ~~https://github.com/github/gh-gei/issues/409~~ https://github.com/github/gh-gei/issues/305.

This PR:

<ul>
  <li>Adds a shebang to <code>publish.ps1</code>.
  <li>Uses <code>#!/usr/bin/env pwsh</code> in the <code>GenerateScriptCommand</code> classes for better portability.
</ul>

- [x] Did you write/update appropriate tests
- [ ] ~~Release notes updated (if appropriate)~~ (n/a)
- [ ] ~~Appropriate logging output~~ (n/a)
- [x] Issue linked
- [ ] ~~Docs updated (or issue created)~~ (n/a)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->