### PR TITLE
Pipeline Path Bug and some caching for perf

### DIFF
--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -378,9 +378,9 @@ namespace OctoshiftCLI
 
             var pipelinePath = NormalizePipelinePath(pipeline);
 
-            if (_pipelineIds.ContainsKey((org.ToUpper(), teamProject.ToUpper(), pipelinePath.ToUpper())))
+            if (_pipelineIds.TryGetValue((org.ToUpper(), teamProject.ToUpper(), pipelinePath.ToUpper()), out var result))
             {
-                return _pipelineIds[(org.ToUpper(), teamProject.ToUpper(), pipelinePath.ToUpper())];
+                return result;
             }
 
             var url = $"{_adoBaseUrl}/{org}/{teamProject}/_apis/build/definitions";

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OctoshiftCLI.Extensions;

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -372,9 +372,9 @@ namespace OctoshiftCLI
 
             var pipelinePath = NormalizePipelinePath(pipeline);
 
-            if (_pipelineIds.ContainsKey((org, teamProject, pipelinePath)))
+            if (_pipelineIds.ContainsKey((org?.ToUpper(), teamProject?.ToUpper(), pipelinePath?.ToUpper())))
             {
-                return _pipelineIds[(org, teamProject, pipelinePath)];
+                return _pipelineIds[(org.ToUpper(), teamProject.ToUpper(), pipelinePath.ToUpper())];
             }
 
             var url = $"{_adoBaseUrl}/{org}/{teamProject}/_apis/build/definitions";
@@ -390,7 +390,7 @@ namespace OctoshiftCLI
                 //    var foo = 12;
                 //}
 
-                var success = _pipelineIds.TryAdd((org, teamProject, path), id);
+                var success = _pipelineIds.TryAdd((org.ToUpper(), teamProject.ToUpper(), path.ToUpper()), id);
 
                 if (!success)
                 {
@@ -398,7 +398,7 @@ namespace OctoshiftCLI
                 }
             }
 
-            return _pipelineIds[(org, teamProject, pipelinePath)];
+            return _pipelineIds[(org.ToUpper(), teamProject.ToUpper(), pipelinePath.ToUpper())];
         }
 
         private string NormalizePipelinePath(string path, string name)

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -406,7 +406,7 @@ namespace OctoshiftCLI
             var parts = path.Split('\\', StringSplitOptions.RemoveEmptyEntries);
 
             var result = string.Join('\\', parts);
-            return $"\\{result}\\name";
+            return $"\\{result}\\{name}";
         }
 
         private string NormalizePipelinePath(string pipeline)

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -407,12 +407,7 @@ namespace OctoshiftCLI
 
             var result = string.Join('\\', parts);
 
-            if (result.Length > 0)
-            {
-                return $"\\{result}\\{name}";
-            }
-
-            return $"\\{name}";
+            return result.Length > 0 ? $"\\{result}\\{name}" : $"\\{name}";
         }
 
         private string NormalizePipelinePath(string pipeline)

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -414,17 +414,8 @@ namespace OctoshiftCLI
         {
             var parts = pipeline.Split('\\', StringSplitOptions.RemoveEmptyEntries);
 
-            var result = new StringBuilder("\\");
-
-            for (var i = 0; i < parts.Length - 1; i++)
-            {
-                result.Append(parts[i]);
-                result.Append('\\');
-            }
-
-            result.Append(parts.Last());
-
-            return result.ToString();
+            var result = string.Join('\\', parts);
+            return $"\\{result}";
         }
 
         public virtual async Task ShareServiceConnection(string adoOrg, string adoTeamProject, string adoTeamProjectId, string serviceConnectionId)

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -361,7 +361,7 @@ namespace OctoshiftCLI
             return result;
         }
 
-        private IDictionary<(string org, string teamProject, string pipelinePath), int> _pipelineIds = new Dictionary<(string org, string teamProject, string pipelinePath), int>();
+        private readonly IDictionary<(string org, string teamProject, string pipelinePath), int> _pipelineIds = new Dictionary<(string org, string teamProject, string pipelinePath), int>();
 
         public virtual async Task<int> GetPipelineId(string org, string teamProject, string pipeline)
         {

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -337,7 +337,7 @@ namespace OctoshiftCLI
 
                 if (!success)
                 {
-                    _log.LogWarning($"Multiple repos with the same name were found [{name}]. Ignoring repo ID {id}");
+                    _log.LogWarning($"Multiple repos with the same name were found [org: {org} project: {teamProject} repo: {name}]. Ignoring repo ID {id}");
                 }
             }
 
@@ -384,11 +384,6 @@ namespace OctoshiftCLI
             {
                 var path = NormalizePipelinePath((string)item["path"], (string)item["name"]);
                 var id = (int)item["id"];
-
-                //if (_pipelineIds.ContainsKey((org, teamProject, path)))
-                //{
-                //    var foo = 12;
-                //}
 
                 var success = _pipelineIds.TryAdd((org.ToUpper(), teamProject.ToUpper(), path.ToUpper()), id);
 

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -385,7 +385,17 @@ namespace OctoshiftCLI
                 var path = NormalizePipelinePath((string)item["path"], (string)item["name"]);
                 var id = (int)item["id"];
 
-                _pipelineIds.Add((org, teamProject, path), id);
+                //if (_pipelineIds.ContainsKey((org, teamProject, path)))
+                //{
+                //    var foo = 12;
+                //}
+
+                var success = _pipelineIds.TryAdd((org, teamProject, path), id);
+
+                if (!success)
+                {
+                    _log.LogWarning($"Multiple pipelines with the same path/name were found [org: {org} project: {teamProject} pipeline: {path}]. Ignoring pipeline ID {id}");
+                }
             }
 
             return _pipelineIds[(org, teamProject, pipelinePath)];

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -296,6 +296,10 @@ namespace OctoshiftCLI
 
         public virtual async Task<string> GetRepoId(string org, string teamProject, string repo)
         {
+            org = org ?? throw new ArgumentNullException(nameof(org));
+            teamProject = teamProject ?? throw new ArgumentNullException(nameof(teamProject));
+            repo = repo ?? throw new ArgumentNullException(nameof(repo));
+
             if (!_repoIds.ContainsKey((org.ToUpper(), teamProject.ToUpper())))
             {
                 var url = $"{_adoBaseUrl}/{org}/{teamProject}/_apis/git/repositories/{repo}?api-version=4.1";
@@ -312,12 +316,15 @@ namespace OctoshiftCLI
                 }
             }
 
-            return _repoIds[(org.ToUpper(), teamProject.ToUpper())][repo?.ToUpper()];
+            return _repoIds[(org.ToUpper(), teamProject.ToUpper())][repo.ToUpper()];
         }
 
         public virtual async Task PopulateRepoIdCache(string org, string teamProject)
         {
-            if (_repoIds.ContainsKey((org?.ToUpper(), teamProject?.ToUpper())))
+            org = org ?? throw new ArgumentNullException(nameof(org));
+            teamProject = teamProject ?? throw new ArgumentNullException(nameof(teamProject));
+
+            if (_repoIds.ContainsKey((org.ToUpper(), teamProject.ToUpper())))
             {
                 return;
             }
@@ -365,14 +372,13 @@ namespace OctoshiftCLI
 
         public virtual async Task<int> GetPipelineId(string org, string teamProject, string pipeline)
         {
-            if (pipeline is null)
-            {
-                throw new ArgumentNullException(nameof(pipeline));
-            }
+            org = org ?? throw new ArgumentNullException(nameof(org));
+            teamProject = teamProject ?? throw new ArgumentNullException(nameof(teamProject));
+            pipeline = pipeline ?? throw new ArgumentNullException(nameof(pipeline));
 
             var pipelinePath = NormalizePipelinePath(pipeline);
 
-            if (_pipelineIds.ContainsKey((org?.ToUpper(), teamProject?.ToUpper(), pipelinePath?.ToUpper())))
+            if (_pipelineIds.ContainsKey((org.ToUpper(), teamProject.ToUpper(), pipelinePath.ToUpper())))
             {
                 return _pipelineIds[(org.ToUpper(), teamProject.ToUpper(), pipelinePath.ToUpper())];
             }

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -406,7 +406,13 @@ namespace OctoshiftCLI
             var parts = path.Split('\\', StringSplitOptions.RemoveEmptyEntries);
 
             var result = string.Join('\\', parts);
-            return $"\\{result}\\{name}";
+
+            if (result.Length > 0)
+            {
+                return $"\\{result}\\{name}";
+            }
+
+            return $"\\{name}";
         }
 
         private string NormalizePipelinePath(string pipeline)

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -296,7 +296,7 @@ namespace OctoshiftCLI
 
         public virtual async Task<string> GetRepoId(string org, string teamProject, string repo)
         {
-            if (!_repoIds.ContainsKey((org, teamProject)))
+            if (!_repoIds.ContainsKey((org.ToUpper(), teamProject.ToUpper())))
             {
                 var url = $"{_adoBaseUrl}/{org}/{teamProject}/_apis/git/repositories/{repo}?api-version=4.1";
 
@@ -312,12 +312,12 @@ namespace OctoshiftCLI
                 }
             }
 
-            return _repoIds[(org, teamProject)][repo];
+            return _repoIds[(org.ToUpper(), teamProject.ToUpper())][repo?.ToUpper()];
         }
 
         public virtual async Task PopulateRepoIdCache(string org, string teamProject)
         {
-            if (_repoIds.ContainsKey((org, teamProject)))
+            if (_repoIds.ContainsKey((org?.ToUpper(), teamProject?.ToUpper())))
             {
                 return;
             }
@@ -333,7 +333,7 @@ namespace OctoshiftCLI
                 var name = (string)item["name"];
                 var id = (string)item["id"];
 
-                var success = ids.TryAdd(name, id);
+                var success = ids.TryAdd(name.ToUpper(), id);
 
                 if (!success)
                 {
@@ -341,7 +341,7 @@ namespace OctoshiftCLI
                 }
             }
 
-            _repoIds.Add((org, teamProject), ids);
+            _repoIds.Add((org.ToUpper(), teamProject.ToUpper()), ids);
         }
 
         public virtual async Task<IEnumerable<string>> GetPipelines(string org, string teamProject, string repoId)
@@ -429,26 +429,6 @@ namespace OctoshiftCLI
 
             return result.ToString();
         }
-
-        //private (string path, string name) ParsePipeline(string pipeline)
-        //{
-        //    if (!pipeline.Contains('\\'))
-        //    {
-        //        return (@"\\", pipeline);
-        //    }
-
-        //    var parts = pipeline.Split('\\', StringSplitOptions.RemoveEmptyEntries);
-
-        //    var result = new StringBuilder("\\");
-
-        //    for (var i = 0; i < parts.Length - 1; i++)
-        //    {
-        //        result.Append(parts[i]);
-        //        result.Append('\\');
-        //    }
-
-        //    return (result.ToString(), parts.Last());
-        //}
 
         public virtual async Task ShareServiceConnection(string adoOrg, string adoTeamProject, string adoTeamProjectId, string serviceConnectionId)
         {

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -406,17 +406,8 @@ namespace OctoshiftCLI
         {
             var parts = path.Split('\\', StringSplitOptions.RemoveEmptyEntries);
 
-            var result = new StringBuilder("\\");
-
-            for (var i = 0; i < parts.Length; i++)
-            {
-                result.Append(parts[i]);
-                result.Append('\\');
-            }
-
-            result.Append(name);
-
-            return result.ToString();
+            var result = string.Join('\\', parts);
+            return $"\\{result}\\name";
         }
 
         private string NormalizePipelinePath(string pipeline)

--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -27,7 +27,7 @@ namespace OctoshiftCLI.IntegrationTests
             var adoToken = Environment.GetEnvironmentVariable("ADO_PAT");
             _adoHttpClient = new HttpClient();
             var adoClient = new AdoClient(logger, _adoHttpClient, new VersionChecker(_versionClient), adoToken);
-            var adoApi = new AdoApi(adoClient, "https://dev.azure.com");
+            var adoApi = new AdoApi(adoClient, "https://dev.azure.com", logger);
 
             var githubToken = Environment.GetEnvironmentVariable("GH_PAT");
             _githubHttpClient = new HttpClient();

--- a/src/OctoshiftCLI.Tests/AdoApiTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoApiTests.cs
@@ -540,11 +540,13 @@ namespace OctoshiftCLI.Tests
                 new
                 {
                     id = "whatever",
-                    name = pipeline1
+                    name = pipeline1,
+                    path = "\\"
                 },
                 new
                 {
-                    name = pipeline2
+                    name = pipeline2,
+                    path = "\\"
                 }
             };
 
@@ -555,7 +557,7 @@ namespace OctoshiftCLI.Tests
             var result = await sut.GetPipelines(org, teamProject, repoId);
 
             result.Count().Should().Be(2);
-            result.Should().Contain(new[] { pipeline1, pipeline2 });
+            result.Should().Contain(new[] { $"\\{pipeline1}", $"\\{pipeline2}" });
         }
 
         [Fact]
@@ -572,12 +574,14 @@ namespace OctoshiftCLI.Tests
                 new
                 {
                     id = 123,
-                    name = "wrong"
+                    name = "wrong",
+                    path = "\\"
                 },
                 new
                 {
                     id = pipelineId,
-                    name = pipeline.ToUpper()
+                    name = pipeline.ToUpper(),
+                    path = "\\"
                 }
             };
 

--- a/src/OctoshiftCLI.Tests/AdoApiTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoApiTests.cs
@@ -16,6 +16,7 @@ namespace OctoshiftCLI.Tests
     public class AdoApiTests
     {
         private const string ADO_SERVICE_URL = "https://dev.azure.com";
+        private readonly OctoLogger logger = new();
 
         [Fact]
         public async Task GetUserId_Should_Return_UserId()
@@ -37,7 +38,7 @@ namespace OctoshiftCLI.Tests
 
             mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(userJson.ToJson());
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetUserId();
 
             result.Should().Be(userId);
@@ -63,7 +64,7 @@ namespace OctoshiftCLI.Tests
 
             mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(userJson.ToJson());
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             await Assert.ThrowsAsync<InvalidDataException>(async () => await sut.GetUserId());
         }
 
@@ -89,7 +90,7 @@ namespace OctoshiftCLI.Tests
 
             mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(accountsJson.ToJson());
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetOrganizations(userId);
 
             result.Count().Should().Be(2);
@@ -123,7 +124,7 @@ namespace OctoshiftCLI.Tests
 
             mockClient.Setup(x => x.GetWithPagingAsync(endpoint).Result).Returns(response);
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetOrganizationId(userId, adoOrg);
 
             result.Should().Be(orgId);
@@ -155,7 +156,7 @@ namespace OctoshiftCLI.Tests
 
             mockClient.Setup(x => x.GetWithPagingAsync(endpoint).Result).Returns(response);
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetTeamProjects(adoOrg);
 
             result.Count().Should().Be(2);
@@ -194,7 +195,7 @@ namespace OctoshiftCLI.Tests
 
             mockClient.Setup(x => x.GetWithPagingAsync(endpoint).Result).Returns(response);
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetEnabledRepos(adoOrg, teamProject);
 
             result.Count().Should().Be(2);
@@ -227,7 +228,7 @@ namespace OctoshiftCLI.Tests
             mockClient.Setup(x => x.GetWithPagingAsync($"https://dev.azure.com/{adoOrg}/{teamProject1}/_apis/serviceendpoint/endpoints?api-version=6.0-preview.4").Result).Returns(JArray.Parse("[]"));
             mockClient.Setup(x => x.GetWithPagingAsync($"https://dev.azure.com/{adoOrg}/{teamProject2}/_apis/serviceendpoint/endpoints?api-version=6.0-preview.4").Result).Returns(response);
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetGithubAppId(adoOrg, githubOrg, teamProjects);
 
             result.Should().Be(appId);
@@ -259,7 +260,7 @@ namespace OctoshiftCLI.Tests
             mockClient.Setup(x => x.GetWithPagingAsync($"https://dev.azure.com/{adoOrg}/{teamProject1}/_apis/serviceendpoint/endpoints?api-version=6.0-preview.4").Result).Returns(JArray.Parse("[]"));
             mockClient.Setup(x => x.GetWithPagingAsync($"https://dev.azure.com/{adoOrg}/{teamProject2}/_apis/serviceendpoint/endpoints?api-version=6.0-preview.4").Result).Returns(response);
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetGithubAppId(adoOrg, githubOrg, teamProjects);
 
             result.Should().BeNull();
@@ -302,7 +303,7 @@ namespace OctoshiftCLI.Tests
 
             mockClient.Setup(x => x.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result).Returns(json);
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetGithubHandle(adoOrg, teamProject, githubToken);
 
             result.Should().Be(handle);
@@ -349,7 +350,7 @@ namespace OctoshiftCLI.Tests
 
             mockClient.Setup(x => x.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result).Returns(json);
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetBoardsGithubConnection("FOO-ORG", "FOO-TEAMPROJECT");
 
             result.connectionId.Should().Be(connectionId);
@@ -399,7 +400,7 @@ namespace OctoshiftCLI.Tests
             var mockClient = TestHelpers.CreateMock<AdoClient>();
             mockClient.Setup(x => x.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result).Returns(json.ToJson());
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.CreateBoardsGithubEndpoint(orgName, teamProjectId, githubToken, githubHandle, endpointName);
 
             result.Should().Be(endpointId);
@@ -454,7 +455,7 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockClient = TestHelpers.CreateMock<AdoClient>();
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             await sut.AddRepoToBoardsGithubConnection(orgName, teamProject, connectionId, connectionName, endpointId, new List<string>() { repo1, repo2 });
 
             mockClient.Verify(m => m.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result);
@@ -473,7 +474,7 @@ namespace OctoshiftCLI.Tests
             var mockClient = TestHelpers.CreateMock<AdoClient>();
             mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(response.ToJson());
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetTeamProjectId(org, teamProject);
 
             result.Should().Be(teamProjectId);
@@ -493,7 +494,7 @@ namespace OctoshiftCLI.Tests
             var mockClient = TestHelpers.CreateMock<AdoClient>();
             mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(response.ToJson());
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetRepoId(org, teamProject, repo);
 
             result.Should().Be(repoId);
@@ -518,7 +519,7 @@ namespace OctoshiftCLI.Tests
             mockClient.Setup(x => x.GetAsync(endpoint).Result).Throws(new HttpRequestException(null, null, HttpStatusCode.NotFound));
             mockClient.Setup(x => x.GetWithPagingAsync(allReposEndpoint).Result).Returns(JArray.Parse(response.ToJson()));
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetRepoId(org, teamProject, repo);
 
             result.Should().Be(repoId);
@@ -550,7 +551,7 @@ namespace OctoshiftCLI.Tests
             var mockClient = TestHelpers.CreateMock<AdoClient>();
             mockClient.Setup(x => x.GetWithPagingAsync(endpoint).Result).Returns(JArray.Parse(response.ToJson()));
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetPipelines(org, teamProject, repoId);
 
             result.Count().Should().Be(2);
@@ -583,7 +584,7 @@ namespace OctoshiftCLI.Tests
             var mockClient = TestHelpers.CreateMock<AdoClient>();
             mockClient.Setup(x => x.GetWithPagingAsync(endpoint).Result).Returns(JArray.Parse(response.ToJson()));
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetPipelineId(org, teamProject, pipeline);
 
             result.Should().Be(pipelineId);
@@ -613,7 +614,7 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockClient = TestHelpers.CreateMock<AdoClient>();
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             await sut.ShareServiceConnection(org, teamProject, teamProjectId, serviceConnectionId);
 
             mockClient.Verify(m => m.PatchAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())));
@@ -643,7 +644,7 @@ namespace OctoshiftCLI.Tests
             var mockClient = TestHelpers.CreateMock<AdoClient>();
             mockClient.Setup(x => x.GetAsync(endpoint).Result).Returns(response.ToJson());
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var (DefaultBranch, Clean, CheckoutSubmodules) = await sut.GetPipeline(org, teamProject, pipelineId);
 
             DefaultBranch.Should().Be(branchName);
@@ -720,7 +721,7 @@ namespace OctoshiftCLI.Tests
 
             var mockClient = TestHelpers.CreateMock<AdoClient>();
             mockClient.Setup(m => m.GetAsync(endpoint).Result).Returns(oldJson.ToJson());
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             await sut.ChangePipelineRepo(org, teamProject, pipelineId, defaultBranch, clean, checkoutSubmodules, githubOrg, githubRepo, serviceConnectionId);
 
             mockClient.Verify(m => m.PutAsync(endpoint, It.Is<object>(y => y.ToJson() == newJson.ToJson())));
@@ -768,7 +769,7 @@ namespace OctoshiftCLI.Tests
             var mockClient = TestHelpers.CreateMock<AdoClient>();
             mockClient.Setup(x => x.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result).Returns(json);
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetBoardsGithubRepoId(orgName, teamProject, teamProjectId, endpointId, githubOrg, githubRepo);
 
             result.Should().Be(repoId);
@@ -818,7 +819,7 @@ namespace OctoshiftCLI.Tests
 
             var mockClient = TestHelpers.CreateMock<AdoClient>();
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             await sut.CreateBoardsGithubConnection(orgName, teamProject, endpointId, repoId);
 
             mockClient.Verify(m => m.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result);
@@ -859,7 +860,7 @@ namespace OctoshiftCLI.Tests
             var mockClient = TestHelpers.CreateMock<AdoClient>();
             mockClient.Setup(m => m.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson()))).ReturnsAsync(json);
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetOrgOwner(orgName);
 
             result.Should().Be($"{ownerName} ({ownerEmail})");
@@ -875,7 +876,7 @@ namespace OctoshiftCLI.Tests
             var endpoint = $"https://dev.azure.com/{orgName}/{teamProject}/_apis/git/repositories/{repoId}?api-version=6.1-preview.1";
 
             var mockClient = TestHelpers.CreateMock<AdoClient>();
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             await sut.DisableRepo(orgName, teamProject, repoId);
 
             var payload = new { isDisabled = true };
@@ -898,7 +899,7 @@ namespace OctoshiftCLI.Tests
 
             mockClient.Setup(x => x.GetWithPagingAsync(endpoint).Result).Returns(JArray.Parse(response));
 
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             var result = await sut.GetIdentityDescriptor(orgName, teamProjectId, groupName);
 
             result.Should().Be(identityDescriptor);
@@ -938,7 +939,7 @@ namespace OctoshiftCLI.Tests
             };
 
             var mockClient = TestHelpers.CreateMock<AdoClient>();
-            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL);
+            var sut = new AdoApi(mockClient.Object, ADO_SERVICE_URL, logger);
             await sut.LockRepo(orgName, teamProjectId, repoId, identityDescriptor);
 
             mockClient.Verify(m => m.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result);

--- a/src/ado2gh/AdoApiFactory.cs
+++ b/src/ado2gh/AdoApiFactory.cs
@@ -23,7 +23,7 @@ namespace OctoshiftCLI.AdoToGithub
         {
             personalAccessToken ??= _environmentVariableProvider.AdoPersonalAccessToken();
             var adoClient = new AdoClient(_octoLogger, _client, _versionProvider, personalAccessToken);
-            return new AdoApi(adoClient, DEFAULT_API_URL);
+            return new AdoApi(adoClient, DEFAULT_API_URL, _octoLogger);
         }
     }
 }

--- a/src/ado2gh/Services/AdoInspectorService.cs
+++ b/src/ado2gh/Services/AdoInspectorService.cs
@@ -111,6 +111,7 @@ namespace OctoshiftCLI.AdoToGithub
                     foreach (var teamProject in repos[org].Keys)
                     {
                         pipelines[org].Add(teamProject, new Dictionary<string, IEnumerable<string>>());
+                        await api.PopulateRepoIdCache(org, teamProject);
 
                         foreach (var repo in repos[org][teamProject])
                         {

--- a/src/gei/AdoApiFactory.cs
+++ b/src/gei/AdoApiFactory.cs
@@ -24,7 +24,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
             adoServerUrl ??= DEFAULT_API_URL;
             personalAccessToken ??= _environmentVariableProvider.AdoPersonalAccessToken();
             var adoClient = new AdoClient(_octoLogger, _client, _versionProvider, personalAccessToken);
-            return new AdoApi(adoClient, adoServerUrl);
+            return new AdoApi(adoClient, adoServerUrl, _octoLogger);
         }
     }
 }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Added 2 caches to AdoApi for translating repo names to repo IDs, and translating pipeline names to pipeline IDs. Previously it would get the list of all pipeline names/ids in order to lookup a single name. And if the code is looping through thousands of pipelines trying to get the IDs (like AdoInspector does) it was retrieving the list of all pipelines, thousands of times. Now it will retrieve the full list on the first call and cache the results.

Also fixed 3 bugs:
1. #410 In ADO pipelines live in pipeline folders, and you can have 2 pipelines with the same name that live in different folders. Our code didn't take into account the folder/path of the pipeline, and if 2 pipelines had the same name the code to lookup the ID would fail.  This PR updates the code to take into consideration the path. If a user passes a simple name to `--ado-pipeline` (e.g. in `rewire-pipeline`) the code will assume it is in the root pipeline folder, but alternatively the user can pass a full pipeline path to that arg and the code will handle it appropriately (e.g. `--ado-pipeline "\some-folder\another\my-pipeline"`)

2. Even after taking into account pipeline paths, we found examples in a large/complex ADO org where 2 pipelines have the same name and path, but different IDs. I have no idea how this can occur and am going to assume that it's not expected. This PR updates the CLI to ignore one of the pipelines when this is encountered and spit out a warning to the console/log.

3. When testing this against a large/complex ADO org, we found examples where 2 repos have the same name, but different ID's. They show up twice in the ADO UI. I have no idea how this can occur and am going to assume that it's not expected. This PR updates the CLI to ignore one of the repos when this is encountered and spit out a warning to the console/log.



- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->