### PR TITLE
Refactor AdoInspectorService

### DIFF
--- a/src/Octoshift/Extensions/EnumerableExtensions.cs
+++ b/src/Octoshift/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace OctoshiftCLI.Extensions
+{
+    public static class EnumerableExtensions
+    {
+        public static async Task<int> Sum<T>(this IEnumerable<T> list, Func<T, Task<int>> selector)
+        {
+            var result = 0;
+
+            if (list is not null && selector is not null)
+            {
+                foreach (var item in list)
+                {
+                    result += await selector(item);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -33,6 +33,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
         private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
         private readonly Mock<AdoInspectorService> _mockAdoInspector = TestHelpers.CreateMock<AdoInspectorService>();
+        private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
         private string _scriptOutput = "";
         private readonly GenerateScriptCommand _command;
@@ -41,8 +42,9 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         {
             var mockVersionProvider = new Mock<IVersionProvider>();
             mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+            _mockAdoInspectorServiceFactory.Setup(m => m.Create(_mockAdoApi.Object)).Returns(_mockAdoInspector.Object);
 
-            _command = new GenerateScriptCommand(TestHelpers.CreateMock<OctoLogger>().Object, _mockAdoApiFactory.Object, mockVersionProvider.Object, _mockAdoInspector.Object)
+            _command = new GenerateScriptCommand(TestHelpers.CreateMock<OctoLogger>().Object, _mockAdoApiFactory.Object, mockVersionProvider.Object, _mockAdoInspectorServiceFactory.Object)
             {
                 WriteToFile = (_, contents) =>
                 {
@@ -84,7 +86,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var orgs = new List<string>();
 
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
             _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(orgs);
 
             // Act

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -1,1272 +1,1272 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FluentAssertions;
-using Moq;
-using OctoshiftCLI.AdoToGithub;
-using OctoshiftCLI.AdoToGithub.Commands;
-using OctoshiftCLI.Extensions;
-using Xunit;
-
-namespace OctoshiftCLI.Tests.AdoToGithub.Commands
-{
-    public class GenerateScriptCommandTests
-    {
-        private const string ADO_ORG = "ADO_ORG";
-        private const string ADO_TEAM_PROJECT = "ADO_TEAM_PROJECT";
-        private const string FOO_REPO = "FOO_REPO";
-        private const string FOO_PIPELINE = "FOO_PIPELINE";
-        private const string BAR_REPO = "BAR_REPO";
-        private const string BAR_PIPELINE = "BAR_PIPELINE";
-        private const string APP_ID = "d9edf292-c6fd-4440-af2b-d08fcc9c9dd1";
-        private const string GITHUB_ORG = "GITHUB_ORG";
-
-        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
-        private readonly IDictionary<string, IEnumerable<string>> ADO_TEAM_PROJECTS = new Dictionary<string, IEnumerable<string>>() { { ADO_ORG, new List<string>() { ADO_TEAM_PROJECT } } };
-        private readonly IDictionary<string, IDictionary<string, IEnumerable<string>>> ADO_REPOS = new Dictionary<string, IDictionary<string, IEnumerable<string>>>() { { ADO_ORG, new Dictionary<string, IEnumerable<string>>() { { ADO_TEAM_PROJECT, new List<string>() { FOO_REPO } } } } };
-        private readonly IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> ADO_PIPELINES =
-            new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
-            { { ADO_ORG, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
-                         { { ADO_TEAM_PROJECT, new Dictionary<string, IEnumerable<string>>()
-                                               { { FOO_REPO, new List<string>()
-                                                             { FOO_PIPELINE } } } } } } };
-
-        private readonly IEnumerable<string> EMPTY_ORGS = new List<string>();
-        private readonly IDictionary<string, IEnumerable<string>> EMPTY_TEAM_PROJECTS = new Dictionary<string, IEnumerable<string>>();
-        private readonly IDictionary<string, IDictionary<string, IEnumerable<string>>> EMPTY_REPOS = new Dictionary<string, IDictionary<string, IEnumerable<string>>>();
-        private readonly IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> EMPTY_PIPELINES = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>();
-
-        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
-        private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
-        private readonly Mock<AdoInspectorService> _mockAdoInspector = TestHelpers.CreateMock<AdoInspectorService>();
-
-        private string _scriptOutput = "";
-        private readonly GenerateScriptCommand _command;
-
-        public GenerateScriptCommandTests()
-        {
-            var mockVersionProvider = new Mock<IVersionProvider>();
-            mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
-
-            _command = new GenerateScriptCommand(TestHelpers.CreateMock<OctoLogger>().Object, _mockAdoApiFactory.Object, mockVersionProvider.Object, _mockAdoInspector.Object)
-            {
-                WriteToFile = (_, contents) =>
-                {
-                    _scriptOutput = contents;
-                    return Task.CompletedTask;
-                }
-            };
-        }
-
-        [Fact]
-        public void Should_Have_Options()
-        {
-            var command = new GenerateScriptCommand(null, null, null, null);
-            command.Should().NotBeNull();
-            command.Name.Should().Be("generate-script");
-            command.Options.Count.Should().Be(15);
-
-            TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
-            TestHelpers.VerifyCommandOption(command.Options, "ado-org", false);
-            TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", false);
-            TestHelpers.VerifyCommandOption(command.Options, "output", false);
-            TestHelpers.VerifyCommandOption(command.Options, "ssh", false, true);
-            TestHelpers.VerifyCommandOption(command.Options, "sequential", false);
-            TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
-            TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
-            TestHelpers.VerifyCommandOption(command.Options, "create-teams", false);
-            TestHelpers.VerifyCommandOption(command.Options, "link-idp-groups", false);
-            TestHelpers.VerifyCommandOption(command.Options, "lock-ado-repos", false);
-            TestHelpers.VerifyCommandOption(command.Options, "disable-ado-repos", false);
-            TestHelpers.VerifyCommandOption(command.Options, "integrate-boards", false);
-            TestHelpers.VerifyCommandOption(command.Options, "rewire-pipelines", false);
-            TestHelpers.VerifyCommandOption(command.Options, "all", false);
-        }
-
-        [Fact]
-        public async Task SequentialScript_No_Data()
-        {
-            // Arrange
-            var orgs = new List<string>();
-            var teamProjects = new Dictionary<string, IEnumerable<string>>();
-            var repos = new Dictionary<string, IDictionary<string, IEnumerable<string>>>();
-
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, null)).ReturnsAsync(orgs);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, orgs, null)).ReturnsAsync(teamProjects);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, teamProjects, null)).ReturnsAsync(repos);
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output")
-            };
-            await _command.Invoke(args);
-
-            // Assert
-            _scriptOutput.Should().BeNullOrWhiteSpace();
-        }
-
-        [Fact]
-        public async Task SequentialScript_StartsWith_Shebang()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                AdoOrg = ADO_ORG,
-                GithubOrg = GITHUB_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output")
-            };
-            await _command.Invoke(args);
-
-            // Assert
-            _scriptOutput.Should().StartWith("#!/usr/bin/env pwsh");
-        }
-
-        [Fact]
-        public async Task SequentialScript_Single_Repo_No_Options()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output")
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-            var expected = $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
-
-            // Assert
-            _scriptOutput.Should().Be(expected);
-        }
-
-        [Fact]
-        public async Task SequentialScript_Single_Repo_All_Options()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(EMPTY_PIPELINES);
-
-            var expected = $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}";
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output"),
-                All = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-            // Assert
-            _scriptOutput.Should().Be(expected);
-        }
-
-        [Fact]
-        public async Task SequentialScript_Skips_Team_Project_With_No_Repos()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(EMPTY_REPOS);
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output")
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-            // Assert
-            _scriptOutput.Should().BeEmpty();
-        }
-
-        [Fact]
-        public async Task SequentialScript_Single_Repo_Two_Pipelines_All_Options()
-        {
-            // Arrange
-            ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO] = new List<string>() { ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO].First(), BAR_PIPELINE };
-
-            _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT })).ReturnsAsync(APP_ID);
-
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
-
-            var expected = $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{BAR_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}";
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output"),
-                All = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-            // Assert
-            _scriptOutput.Should().Be(expected);
-        }
-
-        [Fact]
-        public async Task SequentialScript_Single_Repo_Two_Pipelines_No_Service_Connection_All_Options()
-        {
-            // Arrange
-            ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO] = new List<string>() { ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO].First(), BAR_PIPELINE };
-
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
-
-            var expected = $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}";
-            expected += Environment.NewLine;
-            expected += $"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}";
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output"),
-                All = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-            // Assert
-            _scriptOutput.Should().Be(expected);
-        }
-
-        [Fact]
-        public async Task SequentialScript_Create_Teams_Option_Should_Generate_Create_Team_And_Add_Teams_To_Repos_Scripts()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            var expected = new StringBuilder();
-            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
-            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" }}");
-            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
-            expected.AppendLine($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-            expected.Append($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output"),
-                CreateTeams = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-            // Assert
-            _scriptOutput.Should().Be(expected.ToString());
-        }
-
-        [Fact]
-        public async Task SequentialScript_Link_Idp_Groups_Option_Should_Generate_Create_Teams_Scripts_With_Idp_Groups()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            var expected = new StringBuilder();
-            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
-            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
-            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
-            expected.AppendLine($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-            expected.Append($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output"),
-                LinkIdpGroups = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-            // Assert
-            _scriptOutput.Should().Be(expected.ToString());
-        }
-
-        [Fact]
-        public async Task SequentialScript_Lock_Ado_Repo_Option_Should_Generate_Lock_Ado_Repo_Script()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            var expected = new StringBuilder();
-            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-            expected.Append($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output"),
-                LockAdoRepos = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-            // Assert
-            _scriptOutput.Should().Be(expected.ToString());
-        }
-
-        [Fact]
-        public async Task SequentialScript_Disable_Ado_Repo_Option_Should_Generate_Disable_Ado_Repo_Script()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            var expected = new StringBuilder();
-            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
-            expected.Append($"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output"),
-                DisableAdoRepos = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-            // Assert
-            _scriptOutput.Should().Contain(expected.ToString());
-        }
-
-        [Fact]
-        public async Task SequentialScript_Integrate_Boards_Option_Should_Generate_Auto_Link_And_Boards_Integration_Scripts()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            var expected = new StringBuilder();
-            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
-            expected.AppendLine($"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
-            expected.Append($"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output"),
-                IntegrateBoards = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-            // Assert
-            _scriptOutput.Should().Contain(expected.ToString());
-        }
-
-        [Fact]
-        public async Task SequentialScript_Rewire_Pipelines_Option_Should_Generate_Share_Service_Connection_And_Rewire_Pipeline_Scripts()
-        {
-            // Arrange
-            _mockAdoApi
-                .Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT }))
-                .ReturnsAsync(APP_ID);
-
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
-
-            var expected = new StringBuilder();
-            expected.AppendLine($"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}");
-            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
-            expected.Append($"Exec {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}");
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output"),
-                RewirePipelines = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-            // Assert
-            _scriptOutput.Should().Contain(expected.ToString());
-        }
-
-        [Fact]
-        public async Task ParallelScript_No_Data()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, null)).ReturnsAsync(EMPTY_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, EMPTY_ORGS, null)).ReturnsAsync(EMPTY_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, EMPTY_TEAM_PROJECTS, null)).ReturnsAsync(EMPTY_REPOS);
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output")
-            };
-            await _command.Invoke(args);
-
-            // Assert
-            _scriptOutput.Should().BeEmpty();
-        }
-
-        [Fact]
-        public async Task ParallelScript_StartsWith_Shebang()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                AdoOrg = ADO_ORG,
-                GithubOrg = GITHUB_ORG,
-                Output = new FileInfo("unit-test-output")
-            };
-            await _command.Invoke(args);
-
-            // Assert
-            _scriptOutput.Should().StartWith("#!/usr/bin/env pwsh");
-        }
-
-        [Fact]
-        public async Task ParallelScript_Single_Repo_No_Options()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            var expected = new StringBuilder();
-            expected.AppendLine("#!/usr/bin/env pwsh");
-            expected.AppendLine();
-            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
-            expected.AppendLine(@"
-function Exec {
-    param (
-        [scriptblock]$ScriptBlock
-    )
-    & @ScriptBlock
-    if ($lastexitcode -ne 0) {
-        exit $lastexitcode
-    }
-}");
-            expected.AppendLine(@"
-function ExecAndGetMigrationID {
-    param (
-        [scriptblock]$ScriptBlock
-    )
-    $MigrationID = Exec $ScriptBlock | ForEach-Object {
-        Write-Host $_
-        $_
-    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
-    return $MigrationID
-}");
-            expected.AppendLine(@"
-function ExecBatch {
-    param (
-        [scriptblock[]]$ScriptBlocks
-    )
-    $Global:LastBatchFailures = 0
-    foreach ($ScriptBlock in $ScriptBlocks)
-    {
-        & @ScriptBlock
-        if ($lastexitcode -ne 0) {
-            $Global:LastBatchFailures++
-        }
-    }
-}");
-            expected.AppendLine();
-            expected.AppendLine("$Succeeded = 0");
-            expected.AppendLine("$Failed = 0");
-            expected.AppendLine("$RepoMigrations = [ordered]@{}");
-            expected.AppendLine();
-            expected.AppendLine($"# =========== Queueing migration for Organization: {ADO_ORG} ===========");
-            expected.AppendLine();
-            expected.AppendLine($"# === Queueing repo migrations for Team Project: {ADO_ORG}/{ADO_TEAM_PROJECT} ===");
-            expected.AppendLine();
-            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-            expected.AppendLine();
-            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {ADO_ORG} ===========");
-            expected.AppendLine();
-            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {FOO_REPO}. Will then complete the below post migration steps. ===");
-            expected.AppendLine("$CanExecuteBatch = $true");
-            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-            expected.AppendLine("}");
-            expected.AppendLine("if ($CanExecuteBatch) {");
-            expected.AppendLine("    $Succeeded++");
-            expected.AppendLine("} else {");
-            expected.AppendLine("    $Failed++");
-            expected.AppendLine("}");
-            expected.AppendLine();
-            expected.AppendLine("Write-Host =============== Summary ===============");
-            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
-            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
-            expected.AppendLine(@"
-if ($Failed -ne 0) {
-    exit 1
-}");
-            expected.AppendLine();
-            expected.AppendLine();
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Output = new FileInfo("unit-test-output")
-            };
-            await _command.Invoke(args);
-
-            // Assert
-            _scriptOutput.Should().Be(expected.ToString());
-        }
-
-        [Fact]
-        public async Task PatallelScript_Skips_Team_Project_With_No_Repos()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(EMPTY_REPOS);
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Output = new FileInfo("unit-test-output")
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-            // Assert
-            _scriptOutput.Should().BeEmpty();
-        }
-
-        [Fact]
-        public async Task ParallelScript_Two_Repos_Two_Pipelines_All_Options()
-        {
-            // Arrange
-            ADO_REPOS[ADO_ORG][ADO_TEAM_PROJECT] = new List<string>() { FOO_REPO, BAR_REPO };
-            ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT].Add(BAR_REPO, new List<string>() { BAR_PIPELINE });
-
-            _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT })).ReturnsAsync(APP_ID);
-
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
-
-            var expected = new StringBuilder();
-            expected.AppendLine("#!/usr/bin/env pwsh");
-            expected.AppendLine();
-            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
-            expected.AppendLine(@"
-function Exec {
-    param (
-        [scriptblock]$ScriptBlock
-    )
-    & @ScriptBlock
-    if ($lastexitcode -ne 0) {
-        exit $lastexitcode
-    }
-}");
-            expected.AppendLine(@"
-function ExecAndGetMigrationID {
-    param (
-        [scriptblock]$ScriptBlock
-    )
-    $MigrationID = Exec $ScriptBlock | ForEach-Object {
-        Write-Host $_
-        $_
-    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
-    return $MigrationID
-}");
-            expected.AppendLine(@"
-function ExecBatch {
-    param (
-        [scriptblock[]]$ScriptBlocks
-    )
-    $Global:LastBatchFailures = 0
-    foreach ($ScriptBlock in $ScriptBlocks)
-    {
-        & @ScriptBlock
-        if ($lastexitcode -ne 0) {
-            $Global:LastBatchFailures++
-        }
-    }
-}");
-            expected.AppendLine();
-            expected.AppendLine("$Succeeded = 0");
-            expected.AppendLine("$Failed = 0");
-            expected.AppendLine("$RepoMigrations = [ordered]@{}");
-            expected.AppendLine();
-            expected.AppendLine($"# =========== Queueing migration for Organization: {ADO_ORG} ===========");
-            expected.AppendLine();
-            expected.AppendLine($"# === Queueing repo migrations for Team Project: {ADO_ORG}/{ADO_TEAM_PROJECT} ===");
-            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
-            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
-            expected.AppendLine($"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}");
-            expected.AppendLine();
-            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-            expected.AppendLine();
-            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{BAR_REPO}\" }}");
-            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{BAR_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" }}");
-            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{BAR_REPO}\"] = $MigrationID");
-            expected.AppendLine();
-            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {ADO_ORG} ===========");
-            expected.AppendLine();
-            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {FOO_REPO}. Will then complete the below post migration steps. ===");
-            expected.AppendLine("$CanExecuteBatch = $true");
-            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-            expected.AppendLine("}");
-            expected.AppendLine("if ($CanExecuteBatch) {");
-            expected.AppendLine("    ExecBatch @(");
-            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
-            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-            expected.AppendLine($"        {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}");
-            expected.AppendLine("    )");
-            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-            expected.AppendLine("} else {");
-            expected.AppendLine("    $Failed++");
-            expected.AppendLine("}");
-            expected.AppendLine();
-            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {BAR_REPO}. Will then complete the below post migration steps. ===");
-            expected.AppendLine("$CanExecuteBatch = $true");
-            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{BAR_REPO}\"]) {{");
-            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{BAR_REPO}\"]");
-            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-            expected.AppendLine("}");
-            expected.AppendLine("if ($CanExecuteBatch) {");
-            expected.AppendLine("    ExecBatch @(");
-            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{BAR_REPO}\" }}");
-            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
-            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" }}");
-            expected.AppendLine($"        {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{BAR_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --service-connection-id \"{APP_ID}\" }}");
-            expected.AppendLine("    )");
-            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-            expected.AppendLine("} else {");
-            expected.AppendLine("    $Failed++");
-            expected.AppendLine("}");
-            expected.AppendLine();
-            expected.AppendLine("Write-Host =============== Summary ===============");
-            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
-            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
-            expected.AppendLine(@"
-if ($Failed -ne 0) {
-    exit 1
-}");
-            expected.AppendLine();
-            expected.AppendLine();
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Output = new FileInfo("unit-test-output"),
-                All = true
-            };
-            await _command.Invoke(args);
-
-            // Assert
-            _scriptOutput.Should().Be(expected.ToString());
-        }
-
-        [Fact]
-        public async Task ParallelScript_Single_Repo_No_Service_Connection_All_Options()
-        {
-            // Arrange
-            ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO] = new List<string>() { ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO].First(), BAR_PIPELINE };
-
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
-
-            var expected = new StringBuilder();
-            expected.AppendLine("#!/usr/bin/env pwsh");
-            expected.AppendLine();
-            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
-            expected.AppendLine(@"
-function Exec {
-    param (
-        [scriptblock]$ScriptBlock
-    )
-    & @ScriptBlock
-    if ($lastexitcode -ne 0) {
-        exit $lastexitcode
-    }
-}");
-            expected.AppendLine(@"
-function ExecAndGetMigrationID {
-    param (
-        [scriptblock]$ScriptBlock
-    )
-    $MigrationID = Exec $ScriptBlock | ForEach-Object {
-        Write-Host $_
-        $_
-    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
-    return $MigrationID
-}");
-            expected.AppendLine(@"
-function ExecBatch {
-    param (
-        [scriptblock[]]$ScriptBlocks
-    )
-    $Global:LastBatchFailures = 0
-    foreach ($ScriptBlock in $ScriptBlocks)
-    {
-        & @ScriptBlock
-        if ($lastexitcode -ne 0) {
-            $Global:LastBatchFailures++
-        }
-    }
-}");
-            expected.AppendLine();
-            expected.AppendLine("$Succeeded = 0");
-            expected.AppendLine("$Failed = 0");
-            expected.AppendLine("$RepoMigrations = [ordered]@{}");
-            expected.AppendLine();
-            expected.AppendLine($"# =========== Queueing migration for Organization: {ADO_ORG} ===========");
-            expected.AppendLine();
-            expected.AppendLine("# No GitHub App in this org, skipping the re-wiring of Azure Pipelines to GitHub repos");
-            expected.AppendLine();
-            expected.AppendLine($"# === Queueing repo migrations for Team Project: {ADO_ORG}/{ADO_TEAM_PROJECT} ===");
-            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
-            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
-            expected.AppendLine();
-            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-            expected.AppendLine();
-            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {ADO_ORG} ===========");
-            expected.AppendLine();
-            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {FOO_REPO}. Will then complete the below post migration steps. ===");
-            expected.AppendLine("$CanExecuteBatch = $true");
-            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-            expected.AppendLine("}");
-            expected.AppendLine("if ($CanExecuteBatch) {");
-            expected.AppendLine("    ExecBatch @(");
-            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
-            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-            expected.AppendLine("    )");
-            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-            expected.AppendLine("} else {");
-            expected.AppendLine("    $Failed++");
-            expected.AppendLine("}");
-            expected.AppendLine();
-            expected.AppendLine("Write-Host =============== Summary ===============");
-            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
-            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
-            expected.AppendLine(@"
-if ($Failed -ne 0) {
-    exit 1
-}");
-            expected.AppendLine();
-            expected.AppendLine();
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Output = new FileInfo("unit-test-output"),
-                All = true
-            };
-            await _command.Invoke(args);
-
-            // Assert
-            _scriptOutput.Should().Be(expected.ToString());
-        }
-
-        [Fact]
-        public async Task ParallelScript_Create_Teams_Option_Should_Generate_Create_Teams_And_Add_Teams_To_Repos_Scripts()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            var expected = new StringBuilder();
-            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
-            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" }}");
-            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-            expected.AppendLine("$CanExecuteBatch = $true");
-            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-            expected.AppendLine("}");
-            expected.AppendLine("if ($CanExecuteBatch) {");
-            expected.AppendLine("    ExecBatch @(");
-            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-            expected.AppendLine("    )");
-            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-            expected.AppendLine("} else {");
-            expected.AppendLine("    $Failed++");
-            expected.Append('}');
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Output = new FileInfo("unit-test-output"),
-                CreateTeams = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-            // Assert
-            _scriptOutput.Should().Be(expected.ToString());
-        }
-
-        [Fact]
-        public async Task ParallelScript_Link_Idp_Groups_Option_Should_Generate_Create_Teams_Scripts_With_Idp_Groups()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            var expected = new StringBuilder();
-            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
-            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
-            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-            expected.AppendLine("$CanExecuteBatch = $true");
-            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-            expected.AppendLine("}");
-            expected.AppendLine("if ($CanExecuteBatch) {");
-            expected.AppendLine("    ExecBatch @(");
-            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-            expected.AppendLine("    )");
-            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-            expected.AppendLine("} else {");
-            expected.AppendLine("    $Failed++");
-            expected.Append('}');
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Output = new FileInfo("unit-test-output"),
-                LinkIdpGroups = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-            // Assert
-            _scriptOutput.Should().Be(expected.ToString());
-        }
-
-        [Fact]
-        public async Task ParallelScript_Lock_Ado_Repo_Option_Should_Generate_Lock_Ado_Repo_Script()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            var expected = new StringBuilder();
-            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-            expected.AppendLine("$CanExecuteBatch = $true");
-            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-            expected.AppendLine("}");
-            expected.AppendLine("if ($CanExecuteBatch) {");
-            expected.AppendLine("    $Succeeded++");
-            expected.AppendLine("} else {");
-            expected.AppendLine("    $Failed++");
-            expected.Append('}');
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Output = new FileInfo("unit-test-output"),
-                LockAdoRepos = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-            // Assert
-            _scriptOutput.Should().Be(expected.ToString());
-        }
-
-        [Fact]
-        public async Task ParallelScript_Disable_Ado_Repo_Option_Should_Generate_Disable_Ado_Repo_Script()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            var expected = new StringBuilder();
-            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-            expected.AppendLine("$CanExecuteBatch = $true");
-            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-            expected.AppendLine("}");
-            expected.AppendLine("if ($CanExecuteBatch) {");
-            expected.AppendLine("    ExecBatch @(");
-            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-            expected.AppendLine("    )");
-            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-            expected.AppendLine("} else {");
-            expected.AppendLine("    $Failed++");
-            expected.Append('}');
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Output = new FileInfo("unit-test-output"),
-                DisableAdoRepos = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-            // Assert
-            _scriptOutput.Should().Be(expected.ToString());
-        }
-
-        [Fact]
-        public async Task ParallelScript_Integrate_Boards_Option_Should_Generate_Auto_Link_And_Boards_Integration_Scripts()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-            var expected = new StringBuilder();
-            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-            expected.AppendLine("$CanExecuteBatch = $true");
-            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-            expected.AppendLine("}");
-            expected.AppendLine("if ($CanExecuteBatch) {");
-            expected.AppendLine("    ExecBatch @(");
-            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
-            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-            expected.AppendLine("    )");
-            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-            expected.AppendLine("} else {");
-            expected.AppendLine("    $Failed++");
-            expected.Append('}');
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Output = new FileInfo("unit-test-output"),
-                IntegrateBoards = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-            // Assert
-            _scriptOutput.Should().Be(expected.ToString());
-        }
-
-        [Fact]
-        public async Task ParallelScript_Rewire_Pipelines_Option_Should_Generate_Share_Service_Connection_And_Rewire_Pipeline_Scripts()
-        {
-            // Arrange
-            _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT })).ReturnsAsync(APP_ID);
-
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
-
-            var expected = new StringBuilder();
-            expected.AppendLine($"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}");
-            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-            expected.AppendLine("$CanExecuteBatch = $true");
-            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-            expected.AppendLine("}");
-            expected.AppendLine("if ($CanExecuteBatch) {");
-            expected.AppendLine("    ExecBatch @(");
-            expected.AppendLine($"        {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}");
-            expected.AppendLine("    )");
-            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-            expected.AppendLine("} else {");
-            expected.AppendLine("    $Failed++");
-            expected.Append('}');
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                Output = new FileInfo("unit-test-output"),
-                RewirePipelines = true
-            };
-            await _command.Invoke(args);
-
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-            // Assert
-            _scriptOutput.Should().Be(expected.ToString());
-        }
-
-        [Fact]
-        public async Task It_Uses_The_Ado_Pat_When_Provided()
-        {
-            // Arrange
-            const string adoPat = "ado-pat";
-
-            _mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(EMPTY_REPOS);
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                AdoOrg = ADO_ORG,
-                AdoPat = adoPat,
-                Output = new FileInfo("unit-test-output")
-            };
-            await _command.Invoke(args);
-
-            // Assert
-            _mockAdoApiFactory.Verify(m => m.Create(adoPat));
-        }
-
-        private string TrimNonExecutableLines(string script, int skipFirst = 9, int skipLast = 0)
-        {
-            var lines = script.Split(new[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries).AsEnumerable();
-
-            lines = lines
-                .Where(x => x.HasValue())
-                .Where(x => !x.Trim().StartsWith("#"))
-                .Skip(skipFirst)
-                .SkipLast(skipLast);
-
-            return string.Join(Environment.NewLine, lines);
-        }
-    }
-}
+//using System;
+//using System.Collections.Generic;
+//using System.IO;
+//using System.Linq;
+//using System.Text;
+//using System.Threading.Tasks;
+//using FluentAssertions;
+//using Moq;
+//using OctoshiftCLI.AdoToGithub;
+//using OctoshiftCLI.AdoToGithub.Commands;
+//using OctoshiftCLI.Extensions;
+//using Xunit;
+
+//namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+//{
+//    public class GenerateScriptCommandTests
+//    {
+//        private const string ADO_ORG = "ADO_ORG";
+//        private const string ADO_TEAM_PROJECT = "ADO_TEAM_PROJECT";
+//        private const string FOO_REPO = "FOO_REPO";
+//        private const string FOO_PIPELINE = "FOO_PIPELINE";
+//        private const string BAR_REPO = "BAR_REPO";
+//        private const string BAR_PIPELINE = "BAR_PIPELINE";
+//        private const string APP_ID = "d9edf292-c6fd-4440-af2b-d08fcc9c9dd1";
+//        private const string GITHUB_ORG = "GITHUB_ORG";
+
+//        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
+//        private readonly IDictionary<string, IEnumerable<string>> ADO_TEAM_PROJECTS = new Dictionary<string, IEnumerable<string>>() { { ADO_ORG, new List<string>() { ADO_TEAM_PROJECT } } };
+//        private readonly IDictionary<string, IDictionary<string, IEnumerable<string>>> ADO_REPOS = new Dictionary<string, IDictionary<string, IEnumerable<string>>>() { { ADO_ORG, new Dictionary<string, IEnumerable<string>>() { { ADO_TEAM_PROJECT, new List<string>() { FOO_REPO } } } } };
+//        private readonly IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> ADO_PIPELINES =
+//            new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
+//            { { ADO_ORG, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
+//                         { { ADO_TEAM_PROJECT, new Dictionary<string, IEnumerable<string>>()
+//                                               { { FOO_REPO, new List<string>()
+//                                                             { FOO_PIPELINE } } } } } } };
+
+//        private readonly IEnumerable<string> EMPTY_ORGS = new List<string>();
+//        private readonly IDictionary<string, IEnumerable<string>> EMPTY_TEAM_PROJECTS = new Dictionary<string, IEnumerable<string>>();
+//        private readonly IDictionary<string, IDictionary<string, IEnumerable<string>>> EMPTY_REPOS = new Dictionary<string, IDictionary<string, IEnumerable<string>>>();
+//        private readonly IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> EMPTY_PIPELINES = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>();
+
+//        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
+//        private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
+//        private readonly Mock<AdoInspectorService> _mockAdoInspector = TestHelpers.CreateMock<AdoInspectorService>();
+
+//        private string _scriptOutput = "";
+//        private readonly GenerateScriptCommand _command;
+
+//        public GenerateScriptCommandTests()
+//        {
+//            var mockVersionProvider = new Mock<IVersionProvider>();
+//            mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+
+//            _command = new GenerateScriptCommand(TestHelpers.CreateMock<OctoLogger>().Object, _mockAdoApiFactory.Object, mockVersionProvider.Object, _mockAdoInspector.Object)
+//            {
+//                WriteToFile = (_, contents) =>
+//                {
+//                    _scriptOutput = contents;
+//                    return Task.CompletedTask;
+//                }
+//            };
+//        }
+
+//        [Fact]
+//        public void Should_Have_Options()
+//        {
+//            var command = new GenerateScriptCommand(null, null, null, null);
+//            command.Should().NotBeNull();
+//            command.Name.Should().Be("generate-script");
+//            command.Options.Count.Should().Be(15);
+
+//            TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
+//            TestHelpers.VerifyCommandOption(command.Options, "ado-org", false);
+//            TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", false);
+//            TestHelpers.VerifyCommandOption(command.Options, "output", false);
+//            TestHelpers.VerifyCommandOption(command.Options, "ssh", false, true);
+//            TestHelpers.VerifyCommandOption(command.Options, "sequential", false);
+//            TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
+//            TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+//            TestHelpers.VerifyCommandOption(command.Options, "create-teams", false);
+//            TestHelpers.VerifyCommandOption(command.Options, "link-idp-groups", false);
+//            TestHelpers.VerifyCommandOption(command.Options, "lock-ado-repos", false);
+//            TestHelpers.VerifyCommandOption(command.Options, "disable-ado-repos", false);
+//            TestHelpers.VerifyCommandOption(command.Options, "integrate-boards", false);
+//            TestHelpers.VerifyCommandOption(command.Options, "rewire-pipelines", false);
+//            TestHelpers.VerifyCommandOption(command.Options, "all", false);
+//        }
+
+//        [Fact]
+//        public async Task SequentialScript_No_Data()
+//        {
+//            // Arrange
+//            var orgs = new List<string>();
+//            var teamProjects = new Dictionary<string, IEnumerable<string>>();
+//            var repos = new Dictionary<string, IDictionary<string, IEnumerable<string>>>();
+
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, null)).ReturnsAsync(orgs);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, orgs, null)).ReturnsAsync(teamProjects);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, teamProjects, null)).ReturnsAsync(repos);
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output")
+//            };
+//            await _command.Invoke(args);
+
+//            // Assert
+//            _scriptOutput.Should().BeNullOrWhiteSpace();
+//        }
+
+//        [Fact]
+//        public async Task SequentialScript_StartsWith_Shebang()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                AdoOrg = ADO_ORG,
+//                GithubOrg = GITHUB_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output")
+//            };
+//            await _command.Invoke(args);
+
+//            // Assert
+//            _scriptOutput.Should().StartWith("#!/usr/bin/env pwsh");
+//        }
+
+//        [Fact]
+//        public async Task SequentialScript_Single_Repo_No_Options()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output")
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+//            var expected = $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected);
+//        }
+
+//        [Fact]
+//        public async Task SequentialScript_Single_Repo_All_Options()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(EMPTY_PIPELINES);
+
+//            var expected = $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}";
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output"),
+//                All = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected);
+//        }
+
+//        [Fact]
+//        public async Task SequentialScript_Skips_Team_Project_With_No_Repos()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(EMPTY_REPOS);
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output")
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+//            // Assert
+//            _scriptOutput.Should().BeEmpty();
+//        }
+
+//        [Fact]
+//        public async Task SequentialScript_Single_Repo_Two_Pipelines_All_Options()
+//        {
+//            // Arrange
+//            ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO] = new List<string>() { ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO].First(), BAR_PIPELINE };
+
+//            _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT })).ReturnsAsync(APP_ID);
+
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
+
+//            var expected = $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{BAR_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}";
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output"),
+//                All = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected);
+//        }
+
+//        [Fact]
+//        public async Task SequentialScript_Single_Repo_Two_Pipelines_No_Service_Connection_All_Options()
+//        {
+//            // Arrange
+//            ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO] = new List<string>() { ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO].First(), BAR_PIPELINE };
+
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
+
+//            var expected = $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}";
+//            expected += Environment.NewLine;
+//            expected += $"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}";
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output"),
+//                All = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected);
+//        }
+
+//        [Fact]
+//        public async Task SequentialScript_Create_Teams_Option_Should_Generate_Create_Team_And_Add_Teams_To_Repos_Scripts()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
+//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" }}");
+//            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
+//            expected.AppendLine($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+//            expected.Append($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output"),
+//                CreateTeams = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task SequentialScript_Link_Idp_Groups_Option_Should_Generate_Create_Teams_Scripts_With_Idp_Groups()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
+//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
+//            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
+//            expected.AppendLine($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+//            expected.Append($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output"),
+//                LinkIdpGroups = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task SequentialScript_Lock_Ado_Repo_Option_Should_Generate_Lock_Ado_Repo_Script()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+//            expected.Append($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output"),
+//                LockAdoRepos = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task SequentialScript_Disable_Ado_Repo_Option_Should_Generate_Disable_Ado_Repo_Script()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
+//            expected.Append($"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output"),
+//                DisableAdoRepos = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+//            // Assert
+//            _scriptOutput.Should().Contain(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task SequentialScript_Integrate_Boards_Option_Should_Generate_Auto_Link_And_Boards_Integration_Scripts()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
+//            expected.AppendLine($"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
+//            expected.Append($"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output"),
+//                IntegrateBoards = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+//            // Assert
+//            _scriptOutput.Should().Contain(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task SequentialScript_Rewire_Pipelines_Option_Should_Generate_Share_Service_Connection_And_Rewire_Pipeline_Scripts()
+//        {
+//            // Arrange
+//            _mockAdoApi
+//                .Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT }))
+//                .ReturnsAsync(APP_ID);
+
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine($"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}");
+//            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
+//            expected.Append($"Exec {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}");
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output"),
+//                RewirePipelines = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+//            // Assert
+//            _scriptOutput.Should().Contain(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task ParallelScript_No_Data()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, null)).ReturnsAsync(EMPTY_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, EMPTY_ORGS, null)).ReturnsAsync(EMPTY_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, EMPTY_TEAM_PROJECTS, null)).ReturnsAsync(EMPTY_REPOS);
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                Sequential = true,
+//                Output = new FileInfo("unit-test-output")
+//            };
+//            await _command.Invoke(args);
+
+//            // Assert
+//            _scriptOutput.Should().BeEmpty();
+//        }
+
+//        [Fact]
+//        public async Task ParallelScript_StartsWith_Shebang()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                AdoOrg = ADO_ORG,
+//                GithubOrg = GITHUB_ORG,
+//                Output = new FileInfo("unit-test-output")
+//            };
+//            await _command.Invoke(args);
+
+//            // Assert
+//            _scriptOutput.Should().StartWith("#!/usr/bin/env pwsh");
+//        }
+
+//        [Fact]
+//        public async Task ParallelScript_Single_Repo_No_Options()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine("#!/usr/bin/env pwsh");
+//            expected.AppendLine();
+//            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+//            expected.AppendLine(@"
+//function Exec {
+//    param (
+//        [scriptblock]$ScriptBlock
+//    )
+//    & @ScriptBlock
+//    if ($lastexitcode -ne 0) {
+//        exit $lastexitcode
+//    }
+//}");
+//            expected.AppendLine(@"
+//function ExecAndGetMigrationID {
+//    param (
+//        [scriptblock]$ScriptBlock
+//    )
+//    $MigrationID = Exec $ScriptBlock | ForEach-Object {
+//        Write-Host $_
+//        $_
+//    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
+//    return $MigrationID
+//}");
+//            expected.AppendLine(@"
+//function ExecBatch {
+//    param (
+//        [scriptblock[]]$ScriptBlocks
+//    )
+//    $Global:LastBatchFailures = 0
+//    foreach ($ScriptBlock in $ScriptBlocks)
+//    {
+//        & @ScriptBlock
+//        if ($lastexitcode -ne 0) {
+//            $Global:LastBatchFailures++
+//        }
+//    }
+//}");
+//            expected.AppendLine();
+//            expected.AppendLine("$Succeeded = 0");
+//            expected.AppendLine("$Failed = 0");
+//            expected.AppendLine("$RepoMigrations = [ordered]@{}");
+//            expected.AppendLine();
+//            expected.AppendLine($"# =========== Queueing migration for Organization: {ADO_ORG} ===========");
+//            expected.AppendLine();
+//            expected.AppendLine($"# === Queueing repo migrations for Team Project: {ADO_ORG}/{ADO_TEAM_PROJECT} ===");
+//            expected.AppendLine();
+//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+//            expected.AppendLine();
+//            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {ADO_ORG} ===========");
+//            expected.AppendLine();
+//            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {FOO_REPO}. Will then complete the below post migration steps. ===");
+//            expected.AppendLine("$CanExecuteBatch = $true");
+//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+//            expected.AppendLine("}");
+//            expected.AppendLine("if ($CanExecuteBatch) {");
+//            expected.AppendLine("    $Succeeded++");
+//            expected.AppendLine("} else {");
+//            expected.AppendLine("    $Failed++");
+//            expected.AppendLine("}");
+//            expected.AppendLine();
+//            expected.AppendLine("Write-Host =============== Summary ===============");
+//            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
+//            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
+//            expected.AppendLine(@"
+//if ($Failed -ne 0) {
+//    exit 1
+//}");
+//            expected.AppendLine();
+//            expected.AppendLine();
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Output = new FileInfo("unit-test-output")
+//            };
+//            await _command.Invoke(args);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task PatallelScript_Skips_Team_Project_With_No_Repos()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(EMPTY_REPOS);
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Output = new FileInfo("unit-test-output")
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+//            // Assert
+//            _scriptOutput.Should().BeEmpty();
+//        }
+
+//        [Fact]
+//        public async Task ParallelScript_Two_Repos_Two_Pipelines_All_Options()
+//        {
+//            // Arrange
+//            ADO_REPOS[ADO_ORG][ADO_TEAM_PROJECT] = new List<string>() { FOO_REPO, BAR_REPO };
+//            ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT].Add(BAR_REPO, new List<string>() { BAR_PIPELINE });
+
+//            _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT })).ReturnsAsync(APP_ID);
+
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine("#!/usr/bin/env pwsh");
+//            expected.AppendLine();
+//            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+//            expected.AppendLine(@"
+//function Exec {
+//    param (
+//        [scriptblock]$ScriptBlock
+//    )
+//    & @ScriptBlock
+//    if ($lastexitcode -ne 0) {
+//        exit $lastexitcode
+//    }
+//}");
+//            expected.AppendLine(@"
+//function ExecAndGetMigrationID {
+//    param (
+//        [scriptblock]$ScriptBlock
+//    )
+//    $MigrationID = Exec $ScriptBlock | ForEach-Object {
+//        Write-Host $_
+//        $_
+//    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
+//    return $MigrationID
+//}");
+//            expected.AppendLine(@"
+//function ExecBatch {
+//    param (
+//        [scriptblock[]]$ScriptBlocks
+//    )
+//    $Global:LastBatchFailures = 0
+//    foreach ($ScriptBlock in $ScriptBlocks)
+//    {
+//        & @ScriptBlock
+//        if ($lastexitcode -ne 0) {
+//            $Global:LastBatchFailures++
+//        }
+//    }
+//}");
+//            expected.AppendLine();
+//            expected.AppendLine("$Succeeded = 0");
+//            expected.AppendLine("$Failed = 0");
+//            expected.AppendLine("$RepoMigrations = [ordered]@{}");
+//            expected.AppendLine();
+//            expected.AppendLine($"# =========== Queueing migration for Organization: {ADO_ORG} ===========");
+//            expected.AppendLine();
+//            expected.AppendLine($"# === Queueing repo migrations for Team Project: {ADO_ORG}/{ADO_TEAM_PROJECT} ===");
+//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
+//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
+//            expected.AppendLine($"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}");
+//            expected.AppendLine();
+//            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+//            expected.AppendLine();
+//            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{BAR_REPO}\" }}");
+//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{BAR_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" }}");
+//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{BAR_REPO}\"] = $MigrationID");
+//            expected.AppendLine();
+//            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {ADO_ORG} ===========");
+//            expected.AppendLine();
+//            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {FOO_REPO}. Will then complete the below post migration steps. ===");
+//            expected.AppendLine("$CanExecuteBatch = $true");
+//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+//            expected.AppendLine("}");
+//            expected.AppendLine("if ($CanExecuteBatch) {");
+//            expected.AppendLine("    ExecBatch @(");
+//            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}");
+//            expected.AppendLine("    )");
+//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+//            expected.AppendLine("} else {");
+//            expected.AppendLine("    $Failed++");
+//            expected.AppendLine("}");
+//            expected.AppendLine();
+//            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {BAR_REPO}. Will then complete the below post migration steps. ===");
+//            expected.AppendLine("$CanExecuteBatch = $true");
+//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{BAR_REPO}\"]) {{");
+//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{BAR_REPO}\"]");
+//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+//            expected.AppendLine("}");
+//            expected.AppendLine("if ($CanExecuteBatch) {");
+//            expected.AppendLine("    ExecBatch @(");
+//            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{BAR_REPO}\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{BAR_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --service-connection-id \"{APP_ID}\" }}");
+//            expected.AppendLine("    )");
+//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+//            expected.AppendLine("} else {");
+//            expected.AppendLine("    $Failed++");
+//            expected.AppendLine("}");
+//            expected.AppendLine();
+//            expected.AppendLine("Write-Host =============== Summary ===============");
+//            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
+//            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
+//            expected.AppendLine(@"
+//if ($Failed -ne 0) {
+//    exit 1
+//}");
+//            expected.AppendLine();
+//            expected.AppendLine();
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Output = new FileInfo("unit-test-output"),
+//                All = true
+//            };
+//            await _command.Invoke(args);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task ParallelScript_Single_Repo_No_Service_Connection_All_Options()
+//        {
+//            // Arrange
+//            ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO] = new List<string>() { ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO].First(), BAR_PIPELINE };
+
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine("#!/usr/bin/env pwsh");
+//            expected.AppendLine();
+//            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+//            expected.AppendLine(@"
+//function Exec {
+//    param (
+//        [scriptblock]$ScriptBlock
+//    )
+//    & @ScriptBlock
+//    if ($lastexitcode -ne 0) {
+//        exit $lastexitcode
+//    }
+//}");
+//            expected.AppendLine(@"
+//function ExecAndGetMigrationID {
+//    param (
+//        [scriptblock]$ScriptBlock
+//    )
+//    $MigrationID = Exec $ScriptBlock | ForEach-Object {
+//        Write-Host $_
+//        $_
+//    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
+//    return $MigrationID
+//}");
+//            expected.AppendLine(@"
+//function ExecBatch {
+//    param (
+//        [scriptblock[]]$ScriptBlocks
+//    )
+//    $Global:LastBatchFailures = 0
+//    foreach ($ScriptBlock in $ScriptBlocks)
+//    {
+//        & @ScriptBlock
+//        if ($lastexitcode -ne 0) {
+//            $Global:LastBatchFailures++
+//        }
+//    }
+//}");
+//            expected.AppendLine();
+//            expected.AppendLine("$Succeeded = 0");
+//            expected.AppendLine("$Failed = 0");
+//            expected.AppendLine("$RepoMigrations = [ordered]@{}");
+//            expected.AppendLine();
+//            expected.AppendLine($"# =========== Queueing migration for Organization: {ADO_ORG} ===========");
+//            expected.AppendLine();
+//            expected.AppendLine("# No GitHub App in this org, skipping the re-wiring of Azure Pipelines to GitHub repos");
+//            expected.AppendLine();
+//            expected.AppendLine($"# === Queueing repo migrations for Team Project: {ADO_ORG}/{ADO_TEAM_PROJECT} ===");
+//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
+//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
+//            expected.AppendLine();
+//            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+//            expected.AppendLine();
+//            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {ADO_ORG} ===========");
+//            expected.AppendLine();
+//            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {FOO_REPO}. Will then complete the below post migration steps. ===");
+//            expected.AppendLine("$CanExecuteBatch = $true");
+//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+//            expected.AppendLine("}");
+//            expected.AppendLine("if ($CanExecuteBatch) {");
+//            expected.AppendLine("    ExecBatch @(");
+//            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+//            expected.AppendLine("    )");
+//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+//            expected.AppendLine("} else {");
+//            expected.AppendLine("    $Failed++");
+//            expected.AppendLine("}");
+//            expected.AppendLine();
+//            expected.AppendLine("Write-Host =============== Summary ===============");
+//            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
+//            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
+//            expected.AppendLine(@"
+//if ($Failed -ne 0) {
+//    exit 1
+//}");
+//            expected.AppendLine();
+//            expected.AppendLine();
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Output = new FileInfo("unit-test-output"),
+//                All = true
+//            };
+//            await _command.Invoke(args);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task ParallelScript_Create_Teams_Option_Should_Generate_Create_Teams_And_Add_Teams_To_Repos_Scripts()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
+//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" }}");
+//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+//            expected.AppendLine("$CanExecuteBatch = $true");
+//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+//            expected.AppendLine("}");
+//            expected.AppendLine("if ($CanExecuteBatch) {");
+//            expected.AppendLine("    ExecBatch @(");
+//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+//            expected.AppendLine("    )");
+//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+//            expected.AppendLine("} else {");
+//            expected.AppendLine("    $Failed++");
+//            expected.Append('}');
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Output = new FileInfo("unit-test-output"),
+//                CreateTeams = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task ParallelScript_Link_Idp_Groups_Option_Should_Generate_Create_Teams_Scripts_With_Idp_Groups()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
+//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
+//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+//            expected.AppendLine("$CanExecuteBatch = $true");
+//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+//            expected.AppendLine("}");
+//            expected.AppendLine("if ($CanExecuteBatch) {");
+//            expected.AppendLine("    ExecBatch @(");
+//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+//            expected.AppendLine("    )");
+//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+//            expected.AppendLine("} else {");
+//            expected.AppendLine("    $Failed++");
+//            expected.Append('}');
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Output = new FileInfo("unit-test-output"),
+//                LinkIdpGroups = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task ParallelScript_Lock_Ado_Repo_Option_Should_Generate_Lock_Ado_Repo_Script()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+//            expected.AppendLine("$CanExecuteBatch = $true");
+//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+//            expected.AppendLine("}");
+//            expected.AppendLine("if ($CanExecuteBatch) {");
+//            expected.AppendLine("    $Succeeded++");
+//            expected.AppendLine("} else {");
+//            expected.AppendLine("    $Failed++");
+//            expected.Append('}');
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Output = new FileInfo("unit-test-output"),
+//                LockAdoRepos = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task ParallelScript_Disable_Ado_Repo_Option_Should_Generate_Disable_Ado_Repo_Script()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+//            expected.AppendLine("$CanExecuteBatch = $true");
+//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+//            expected.AppendLine("}");
+//            expected.AppendLine("if ($CanExecuteBatch) {");
+//            expected.AppendLine("    ExecBatch @(");
+//            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+//            expected.AppendLine("    )");
+//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+//            expected.AppendLine("} else {");
+//            expected.AppendLine("    $Failed++");
+//            expected.Append('}');
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Output = new FileInfo("unit-test-output"),
+//                DisableAdoRepos = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task ParallelScript_Integrate_Boards_Option_Should_Generate_Auto_Link_And_Boards_Integration_Scripts()
+//        {
+//            // Arrange
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+//            expected.AppendLine("$CanExecuteBatch = $true");
+//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+//            expected.AppendLine("}");
+//            expected.AppendLine("if ($CanExecuteBatch) {");
+//            expected.AppendLine("    ExecBatch @(");
+//            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
+//            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+//            expected.AppendLine("    )");
+//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+//            expected.AppendLine("} else {");
+//            expected.AppendLine("    $Failed++");
+//            expected.Append('}');
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Output = new FileInfo("unit-test-output"),
+//                IntegrateBoards = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task ParallelScript_Rewire_Pipelines_Option_Should_Generate_Share_Service_Connection_And_Rewire_Pipeline_Scripts()
+//        {
+//            // Arrange
+//            _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT })).ReturnsAsync(APP_ID);
+
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
+
+//            var expected = new StringBuilder();
+//            expected.AppendLine($"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}");
+//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+//            expected.AppendLine("$CanExecuteBatch = $true");
+//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+//            expected.AppendLine("}");
+//            expected.AppendLine("if ($CanExecuteBatch) {");
+//            expected.AppendLine("    ExecBatch @(");
+//            expected.AppendLine($"        {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}");
+//            expected.AppendLine("    )");
+//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+//            expected.AppendLine("} else {");
+//            expected.AppendLine("    $Failed++");
+//            expected.Append('}');
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                Output = new FileInfo("unit-test-output"),
+//                RewirePipelines = true
+//            };
+//            await _command.Invoke(args);
+
+//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+//            // Assert
+//            _scriptOutput.Should().Be(expected.ToString());
+//        }
+
+//        [Fact]
+//        public async Task It_Uses_The_Ado_Pat_When_Provided()
+//        {
+//            // Arrange
+//            const string adoPat = "ado-pat";
+
+//            _mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(_mockAdoApi.Object);
+
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(EMPTY_REPOS);
+
+//            // Act
+//            var args = new GenerateScriptCommandArgs
+//            {
+//                GithubOrg = GITHUB_ORG,
+//                AdoOrg = ADO_ORG,
+//                AdoPat = adoPat,
+//                Output = new FileInfo("unit-test-output")
+//            };
+//            await _command.Invoke(args);
+
+//            // Assert
+//            _mockAdoApiFactory.Verify(m => m.Create(adoPat));
+//        }
+
+//        private string TrimNonExecutableLines(string script, int skipFirst = 9, int skipLast = 0)
+//        {
+//            var lines = script.Split(new[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries).AsEnumerable();
+
+//            lines = lines
+//                .Where(x => x.HasValue())
+//                .Where(x => !x.Trim().StartsWith("#"))
+//                .Skip(skipFirst)
+//                .SkipLast(skipLast);
+
+//            return string.Join(Environment.NewLine, lines);
+//        }
+//    }
+//}

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -1,1272 +1,1274 @@
-//using System;
-//using System.Collections.Generic;
-//using System.IO;
-//using System.Linq;
-//using System.Text;
-//using System.Threading.Tasks;
-//using FluentAssertions;
-//using Moq;
-//using OctoshiftCLI.AdoToGithub;
-//using OctoshiftCLI.AdoToGithub.Commands;
-//using OctoshiftCLI.Extensions;
-//using Xunit;
-
-//namespace OctoshiftCLI.Tests.AdoToGithub.Commands
-//{
-//    public class GenerateScriptCommandTests
-//    {
-//        private const string ADO_ORG = "ADO_ORG";
-//        private const string ADO_TEAM_PROJECT = "ADO_TEAM_PROJECT";
-//        private const string FOO_REPO = "FOO_REPO";
-//        private const string FOO_PIPELINE = "FOO_PIPELINE";
-//        private const string BAR_REPO = "BAR_REPO";
-//        private const string BAR_PIPELINE = "BAR_PIPELINE";
-//        private const string APP_ID = "d9edf292-c6fd-4440-af2b-d08fcc9c9dd1";
-//        private const string GITHUB_ORG = "GITHUB_ORG";
-
-//        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
-//        private readonly IDictionary<string, IEnumerable<string>> ADO_TEAM_PROJECTS = new Dictionary<string, IEnumerable<string>>() { { ADO_ORG, new List<string>() { ADO_TEAM_PROJECT } } };
-//        private readonly IDictionary<string, IDictionary<string, IEnumerable<string>>> ADO_REPOS = new Dictionary<string, IDictionary<string, IEnumerable<string>>>() { { ADO_ORG, new Dictionary<string, IEnumerable<string>>() { { ADO_TEAM_PROJECT, new List<string>() { FOO_REPO } } } } };
-//        private readonly IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> ADO_PIPELINES =
-//            new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
-//            { { ADO_ORG, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
-//                         { { ADO_TEAM_PROJECT, new Dictionary<string, IEnumerable<string>>()
-//                                               { { FOO_REPO, new List<string>()
-//                                                             { FOO_PIPELINE } } } } } } };
-
-//        private readonly IEnumerable<string> EMPTY_ORGS = new List<string>();
-//        private readonly IDictionary<string, IEnumerable<string>> EMPTY_TEAM_PROJECTS = new Dictionary<string, IEnumerable<string>>();
-//        private readonly IDictionary<string, IDictionary<string, IEnumerable<string>>> EMPTY_REPOS = new Dictionary<string, IDictionary<string, IEnumerable<string>>>();
-//        private readonly IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> EMPTY_PIPELINES = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>();
-
-//        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
-//        private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
-//        private readonly Mock<AdoInspectorService> _mockAdoInspector = TestHelpers.CreateMock<AdoInspectorService>();
-
-//        private string _scriptOutput = "";
-//        private readonly GenerateScriptCommand _command;
-
-//        public GenerateScriptCommandTests()
-//        {
-//            var mockVersionProvider = new Mock<IVersionProvider>();
-//            mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
-
-//            _command = new GenerateScriptCommand(TestHelpers.CreateMock<OctoLogger>().Object, _mockAdoApiFactory.Object, mockVersionProvider.Object, _mockAdoInspector.Object)
-//            {
-//                WriteToFile = (_, contents) =>
-//                {
-//                    _scriptOutput = contents;
-//                    return Task.CompletedTask;
-//                }
-//            };
-//        }
-
-//        [Fact]
-//        public void Should_Have_Options()
-//        {
-//            var command = new GenerateScriptCommand(null, null, null, null);
-//            command.Should().NotBeNull();
-//            command.Name.Should().Be("generate-script");
-//            command.Options.Count.Should().Be(15);
-
-//            TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
-//            TestHelpers.VerifyCommandOption(command.Options, "ado-org", false);
-//            TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", false);
-//            TestHelpers.VerifyCommandOption(command.Options, "output", false);
-//            TestHelpers.VerifyCommandOption(command.Options, "ssh", false, true);
-//            TestHelpers.VerifyCommandOption(command.Options, "sequential", false);
-//            TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
-//            TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
-//            TestHelpers.VerifyCommandOption(command.Options, "create-teams", false);
-//            TestHelpers.VerifyCommandOption(command.Options, "link-idp-groups", false);
-//            TestHelpers.VerifyCommandOption(command.Options, "lock-ado-repos", false);
-//            TestHelpers.VerifyCommandOption(command.Options, "disable-ado-repos", false);
-//            TestHelpers.VerifyCommandOption(command.Options, "integrate-boards", false);
-//            TestHelpers.VerifyCommandOption(command.Options, "rewire-pipelines", false);
-//            TestHelpers.VerifyCommandOption(command.Options, "all", false);
-//        }
-
-//        [Fact]
-//        public async Task SequentialScript_No_Data()
-//        {
-//            // Arrange
-//            var orgs = new List<string>();
-//            var teamProjects = new Dictionary<string, IEnumerable<string>>();
-//            var repos = new Dictionary<string, IDictionary<string, IEnumerable<string>>>();
-
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, null)).ReturnsAsync(orgs);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, orgs, null)).ReturnsAsync(teamProjects);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, teamProjects, null)).ReturnsAsync(repos);
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output")
-//            };
-//            await _command.Invoke(args);
-
-//            // Assert
-//            _scriptOutput.Should().BeNullOrWhiteSpace();
-//        }
-
-//        [Fact]
-//        public async Task SequentialScript_StartsWith_Shebang()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                AdoOrg = ADO_ORG,
-//                GithubOrg = GITHUB_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output")
-//            };
-//            await _command.Invoke(args);
-
-//            // Assert
-//            _scriptOutput.Should().StartWith("#!/usr/bin/env pwsh");
-//        }
-
-//        [Fact]
-//        public async Task SequentialScript_Single_Repo_No_Options()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output")
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-//            var expected = $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected);
-//        }
-
-//        [Fact]
-//        public async Task SequentialScript_Single_Repo_All_Options()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(EMPTY_PIPELINES);
-
-//            var expected = $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}";
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output"),
-//                All = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected);
-//        }
-
-//        [Fact]
-//        public async Task SequentialScript_Skips_Team_Project_With_No_Repos()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(EMPTY_REPOS);
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output")
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-//            // Assert
-//            _scriptOutput.Should().BeEmpty();
-//        }
-
-//        [Fact]
-//        public async Task SequentialScript_Single_Repo_Two_Pipelines_All_Options()
-//        {
-//            // Arrange
-//            ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO] = new List<string>() { ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO].First(), BAR_PIPELINE };
-
-//            _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT })).ReturnsAsync(APP_ID);
-
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
-
-//            var expected = $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{BAR_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}";
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output"),
-//                All = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected);
-//        }
-
-//        [Fact]
-//        public async Task SequentialScript_Single_Repo_Two_Pipelines_No_Service_Connection_All_Options()
-//        {
-//            // Arrange
-//            ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO] = new List<string>() { ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO].First(), BAR_PIPELINE };
-
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
-
-//            var expected = $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}";
-//            expected += Environment.NewLine;
-//            expected += $"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}";
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output"),
-//                All = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected);
-//        }
-
-//        [Fact]
-//        public async Task SequentialScript_Create_Teams_Option_Should_Generate_Create_Team_And_Add_Teams_To_Repos_Scripts()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
-//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" }}");
-//            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
-//            expected.AppendLine($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-//            expected.Append($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output"),
-//                CreateTeams = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task SequentialScript_Link_Idp_Groups_Option_Should_Generate_Create_Teams_Scripts_With_Idp_Groups()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
-//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
-//            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
-//            expected.AppendLine($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-//            expected.Append($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output"),
-//                LinkIdpGroups = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task SequentialScript_Lock_Ado_Repo_Option_Should_Generate_Lock_Ado_Repo_Script()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-//            expected.Append($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output"),
-//                LockAdoRepos = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task SequentialScript_Disable_Ado_Repo_Option_Should_Generate_Disable_Ado_Repo_Script()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
-//            expected.Append($"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output"),
-//                DisableAdoRepos = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-//            // Assert
-//            _scriptOutput.Should().Contain(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task SequentialScript_Integrate_Boards_Option_Should_Generate_Auto_Link_And_Boards_Integration_Scripts()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
-//            expected.AppendLine($"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
-//            expected.Append($"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output"),
-//                IntegrateBoards = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-//            // Assert
-//            _scriptOutput.Should().Contain(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task SequentialScript_Rewire_Pipelines_Option_Should_Generate_Share_Service_Connection_And_Rewire_Pipeline_Scripts()
-//        {
-//            // Arrange
-//            _mockAdoApi
-//                .Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT }))
-//                .ReturnsAsync(APP_ID);
-
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine($"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}");
-//            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
-//            expected.Append($"Exec {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}");
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output"),
-//                RewirePipelines = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
-//            // Assert
-//            _scriptOutput.Should().Contain(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task ParallelScript_No_Data()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, null)).ReturnsAsync(EMPTY_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, EMPTY_ORGS, null)).ReturnsAsync(EMPTY_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, EMPTY_TEAM_PROJECTS, null)).ReturnsAsync(EMPTY_REPOS);
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                Sequential = true,
-//                Output = new FileInfo("unit-test-output")
-//            };
-//            await _command.Invoke(args);
-
-//            // Assert
-//            _scriptOutput.Should().BeEmpty();
-//        }
-
-//        [Fact]
-//        public async Task ParallelScript_StartsWith_Shebang()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                AdoOrg = ADO_ORG,
-//                GithubOrg = GITHUB_ORG,
-//                Output = new FileInfo("unit-test-output")
-//            };
-//            await _command.Invoke(args);
-
-//            // Assert
-//            _scriptOutput.Should().StartWith("#!/usr/bin/env pwsh");
-//        }
-
-//        [Fact]
-//        public async Task ParallelScript_Single_Repo_No_Options()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine("#!/usr/bin/env pwsh");
-//            expected.AppendLine();
-//            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
-//            expected.AppendLine(@"
-//function Exec {
-//    param (
-//        [scriptblock]$ScriptBlock
-//    )
-//    & @ScriptBlock
-//    if ($lastexitcode -ne 0) {
-//        exit $lastexitcode
-//    }
-//}");
-//            expected.AppendLine(@"
-//function ExecAndGetMigrationID {
-//    param (
-//        [scriptblock]$ScriptBlock
-//    )
-//    $MigrationID = Exec $ScriptBlock | ForEach-Object {
-//        Write-Host $_
-//        $_
-//    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
-//    return $MigrationID
-//}");
-//            expected.AppendLine(@"
-//function ExecBatch {
-//    param (
-//        [scriptblock[]]$ScriptBlocks
-//    )
-//    $Global:LastBatchFailures = 0
-//    foreach ($ScriptBlock in $ScriptBlocks)
-//    {
-//        & @ScriptBlock
-//        if ($lastexitcode -ne 0) {
-//            $Global:LastBatchFailures++
-//        }
-//    }
-//}");
-//            expected.AppendLine();
-//            expected.AppendLine("$Succeeded = 0");
-//            expected.AppendLine("$Failed = 0");
-//            expected.AppendLine("$RepoMigrations = [ordered]@{}");
-//            expected.AppendLine();
-//            expected.AppendLine($"# =========== Queueing migration for Organization: {ADO_ORG} ===========");
-//            expected.AppendLine();
-//            expected.AppendLine($"# === Queueing repo migrations for Team Project: {ADO_ORG}/{ADO_TEAM_PROJECT} ===");
-//            expected.AppendLine();
-//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-//            expected.AppendLine();
-//            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {ADO_ORG} ===========");
-//            expected.AppendLine();
-//            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {FOO_REPO}. Will then complete the below post migration steps. ===");
-//            expected.AppendLine("$CanExecuteBatch = $true");
-//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-//            expected.AppendLine("}");
-//            expected.AppendLine("if ($CanExecuteBatch) {");
-//            expected.AppendLine("    $Succeeded++");
-//            expected.AppendLine("} else {");
-//            expected.AppendLine("    $Failed++");
-//            expected.AppendLine("}");
-//            expected.AppendLine();
-//            expected.AppendLine("Write-Host =============== Summary ===============");
-//            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
-//            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
-//            expected.AppendLine(@"
-//if ($Failed -ne 0) {
-//    exit 1
-//}");
-//            expected.AppendLine();
-//            expected.AppendLine();
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Output = new FileInfo("unit-test-output")
-//            };
-//            await _command.Invoke(args);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task PatallelScript_Skips_Team_Project_With_No_Repos()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(EMPTY_REPOS);
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Output = new FileInfo("unit-test-output")
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-//            // Assert
-//            _scriptOutput.Should().BeEmpty();
-//        }
-
-//        [Fact]
-//        public async Task ParallelScript_Two_Repos_Two_Pipelines_All_Options()
-//        {
-//            // Arrange
-//            ADO_REPOS[ADO_ORG][ADO_TEAM_PROJECT] = new List<string>() { FOO_REPO, BAR_REPO };
-//            ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT].Add(BAR_REPO, new List<string>() { BAR_PIPELINE });
-
-//            _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT })).ReturnsAsync(APP_ID);
-
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine("#!/usr/bin/env pwsh");
-//            expected.AppendLine();
-//            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
-//            expected.AppendLine(@"
-//function Exec {
-//    param (
-//        [scriptblock]$ScriptBlock
-//    )
-//    & @ScriptBlock
-//    if ($lastexitcode -ne 0) {
-//        exit $lastexitcode
-//    }
-//}");
-//            expected.AppendLine(@"
-//function ExecAndGetMigrationID {
-//    param (
-//        [scriptblock]$ScriptBlock
-//    )
-//    $MigrationID = Exec $ScriptBlock | ForEach-Object {
-//        Write-Host $_
-//        $_
-//    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
-//    return $MigrationID
-//}");
-//            expected.AppendLine(@"
-//function ExecBatch {
-//    param (
-//        [scriptblock[]]$ScriptBlocks
-//    )
-//    $Global:LastBatchFailures = 0
-//    foreach ($ScriptBlock in $ScriptBlocks)
-//    {
-//        & @ScriptBlock
-//        if ($lastexitcode -ne 0) {
-//            $Global:LastBatchFailures++
-//        }
-//    }
-//}");
-//            expected.AppendLine();
-//            expected.AppendLine("$Succeeded = 0");
-//            expected.AppendLine("$Failed = 0");
-//            expected.AppendLine("$RepoMigrations = [ordered]@{}");
-//            expected.AppendLine();
-//            expected.AppendLine($"# =========== Queueing migration for Organization: {ADO_ORG} ===========");
-//            expected.AppendLine();
-//            expected.AppendLine($"# === Queueing repo migrations for Team Project: {ADO_ORG}/{ADO_TEAM_PROJECT} ===");
-//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
-//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
-//            expected.AppendLine($"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}");
-//            expected.AppendLine();
-//            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-//            expected.AppendLine();
-//            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{BAR_REPO}\" }}");
-//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{BAR_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" }}");
-//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{BAR_REPO}\"] = $MigrationID");
-//            expected.AppendLine();
-//            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {ADO_ORG} ===========");
-//            expected.AppendLine();
-//            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {FOO_REPO}. Will then complete the below post migration steps. ===");
-//            expected.AppendLine("$CanExecuteBatch = $true");
-//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-//            expected.AppendLine("}");
-//            expected.AppendLine("if ($CanExecuteBatch) {");
-//            expected.AppendLine("    ExecBatch @(");
-//            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}");
-//            expected.AppendLine("    )");
-//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-//            expected.AppendLine("} else {");
-//            expected.AppendLine("    $Failed++");
-//            expected.AppendLine("}");
-//            expected.AppendLine();
-//            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {BAR_REPO}. Will then complete the below post migration steps. ===");
-//            expected.AppendLine("$CanExecuteBatch = $true");
-//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{BAR_REPO}\"]) {{");
-//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{BAR_REPO}\"]");
-//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-//            expected.AppendLine("}");
-//            expected.AppendLine("if ($CanExecuteBatch) {");
-//            expected.AppendLine("    ExecBatch @(");
-//            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{BAR_REPO}\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{BAR_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --service-connection-id \"{APP_ID}\" }}");
-//            expected.AppendLine("    )");
-//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-//            expected.AppendLine("} else {");
-//            expected.AppendLine("    $Failed++");
-//            expected.AppendLine("}");
-//            expected.AppendLine();
-//            expected.AppendLine("Write-Host =============== Summary ===============");
-//            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
-//            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
-//            expected.AppendLine(@"
-//if ($Failed -ne 0) {
-//    exit 1
-//}");
-//            expected.AppendLine();
-//            expected.AppendLine();
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Output = new FileInfo("unit-test-output"),
-//                All = true
-//            };
-//            await _command.Invoke(args);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task ParallelScript_Single_Repo_No_Service_Connection_All_Options()
-//        {
-//            // Arrange
-//            ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO] = new List<string>() { ADO_PIPELINES[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO].First(), BAR_PIPELINE };
-
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine("#!/usr/bin/env pwsh");
-//            expected.AppendLine();
-//            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
-//            expected.AppendLine(@"
-//function Exec {
-//    param (
-//        [scriptblock]$ScriptBlock
-//    )
-//    & @ScriptBlock
-//    if ($lastexitcode -ne 0) {
-//        exit $lastexitcode
-//    }
-//}");
-//            expected.AppendLine(@"
-//function ExecAndGetMigrationID {
-//    param (
-//        [scriptblock]$ScriptBlock
-//    )
-//    $MigrationID = Exec $ScriptBlock | ForEach-Object {
-//        Write-Host $_
-//        $_
-//    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
-//    return $MigrationID
-//}");
-//            expected.AppendLine(@"
-//function ExecBatch {
-//    param (
-//        [scriptblock[]]$ScriptBlocks
-//    )
-//    $Global:LastBatchFailures = 0
-//    foreach ($ScriptBlock in $ScriptBlocks)
-//    {
-//        & @ScriptBlock
-//        if ($lastexitcode -ne 0) {
-//            $Global:LastBatchFailures++
-//        }
-//    }
-//}");
-//            expected.AppendLine();
-//            expected.AppendLine("$Succeeded = 0");
-//            expected.AppendLine("$Failed = 0");
-//            expected.AppendLine("$RepoMigrations = [ordered]@{}");
-//            expected.AppendLine();
-//            expected.AppendLine($"# =========== Queueing migration for Organization: {ADO_ORG} ===========");
-//            expected.AppendLine();
-//            expected.AppendLine("# No GitHub App in this org, skipping the re-wiring of Azure Pipelines to GitHub repos");
-//            expected.AppendLine();
-//            expected.AppendLine($"# === Queueing repo migrations for Team Project: {ADO_ORG}/{ADO_TEAM_PROJECT} ===");
-//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
-//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
-//            expected.AppendLine();
-//            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-//            expected.AppendLine();
-//            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {ADO_ORG} ===========");
-//            expected.AppendLine();
-//            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {FOO_REPO}. Will then complete the below post migration steps. ===");
-//            expected.AppendLine("$CanExecuteBatch = $true");
-//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-//            expected.AppendLine("}");
-//            expected.AppendLine("if ($CanExecuteBatch) {");
-//            expected.AppendLine("    ExecBatch @(");
-//            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-//            expected.AppendLine("    )");
-//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-//            expected.AppendLine("} else {");
-//            expected.AppendLine("    $Failed++");
-//            expected.AppendLine("}");
-//            expected.AppendLine();
-//            expected.AppendLine("Write-Host =============== Summary ===============");
-//            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
-//            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
-//            expected.AppendLine(@"
-//if ($Failed -ne 0) {
-//    exit 1
-//}");
-//            expected.AppendLine();
-//            expected.AppendLine();
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Output = new FileInfo("unit-test-output"),
-//                All = true
-//            };
-//            await _command.Invoke(args);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task ParallelScript_Create_Teams_Option_Should_Generate_Create_Teams_And_Add_Teams_To_Repos_Scripts()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
-//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" }}");
-//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-//            expected.AppendLine("$CanExecuteBatch = $true");
-//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-//            expected.AppendLine("}");
-//            expected.AppendLine("if ($CanExecuteBatch) {");
-//            expected.AppendLine("    ExecBatch @(");
-//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-//            expected.AppendLine("    )");
-//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-//            expected.AppendLine("} else {");
-//            expected.AppendLine("    $Failed++");
-//            expected.Append('}');
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Output = new FileInfo("unit-test-output"),
-//                CreateTeams = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task ParallelScript_Link_Idp_Groups_Option_Should_Generate_Create_Teams_Scripts_With_Idp_Groups()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
-//            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
-//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-//            expected.AppendLine("$CanExecuteBatch = $true");
-//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-//            expected.AppendLine("}");
-//            expected.AppendLine("if ($CanExecuteBatch) {");
-//            expected.AppendLine("    ExecBatch @(");
-//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
-//            expected.AppendLine("    )");
-//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-//            expected.AppendLine("} else {");
-//            expected.AppendLine("    $Failed++");
-//            expected.Append('}');
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Output = new FileInfo("unit-test-output"),
-//                LinkIdpGroups = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task ParallelScript_Lock_Ado_Repo_Option_Should_Generate_Lock_Ado_Repo_Script()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-//            expected.AppendLine("$CanExecuteBatch = $true");
-//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-//            expected.AppendLine("}");
-//            expected.AppendLine("if ($CanExecuteBatch) {");
-//            expected.AppendLine("    $Succeeded++");
-//            expected.AppendLine("} else {");
-//            expected.AppendLine("    $Failed++");
-//            expected.Append('}');
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Output = new FileInfo("unit-test-output"),
-//                LockAdoRepos = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task ParallelScript_Disable_Ado_Repo_Option_Should_Generate_Disable_Ado_Repo_Script()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-//            expected.AppendLine("$CanExecuteBatch = $true");
-//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-//            expected.AppendLine("}");
-//            expected.AppendLine("if ($CanExecuteBatch) {");
-//            expected.AppendLine("    ExecBatch @(");
-//            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
-//            expected.AppendLine("    )");
-//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-//            expected.AppendLine("} else {");
-//            expected.AppendLine("    $Failed++");
-//            expected.Append('}');
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Output = new FileInfo("unit-test-output"),
-//                DisableAdoRepos = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task ParallelScript_Integrate_Boards_Option_Should_Generate_Auto_Link_And_Boards_Integration_Scripts()
-//        {
-//            // Arrange
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-//            expected.AppendLine("$CanExecuteBatch = $true");
-//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-//            expected.AppendLine("}");
-//            expected.AppendLine("if ($CanExecuteBatch) {");
-//            expected.AppendLine("    ExecBatch @(");
-//            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
-//            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-//            expected.AppendLine("    )");
-//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-//            expected.AppendLine("} else {");
-//            expected.AppendLine("    $Failed++");
-//            expected.Append('}');
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Output = new FileInfo("unit-test-output"),
-//                IntegrateBoards = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task ParallelScript_Rewire_Pipelines_Option_Should_Generate_Share_Service_Connection_And_Rewire_Pipeline_Scripts()
-//        {
-//            // Arrange
-//            _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT })).ReturnsAsync(APP_ID);
-
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
-
-//            var expected = new StringBuilder();
-//            expected.AppendLine($"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}");
-//            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
-//            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
-//            expected.AppendLine("$CanExecuteBatch = $true");
-//            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
-//            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
-//            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
-//            expected.AppendLine("}");
-//            expected.AppendLine("if ($CanExecuteBatch) {");
-//            expected.AppendLine("    ExecBatch @(");
-//            expected.AppendLine($"        {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}");
-//            expected.AppendLine("    )");
-//            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
-//            expected.AppendLine("} else {");
-//            expected.AppendLine("    $Failed++");
-//            expected.Append('}');
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                Output = new FileInfo("unit-test-output"),
-//                RewirePipelines = true
-//            };
-//            await _command.Invoke(args);
-
-//            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
-//            // Assert
-//            _scriptOutput.Should().Be(expected.ToString());
-//        }
-
-//        [Fact]
-//        public async Task It_Uses_The_Ado_Pat_When_Provided()
-//        {
-//            // Arrange
-//            const string adoPat = "ado-pat";
-
-//            _mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(_mockAdoApi.Object);
-
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(EMPTY_REPOS);
-
-//            // Act
-//            var args = new GenerateScriptCommandArgs
-//            {
-//                GithubOrg = GITHUB_ORG,
-//                AdoOrg = ADO_ORG,
-//                AdoPat = adoPat,
-//                Output = new FileInfo("unit-test-output")
-//            };
-//            await _command.Invoke(args);
-
-//            // Assert
-//            _mockAdoApiFactory.Verify(m => m.Create(adoPat));
-//        }
-
-//        private string TrimNonExecutableLines(string script, int skipFirst = 9, int skipLast = 0)
-//        {
-//            var lines = script.Split(new[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries).AsEnumerable();
-
-//            lines = lines
-//                .Where(x => x.HasValue())
-//                .Where(x => !x.Trim().StartsWith("#"))
-//                .Skip(skipFirst)
-//                .SkipLast(skipLast);
-
-//            return string.Join(Environment.NewLine, lines);
-//        }
-//    }
-//}
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using OctoshiftCLI.AdoToGithub;
+using OctoshiftCLI.AdoToGithub.Commands;
+using OctoshiftCLI.Extensions;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+{
+    public class GenerateScriptCommandTests
+    {
+        private const string ADO_ORG = "ADO_ORG";
+        private const string ADO_TEAM_PROJECT = "ADO_TEAM_PROJECT";
+        private const string FOO_REPO = "FOO_REPO";
+        private const string FOO_PIPELINE = "FOO_PIPELINE";
+        private const string BAR_REPO = "BAR_REPO";
+        private const string BAR_PIPELINE = "BAR_PIPELINE";
+        private const string APP_ID = "d9edf292-c6fd-4440-af2b-d08fcc9c9dd1";
+        private const string GITHUB_ORG = "GITHUB_ORG";
+
+        private IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
+        private IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
+        private IEnumerable<string> ADO_REPOS = new List<string>() { FOO_REPO };
+        private IEnumerable<string> ADO_PIPELINES = new List<string>() { FOO_PIPELINE };
+
+        private IEnumerable<string> EMPTY_ORGS = new List<string>();
+        private IEnumerable<string> EMPTY_TEAM_PROJECTS = new List<string>();
+        private IEnumerable<string> EMPTY_REPOS = new List<string>();
+        private IEnumerable<string> EMPTY_PIPELINES = new List<string>();
+
+        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
+        private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
+        private readonly Mock<AdoInspectorService> _mockAdoInspector = TestHelpers.CreateMock<AdoInspectorService>();
+
+        private string _scriptOutput = "";
+        private readonly GenerateScriptCommand _command;
+
+        public GenerateScriptCommandTests()
+        {
+            var mockVersionProvider = new Mock<IVersionProvider>();
+            mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+
+            _command = new GenerateScriptCommand(TestHelpers.CreateMock<OctoLogger>().Object, _mockAdoApiFactory.Object, mockVersionProvider.Object, _mockAdoInspector.Object)
+            {
+                WriteToFile = (_, contents) =>
+                {
+                    _scriptOutput = contents;
+                    return Task.CompletedTask;
+                }
+            };
+        }
+
+        [Fact]
+        public void Should_Have_Options()
+        {
+            var command = new GenerateScriptCommand(null, null, null, null);
+            command.Should().NotBeNull();
+            command.Name.Should().Be("generate-script");
+            command.Options.Count.Should().Be(15);
+
+            TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
+            TestHelpers.VerifyCommandOption(command.Options, "ado-org", false);
+            TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", false);
+            TestHelpers.VerifyCommandOption(command.Options, "output", false);
+            TestHelpers.VerifyCommandOption(command.Options, "ssh", false, true);
+            TestHelpers.VerifyCommandOption(command.Options, "sequential", false);
+            TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
+            TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+            TestHelpers.VerifyCommandOption(command.Options, "create-teams", false);
+            TestHelpers.VerifyCommandOption(command.Options, "link-idp-groups", false);
+            TestHelpers.VerifyCommandOption(command.Options, "lock-ado-repos", false);
+            TestHelpers.VerifyCommandOption(command.Options, "disable-ado-repos", false);
+            TestHelpers.VerifyCommandOption(command.Options, "integrate-boards", false);
+            TestHelpers.VerifyCommandOption(command.Options, "rewire-pipelines", false);
+            TestHelpers.VerifyCommandOption(command.Options, "all", false);
+        }
+
+        [Fact]
+        public async Task SequentialScript_No_Data()
+        {
+            // Arrange
+            var orgs = new List<string>();
+            var teamProjects = new Dictionary<string, IEnumerable<string>>();
+            var repos = new Dictionary<string, IDictionary<string, IEnumerable<string>>>();
+
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(orgs);
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                Sequential = true,
+                Output = new FileInfo("unit-test-output")
+            };
+            await _command.Invoke(args);
+
+            // Assert
+            _scriptOutput.Should().BeNullOrWhiteSpace();
+        }
+
+        [Fact]
+        public async Task SequentialScript_StartsWith_Shebang()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                GithubOrg = GITHUB_ORG,
+                Sequential = true,
+                Output = new FileInfo("unit-test-output")
+            };
+            await _command.Invoke(args);
+
+            // Assert
+            _scriptOutput.Should().StartWith("#!/usr/bin/env pwsh");
+        }
+
+        [Fact]
+        public async Task SequentialScript_Single_Repo_No_Options()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Sequential = true,
+                Output = new FileInfo("unit-test-output")
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+            var expected = $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
+
+            // Assert
+            _scriptOutput.Should().Be(expected);
+        }
+
+        [Fact]
+        public async Task SequentialScript_Single_Repo_All_Options()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+            _mockAdoInspector.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(EMPTY_PIPELINES);
+
+            var expected = $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}";
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Sequential = true,
+                Output = new FileInfo("unit-test-output"),
+                All = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+            // Assert
+            _scriptOutput.Should().Be(expected);
+        }
+
+        [Fact]
+        public async Task SequentialScript_Skips_Team_Project_With_No_Repos()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(0);
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Sequential = true,
+                Output = new FileInfo("unit-test-output")
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+            // Assert
+            _scriptOutput.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task SequentialScript_Single_Repo_Two_Pipelines_All_Options()
+        {
+            // Arrange
+            ADO_PIPELINES = new List<string> { FOO_PIPELINE, BAR_PIPELINE };
+
+            _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, ADO_TEAM_PROJECTS)).ReturnsAsync(APP_ID);
+
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+            _mockAdoInspector.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(ADO_PIPELINES);
+
+            var expected = $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{BAR_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}";
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Sequential = true,
+                Output = new FileInfo("unit-test-output"),
+                All = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+            // Assert
+            _scriptOutput.Should().Be(expected);
+        }
+
+        [Fact]
+        public async Task SequentialScript_Single_Repo_Two_Pipelines_No_Service_Connection_All_Options()
+        {
+            // Arrange
+            ADO_PIPELINES = new List<string> { FOO_PIPELINE, BAR_PIPELINE };
+
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+            _mockAdoInspector.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(ADO_PIPELINES);
+
+            var expected = $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}";
+            expected += Environment.NewLine;
+            expected += $"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}";
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Sequential = true,
+                Output = new FileInfo("unit-test-output"),
+                All = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+            // Assert
+            _scriptOutput.Should().Be(expected);
+        }
+
+        [Fact]
+        public async Task SequentialScript_Create_Teams_Option_Should_Generate_Create_Team_And_Add_Teams_To_Repos_Scripts()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+
+            var expected = new StringBuilder();
+            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
+            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" }}");
+            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
+            expected.AppendLine($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+            expected.Append($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Sequential = true,
+                Output = new FileInfo("unit-test-output"),
+                CreateTeams = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+            // Assert
+            _scriptOutput.Should().Be(expected.ToString());
+        }
+
+        [Fact]
+        public async Task SequentialScript_Link_Idp_Groups_Option_Should_Generate_Create_Teams_Scripts_With_Idp_Groups()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+
+            var expected = new StringBuilder();
+            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
+            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
+            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
+            expected.AppendLine($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+            expected.Append($"Exec {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Sequential = true,
+                Output = new FileInfo("unit-test-output"),
+                LinkIdpGroups = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+            // Assert
+            _scriptOutput.Should().Be(expected.ToString());
+        }
+
+        [Fact]
+        public async Task SequentialScript_Lock_Ado_Repo_Option_Should_Generate_Lock_Ado_Repo_Script()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+
+            var expected = new StringBuilder();
+            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+            expected.Append($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Sequential = true,
+                Output = new FileInfo("unit-test-output"),
+                LockAdoRepos = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+            // Assert
+            _scriptOutput.Should().Be(expected.ToString());
+        }
+
+        [Fact]
+        public async Task SequentialScript_Disable_Ado_Repo_Option_Should_Generate_Disable_Ado_Repo_Script()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+
+            var expected = new StringBuilder();
+            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
+            expected.Append($"Exec {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Sequential = true,
+                Output = new FileInfo("unit-test-output"),
+                DisableAdoRepos = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+            // Assert
+            _scriptOutput.Should().Contain(expected.ToString());
+        }
+
+        [Fact]
+        public async Task SequentialScript_Integrate_Boards_Option_Should_Generate_Auto_Link_And_Boards_Integration_Scripts()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+
+            var expected = new StringBuilder();
+            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
+            expected.AppendLine($"Exec {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
+            expected.Append($"Exec {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Sequential = true,
+                Output = new FileInfo("unit-test-output"),
+                IntegrateBoards = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+            // Assert
+            _scriptOutput.Should().Contain(expected.ToString());
+        }
+
+        [Fact]
+        public async Task SequentialScript_Rewire_Pipelines_Option_Should_Generate_Share_Service_Connection_And_Rewire_Pipeline_Scripts()
+        {
+            // Arrange
+            _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoApi
+                .Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, ADO_TEAM_PROJECTS))
+                .ReturnsAsync(APP_ID);
+
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+            _mockAdoInspector.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(ADO_PIPELINES);
+
+            var expected = new StringBuilder();
+            expected.AppendLine($"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}");
+            expected.AppendLine($"Exec {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --wait }}");
+            expected.Append($"Exec {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}");
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Sequential = true,
+                Output = new FileInfo("unit-test-output"),
+                RewirePipelines = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+
+            // Assert
+            _scriptOutput.Should().Contain(expected.ToString());
+        }
+
+        [Fact]
+        public async Task ParallelScript_No_Data()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(0);
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                Output = new FileInfo("unit-test-output")
+            };
+            await _command.Invoke(args);
+
+            // Assert
+            _scriptOutput.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task ParallelScript_StartsWith_Shebang()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                GithubOrg = GITHUB_ORG,
+                Output = new FileInfo("unit-test-output")
+            };
+            await _command.Invoke(args);
+
+            // Assert
+            _scriptOutput.Should().StartWith("#!/usr/bin/env pwsh");
+        }
+
+        [Fact]
+        public async Task ParallelScript_Single_Repo_No_Options()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+
+            var expected = new StringBuilder();
+            expected.AppendLine("#!/usr/bin/env pwsh");
+            expected.AppendLine();
+            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+            expected.AppendLine(@"
+function Exec {
+    param (
+        [scriptblock]$ScriptBlock
+    )
+    & @ScriptBlock
+    if ($lastexitcode -ne 0) {
+        exit $lastexitcode
+    }
+}");
+            expected.AppendLine(@"
+function ExecAndGetMigrationID {
+    param (
+        [scriptblock]$ScriptBlock
+    )
+    $MigrationID = Exec $ScriptBlock | ForEach-Object {
+        Write-Host $_
+        $_
+    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
+    return $MigrationID
+}");
+            expected.AppendLine(@"
+function ExecBatch {
+    param (
+        [scriptblock[]]$ScriptBlocks
+    )
+    $Global:LastBatchFailures = 0
+    foreach ($ScriptBlock in $ScriptBlocks)
+    {
+        & @ScriptBlock
+        if ($lastexitcode -ne 0) {
+            $Global:LastBatchFailures++
+        }
+    }
+}");
+            expected.AppendLine();
+            expected.AppendLine("$Succeeded = 0");
+            expected.AppendLine("$Failed = 0");
+            expected.AppendLine("$RepoMigrations = [ordered]@{}");
+            expected.AppendLine();
+            expected.AppendLine($"# =========== Queueing migration for Organization: {ADO_ORG} ===========");
+            expected.AppendLine();
+            expected.AppendLine($"# === Queueing repo migrations for Team Project: {ADO_ORG}/{ADO_TEAM_PROJECT} ===");
+            expected.AppendLine();
+            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+            expected.AppendLine();
+            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {ADO_ORG} ===========");
+            expected.AppendLine();
+            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {FOO_REPO}. Will then complete the below post migration steps. ===");
+            expected.AppendLine("$CanExecuteBatch = $true");
+            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+            expected.AppendLine("}");
+            expected.AppendLine("if ($CanExecuteBatch) {");
+            expected.AppendLine("    $Succeeded++");
+            expected.AppendLine("} else {");
+            expected.AppendLine("    $Failed++");
+            expected.AppendLine("}");
+            expected.AppendLine();
+            expected.AppendLine("Write-Host =============== Summary ===============");
+            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
+            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
+            expected.AppendLine(@"
+if ($Failed -ne 0) {
+    exit 1
+}");
+            expected.AppendLine();
+            expected.AppendLine();
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Output = new FileInfo("unit-test-output")
+            };
+            await _command.Invoke(args);
+
+            // Assert
+            _scriptOutput.Should().Be(expected.ToString());
+        }
+
+        [Fact]
+        public async Task PatallelScript_Skips_Team_Project_With_No_Repos()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(0);
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Output = new FileInfo("unit-test-output")
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+            // Assert
+            _scriptOutput.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task ParallelScript_Two_Repos_Two_Pipelines_All_Options()
+        {
+            // Arrange
+            ADO_REPOS = new List<string> { FOO_REPO, BAR_REPO };
+
+            _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, ADO_TEAM_PROJECTS)).ReturnsAsync(APP_ID);
+
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(2);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+            _mockAdoInspector.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(new[] { FOO_PIPELINE });
+            _mockAdoInspector.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, BAR_REPO)).ReturnsAsync(new[] { BAR_PIPELINE });
+
+            var expected = new StringBuilder();
+            expected.AppendLine("#!/usr/bin/env pwsh");
+            expected.AppendLine();
+            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+            expected.AppendLine(@"
+function Exec {
+    param (
+        [scriptblock]$ScriptBlock
+    )
+    & @ScriptBlock
+    if ($lastexitcode -ne 0) {
+        exit $lastexitcode
+    }
+}");
+            expected.AppendLine(@"
+function ExecAndGetMigrationID {
+    param (
+        [scriptblock]$ScriptBlock
+    )
+    $MigrationID = Exec $ScriptBlock | ForEach-Object {
+        Write-Host $_
+        $_
+    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
+    return $MigrationID
+}");
+            expected.AppendLine(@"
+function ExecBatch {
+    param (
+        [scriptblock[]]$ScriptBlocks
+    )
+    $Global:LastBatchFailures = 0
+    foreach ($ScriptBlock in $ScriptBlocks)
+    {
+        & @ScriptBlock
+        if ($lastexitcode -ne 0) {
+            $Global:LastBatchFailures++
+        }
+    }
+}");
+            expected.AppendLine();
+            expected.AppendLine("$Succeeded = 0");
+            expected.AppendLine("$Failed = 0");
+            expected.AppendLine("$RepoMigrations = [ordered]@{}");
+            expected.AppendLine();
+            expected.AppendLine($"# =========== Queueing migration for Organization: {ADO_ORG} ===========");
+            expected.AppendLine();
+            expected.AppendLine($"# === Queueing repo migrations for Team Project: {ADO_ORG}/{ADO_TEAM_PROJECT} ===");
+            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
+            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
+            expected.AppendLine($"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}");
+            expected.AppendLine();
+            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+            expected.AppendLine();
+            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{BAR_REPO}\" }}");
+            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{BAR_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" }}");
+            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{BAR_REPO}\"] = $MigrationID");
+            expected.AppendLine();
+            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {ADO_ORG} ===========");
+            expected.AppendLine();
+            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {FOO_REPO}. Will then complete the below post migration steps. ===");
+            expected.AppendLine("$CanExecuteBatch = $true");
+            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+            expected.AppendLine("}");
+            expected.AppendLine("if ($CanExecuteBatch) {");
+            expected.AppendLine("    ExecBatch @(");
+            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
+            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+            expected.AppendLine($"        {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}");
+            expected.AppendLine("    )");
+            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+            expected.AppendLine("} else {");
+            expected.AppendLine("    $Failed++");
+            expected.AppendLine("}");
+            expected.AppendLine();
+            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {BAR_REPO}. Will then complete the below post migration steps. ===");
+            expected.AppendLine("$CanExecuteBatch = $true");
+            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{BAR_REPO}\"]) {{");
+            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{BAR_REPO}\"]");
+            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+            expected.AppendLine("}");
+            expected.AppendLine("if ($CanExecuteBatch) {");
+            expected.AppendLine("    ExecBatch @(");
+            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{BAR_REPO}\" }}");
+            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
+            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" }}");
+            expected.AppendLine($"        {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{BAR_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{BAR_REPO}\" --service-connection-id \"{APP_ID}\" }}");
+            expected.AppendLine("    )");
+            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+            expected.AppendLine("} else {");
+            expected.AppendLine("    $Failed++");
+            expected.AppendLine("}");
+            expected.AppendLine();
+            expected.AppendLine("Write-Host =============== Summary ===============");
+            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
+            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
+            expected.AppendLine(@"
+if ($Failed -ne 0) {
+    exit 1
+}");
+            expected.AppendLine();
+            expected.AppendLine();
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Output = new FileInfo("unit-test-output"),
+                All = true
+            };
+            await _command.Invoke(args);
+
+            // Assert
+            _scriptOutput.Should().Be(expected.ToString());
+        }
+
+        [Fact]
+        public async Task ParallelScript_Single_Repo_No_Service_Connection_All_Options()
+        {
+            // Arrange
+            ADO_PIPELINES = new List<string> { FOO_PIPELINE, BAR_PIPELINE };
+
+            _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+            _mockAdoInspector.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(ADO_PIPELINES);
+
+            var expected = new StringBuilder();
+            expected.AppendLine("#!/usr/bin/env pwsh");
+            expected.AppendLine();
+            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+            expected.AppendLine(@"
+function Exec {
+    param (
+        [scriptblock]$ScriptBlock
+    )
+    & @ScriptBlock
+    if ($lastexitcode -ne 0) {
+        exit $lastexitcode
+    }
+}");
+            expected.AppendLine(@"
+function ExecAndGetMigrationID {
+    param (
+        [scriptblock]$ScriptBlock
+    )
+    $MigrationID = Exec $ScriptBlock | ForEach-Object {
+        Write-Host $_
+        $_
+    } | Select-String -Pattern ""\(ID: (.+)\)"" | ForEach-Object { $_.matches.groups[1] }
+    return $MigrationID
+}");
+            expected.AppendLine(@"
+function ExecBatch {
+    param (
+        [scriptblock[]]$ScriptBlocks
+    )
+    $Global:LastBatchFailures = 0
+    foreach ($ScriptBlock in $ScriptBlocks)
+    {
+        & @ScriptBlock
+        if ($lastexitcode -ne 0) {
+            $Global:LastBatchFailures++
+        }
+    }
+}");
+            expected.AppendLine();
+            expected.AppendLine("$Succeeded = 0");
+            expected.AppendLine("$Failed = 0");
+            expected.AppendLine("$RepoMigrations = [ordered]@{}");
+            expected.AppendLine();
+            expected.AppendLine($"# =========== Queueing migration for Organization: {ADO_ORG} ===========");
+            expected.AppendLine();
+            expected.AppendLine("# No GitHub App in this org, skipping the re-wiring of Azure Pipelines to GitHub repos");
+            expected.AppendLine();
+            expected.AppendLine($"# === Queueing repo migrations for Team Project: {ADO_ORG}/{ADO_TEAM_PROJECT} ===");
+            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
+            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
+            expected.AppendLine();
+            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+            expected.AppendLine();
+            expected.AppendLine($"# =========== Waiting for all migrations to finish for Organization: {ADO_ORG} ===========");
+            expected.AppendLine();
+            expected.AppendLine($"# === Waiting for repo migration to finish for Team Project: {ADO_TEAM_PROJECT} and Repo: {FOO_REPO}. Will then complete the below post migration steps. ===");
+            expected.AppendLine("$CanExecuteBatch = $true");
+            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+            expected.AppendLine("}");
+            expected.AppendLine("if ($CanExecuteBatch) {");
+            expected.AppendLine("    ExecBatch @(");
+            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
+            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+            expected.AppendLine("    )");
+            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+            expected.AppendLine("} else {");
+            expected.AppendLine("    $Failed++");
+            expected.AppendLine("}");
+            expected.AppendLine();
+            expected.AppendLine("Write-Host =============== Summary ===============");
+            expected.AppendLine("Write-Host Total number of successful migrations: $Succeeded");
+            expected.AppendLine("Write-Host Total number of failed migrations: $Failed");
+            expected.AppendLine(@"
+if ($Failed -ne 0) {
+    exit 1
+}");
+            expected.AppendLine();
+            expected.AppendLine();
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Output = new FileInfo("unit-test-output"),
+                All = true
+            };
+            await _command.Invoke(args);
+
+            // Assert
+            _scriptOutput.Should().Be(expected.ToString());
+        }
+
+        [Fact]
+        public async Task ParallelScript_Create_Teams_Option_Should_Generate_Create_Teams_And_Add_Teams_To_Repos_Scripts()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+
+            var expected = new StringBuilder();
+            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
+            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" }}");
+            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+            expected.AppendLine("$CanExecuteBatch = $true");
+            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+            expected.AppendLine("}");
+            expected.AppendLine("if ($CanExecuteBatch) {");
+            expected.AppendLine("    ExecBatch @(");
+            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+            expected.AppendLine("    )");
+            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+            expected.AppendLine("} else {");
+            expected.AppendLine("    $Failed++");
+            expected.Append('}');
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Output = new FileInfo("unit-test-output"),
+                CreateTeams = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+            // Assert
+            _scriptOutput.Should().Be(expected.ToString());
+        }
+
+        [Fact]
+        public async Task ParallelScript_Link_Idp_Groups_Option_Should_Generate_Create_Teams_Scripts_With_Idp_Groups()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+
+            var expected = new StringBuilder();
+            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Maintainers\" --idp-group \"{ADO_TEAM_PROJECT}-Maintainers\" }}");
+            expected.AppendLine($"Exec {{ ./ado2gh create-team --github-org \"{GITHUB_ORG}\" --team-name \"{ADO_TEAM_PROJECT}-Admins\" --idp-group \"{ADO_TEAM_PROJECT}-Admins\" }}");
+            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+            expected.AppendLine("$CanExecuteBatch = $true");
+            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+            expected.AppendLine("}");
+            expected.AppendLine("if ($CanExecuteBatch) {");
+            expected.AppendLine("    ExecBatch @(");
+            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Maintainers\" --role \"maintain\" }}");
+            expected.AppendLine($"        {{ ./ado2gh add-team-to-repo --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --team \"{ADO_TEAM_PROJECT}-Admins\" --role \"admin\" }}");
+            expected.AppendLine("    )");
+            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+            expected.AppendLine("} else {");
+            expected.AppendLine("    $Failed++");
+            expected.Append('}');
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Output = new FileInfo("unit-test-output"),
+                LinkIdpGroups = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+            // Assert
+            _scriptOutput.Should().Be(expected.ToString());
+        }
+
+        [Fact]
+        public async Task ParallelScript_Lock_Ado_Repo_Option_Should_Generate_Lock_Ado_Repo_Script()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+
+            var expected = new StringBuilder();
+            expected.AppendLine($"Exec {{ ./ado2gh lock-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+            expected.AppendLine("$CanExecuteBatch = $true");
+            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+            expected.AppendLine("}");
+            expected.AppendLine("if ($CanExecuteBatch) {");
+            expected.AppendLine("    $Succeeded++");
+            expected.AppendLine("} else {");
+            expected.AppendLine("    $Failed++");
+            expected.Append('}');
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Output = new FileInfo("unit-test-output"),
+                LockAdoRepos = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+            // Assert
+            _scriptOutput.Should().Be(expected.ToString());
+        }
+
+        [Fact]
+        public async Task ParallelScript_Disable_Ado_Repo_Option_Should_Generate_Disable_Ado_Repo_Script()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+
+            var expected = new StringBuilder();
+            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+            expected.AppendLine("$CanExecuteBatch = $true");
+            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+            expected.AppendLine("}");
+            expected.AppendLine("if ($CanExecuteBatch) {");
+            expected.AppendLine("    ExecBatch @(");
+            expected.AppendLine($"        {{ ./ado2gh disable-ado-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" }}");
+            expected.AppendLine("    )");
+            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+            expected.AppendLine("} else {");
+            expected.AppendLine("    $Failed++");
+            expected.Append('}');
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Output = new FileInfo("unit-test-output"),
+                DisableAdoRepos = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+            // Assert
+            _scriptOutput.Should().Be(expected.ToString());
+        }
+
+        [Fact]
+        public async Task ParallelScript_Integrate_Boards_Option_Should_Generate_Auto_Link_And_Boards_Integration_Scripts()
+        {
+            // Arrange
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+
+            var expected = new StringBuilder();
+            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+            expected.AppendLine("$CanExecuteBatch = $true");
+            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+            expected.AppendLine("}");
+            expected.AppendLine("if ($CanExecuteBatch) {");
+            expected.AppendLine("    ExecBatch @(");
+            expected.AppendLine($"        {{ ./ado2gh configure-autolink --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" }}");
+            expected.AppendLine($"        {{ ./ado2gh integrate-boards --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+            expected.AppendLine("    )");
+            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+            expected.AppendLine("} else {");
+            expected.AppendLine("    $Failed++");
+            expected.Append('}');
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Output = new FileInfo("unit-test-output"),
+                IntegrateBoards = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+            // Assert
+            _scriptOutput.Should().Be(expected.ToString());
+        }
+
+        [Fact]
+        public async Task ParallelScript_Rewire_Pipelines_Option_Should_Generate_Share_Service_Connection_And_Rewire_Pipeline_Scripts()
+        {
+            // Arrange
+            _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT })).ReturnsAsync(APP_ID);
+
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+            _mockAdoInspector.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(ADO_PIPELINES);
+
+            var expected = new StringBuilder();
+            expected.AppendLine($"Exec {{ ./ado2gh share-service-connection --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --service-connection-id \"{APP_ID}\" }}");
+            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ ./ado2gh migrate-repo --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" }}");
+            expected.AppendLine($"$RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"] = $MigrationID");
+            expected.AppendLine("$CanExecuteBatch = $true");
+            expected.AppendLine($"if ($null -ne $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]) {{");
+            expected.AppendLine($"    ./ado2gh wait-for-migration --migration-id $RepoMigrations[\"{ADO_ORG}/{ADO_TEAM_PROJECT}-{FOO_REPO}\"]");
+            expected.AppendLine("    $CanExecuteBatch = ($lastexitcode -eq 0)");
+            expected.AppendLine("}");
+            expected.AppendLine("if ($CanExecuteBatch) {");
+            expected.AppendLine("    ExecBatch @(");
+            expected.AppendLine($"        {{ ./ado2gh rewire-pipeline --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}");
+            expected.AppendLine("    )");
+            expected.AppendLine("    if ($Global:LastBatchFailures -eq 0) { $Succeeded++ }");
+            expected.AppendLine("} else {");
+            expected.AppendLine("    $Failed++");
+            expected.Append('}');
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                Output = new FileInfo("unit-test-output"),
+                RewirePipelines = true
+            };
+            await _command.Invoke(args);
+
+            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+
+            // Assert
+            _scriptOutput.Should().Be(expected.ToString());
+        }
+
+        [Fact]
+        public async Task It_Uses_The_Ado_Pat_When_Provided()
+        {
+            // Arrange
+            const string adoPat = "ado-pat";
+
+            _mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(_mockAdoApi.Object);
+
+            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(0);
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                AdoOrg = ADO_ORG,
+                AdoPat = adoPat,
+                Output = new FileInfo("unit-test-output")
+            };
+            await _command.Invoke(args);
+
+            // Assert
+            _mockAdoApiFactory.Verify(m => m.Create(adoPat));
+        }
+
+        private string TrimNonExecutableLines(string script, int skipFirst = 9, int skipLast = 0)
+        {
+            var lines = script.Split(new[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries).AsEnumerable();
+
+            lines = lines
+                .Where(x => x.HasValue())
+                .Where(x => !x.Trim().StartsWith("#"))
+                .Skip(skipFirst)
+                .SkipLast(skipLast);
+
+            return string.Join(Environment.NewLine, lines);
+        }
+    }
+}

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -82,8 +82,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         {
             // Arrange
             var orgs = new List<string>();
-            var teamProjects = new Dictionary<string, IEnumerable<string>>();
-            var repos = new Dictionary<string, IDictionary<string, IEnumerable<string>>>();
 
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -24,15 +24,11 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private const string APP_ID = "d9edf292-c6fd-4440-af2b-d08fcc9c9dd1";
         private const string GITHUB_ORG = "GITHUB_ORG";
 
-        private IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
-        private IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
+        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
+        private readonly IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
         private IEnumerable<string> ADO_REPOS = new List<string>() { FOO_REPO };
         private IEnumerable<string> ADO_PIPELINES = new List<string>() { FOO_PIPELINE };
-
-        private IEnumerable<string> EMPTY_ORGS = new List<string>();
-        private IEnumerable<string> EMPTY_TEAM_PROJECTS = new List<string>();
-        private IEnumerable<string> EMPTY_REPOS = new List<string>();
-        private IEnumerable<string> EMPTY_PIPELINES = new List<string>();
+        private readonly IEnumerable<string> EMPTY_PIPELINES = new List<string>();
 
         private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
         private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
@@ -88,10 +88,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            _mockOrgsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedOrgsCsv);
-            _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedTeamProjectsCsv);
-            _mockReposCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedReposCsv);
-            _mockPipelinesCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedPipelinesCsv);
+            _mockOrgsCsvGenerator.Setup(m => m.Generate(null)).ReturnsAsync(expectedOrgsCsv);
+            _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(null)).ReturnsAsync(expectedTeamProjectsCsv);
+            _mockReposCsvGenerator.Setup(m => m.Generate(null)).ReturnsAsync(expectedReposCsv);
+            _mockPipelinesCsvGenerator.Setup(m => m.Generate(null)).ReturnsAsync(expectedPipelinesCsv);
 
             await _command.Invoke(null);
 
@@ -111,10 +111,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            _mockOrgsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedOrgsCsv);
-            _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedTeamProjectsCsv);
-            _mockReposCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedReposCsv);
-            _mockPipelinesCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedPipelinesCsv);
+            _mockOrgsCsvGenerator.Setup(m => m.Generate(null)).ReturnsAsync(expectedOrgsCsv);
+            _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(null)).ReturnsAsync(expectedTeamProjectsCsv);
+            _mockReposCsvGenerator.Setup(m => m.Generate(null)).ReturnsAsync(expectedReposCsv);
+            _mockPipelinesCsvGenerator.Setup(m => m.Generate(null)).ReturnsAsync(expectedPipelinesCsv);
 
             await _command.Invoke(ADO_ORG);
 
@@ -135,6 +135,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await _command.Invoke("some org", adoPat);
 
             _mockAdoApiFactory.Verify(m => m.Create(adoPat));
+            _mockOrgsCsvGenerator.Verify(m => m.Generate(adoPat));
+            _mockTeamProjectsCsvGenerator.Verify(m => m.Generate(adoPat));
+            _mockReposCsvGenerator.Verify(m => m.Generate(adoPat));
+            _mockPipelinesCsvGenerator.Verify(m => m.Generate(adoPat));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
@@ -13,6 +13,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
         private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
         private readonly Mock<AdoInspectorService> _mockAdoInspector = TestHelpers.CreateMock<AdoInspectorService>();
+        private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
         private readonly Mock<OrgsCsvGeneratorService> _mockOrgsCsvGenerator = TestHelpers.CreateMock<OrgsCsvGeneratorService>();
         private readonly Mock<TeamProjectsCsvGeneratorService> _mockTeamProjectsCsvGenerator = TestHelpers.CreateMock<TeamProjectsCsvGeneratorService>();
         private readonly Mock<ReposCsvGeneratorService> _mockReposCsvGenerator = TestHelpers.CreateMock<ReposCsvGeneratorService>();
@@ -27,9 +28,16 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
         public InventoryReportCommandTests()
         {
-            _mockAdoInspector.SetupAllProperties();
+            _mockAdoInspectorServiceFactory.Setup(m => m.Create(_mockAdoApi.Object)).Returns(_mockAdoInspector.Object);
 
-            _command = new InventoryReportCommand(TestHelpers.CreateMock<OctoLogger>().Object, _mockAdoApiFactory.Object, _mockAdoInspector.Object, _mockOrgsCsvGenerator.Object, _mockTeamProjectsCsvGenerator.Object, _mockReposCsvGenerator.Object, _mockPipelinesCsvGenerator.Object)
+            _command = new InventoryReportCommand(
+                TestHelpers.CreateMock<OctoLogger>().Object,
+                _mockAdoApiFactory.Object,
+                _mockAdoInspectorServiceFactory.Object,
+                _mockOrgsCsvGenerator.Object,
+                _mockTeamProjectsCsvGenerator.Object,
+                _mockReposCsvGenerator.Object,
+                _mockPipelinesCsvGenerator.Object)
             {
                 WriteToFile = (path, contents) =>
                 {
@@ -91,8 +99,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _teamProjectsCsvOutput.Should().Be(expectedTeamProjectsCsv);
             _reposCsvOutput.Should().Be(expectedReposCsv);
             _pipelinesCsvOutput.Should().Be(expectedPipelinesCsv);
-
-            _mockAdoInspector.Object.AdoApi.Should().Be(_mockAdoApi.Object);
         }
 
         [Fact]
@@ -124,6 +130,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         public async Task It_Uses_The_Ado_Pat_When_Provided()
         {
             const string adoPat = "ado-pat";
+            _mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(_mockAdoApi.Object);
 
             await _command.Invoke("some org", adoPat);
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
@@ -11,10 +10,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
     public class InventoryReportCommandTests
     {
         private const string ADO_ORG = "foo-org";
-        private const string ADO_TEAM_PROJECT = "foo-tp";
-        private const string FOO_REPO = "foo-repo";
-        private const string FOO_PIPELINE = "foo-pipeline";
-
         private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
         private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
         private readonly Mock<AdoInspectorService> _mockAdoInspector = TestHelpers.CreateMock<AdoInspectorService>();

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
@@ -1,151 +1,138 @@
-//using System.Collections.Generic;
-//using System.Threading.Tasks;
-//using FluentAssertions;
-//using Moq;
-//using OctoshiftCLI.AdoToGithub;
-//using OctoshiftCLI.AdoToGithub.Commands;
-//using Xunit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using OctoshiftCLI.AdoToGithub;
+using OctoshiftCLI.AdoToGithub.Commands;
+using Xunit;
 
-//namespace OctoshiftCLI.Tests.AdoToGithub.Commands
-//{
-//    public class InventoryReportCommandTests
-//    {
-//        private const string ADO_ORG = "foo-org";
-//        private const string ADO_TEAM_PROJECT = "foo-tp";
-//        private const string FOO_REPO = "foo-repo";
-//        private const string FOO_PIPELINE = "foo-pipeline";
-//        private readonly IList<string> ADO_ORGS = new List<string>() { ADO_ORG };
-//        private readonly IDictionary<string, IEnumerable<string>> ADO_TEAM_PROJECTS = new Dictionary<string, IEnumerable<string>>() { { ADO_ORG, new List<string>() { ADO_TEAM_PROJECT } } };
-//        private readonly IDictionary<string, IDictionary<string, IEnumerable<string>>> ADO_REPOS = new Dictionary<string, IDictionary<string, IEnumerable<string>>>() { { ADO_ORG, new Dictionary<string, IEnumerable<string>>() { { ADO_TEAM_PROJECT, new List<string>() { FOO_REPO } } } } };
-//        private readonly IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> ADO_PIPELINES =
-//    new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
-//    { { ADO_ORG, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
-//                         { { ADO_TEAM_PROJECT, new Dictionary<string, IEnumerable<string>>()
-//                                               { { FOO_REPO, new List<string>()
-//                                                             { FOO_PIPELINE } } } } } } };
+namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+{
+    public class InventoryReportCommandTests
+    {
+        private const string ADO_ORG = "foo-org";
+        private const string ADO_TEAM_PROJECT = "foo-tp";
+        private const string FOO_REPO = "foo-repo";
+        private const string FOO_PIPELINE = "foo-pipeline";
 
-//        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
-//        private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
-//        private readonly Mock<AdoInspectorService> _mockAdoInspector = TestHelpers.CreateMock<AdoInspectorService>();
-//        private readonly Mock<OrgsCsvGeneratorService> _mockOrgsCsvGenerator = TestHelpers.CreateMock<OrgsCsvGeneratorService>();
-//        private readonly Mock<TeamProjectsCsvGeneratorService> _mockTeamProjectsCsvGenerator = TestHelpers.CreateMock<TeamProjectsCsvGeneratorService>();
-//        private readonly Mock<ReposCsvGeneratorService> _mockReposCsvGenerator = TestHelpers.CreateMock<ReposCsvGeneratorService>();
-//        private readonly Mock<PipelinesCsvGeneratorService> _mockPipelinesCsvGenerator = TestHelpers.CreateMock<PipelinesCsvGeneratorService>();
+        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
+        private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
+        private readonly Mock<AdoInspectorService> _mockAdoInspector = TestHelpers.CreateMock<AdoInspectorService>();
+        private readonly Mock<OrgsCsvGeneratorService> _mockOrgsCsvGenerator = TestHelpers.CreateMock<OrgsCsvGeneratorService>();
+        private readonly Mock<TeamProjectsCsvGeneratorService> _mockTeamProjectsCsvGenerator = TestHelpers.CreateMock<TeamProjectsCsvGeneratorService>();
+        private readonly Mock<ReposCsvGeneratorService> _mockReposCsvGenerator = TestHelpers.CreateMock<ReposCsvGeneratorService>();
+        private readonly Mock<PipelinesCsvGeneratorService> _mockPipelinesCsvGenerator = TestHelpers.CreateMock<PipelinesCsvGeneratorService>();
 
-//        private string _orgsCsvOutput = "";
-//        private string _teamProjectsCsvOutput = "";
-//        private string _reposCsvOutput = "";
-//        private string _pipelinesCsvOutput = "";
+        private string _orgsCsvOutput = "";
+        private string _teamProjectsCsvOutput = "";
+        private string _reposCsvOutput = "";
+        private string _pipelinesCsvOutput = "";
 
-//        private readonly InventoryReportCommand _command;
+        private readonly InventoryReportCommand _command;
 
-//        public InventoryReportCommandTests()
-//        {
-//            _command = new InventoryReportCommand(TestHelpers.CreateMock<OctoLogger>().Object, _mockAdoApiFactory.Object, _mockAdoInspector.Object, _mockOrgsCsvGenerator.Object, _mockTeamProjectsCsvGenerator.Object, _mockReposCsvGenerator.Object, _mockPipelinesCsvGenerator.Object)
-//            {
-//                WriteToFile = (path, contents) =>
-//                {
-//                    if (path == "orgs.csv")
-//                    {
-//                        _orgsCsvOutput = contents;
-//                    }
+        public InventoryReportCommandTests()
+        {
+            _mockAdoInspector.SetupAllProperties();
 
-//                    if (path == "team-projects.csv")
-//                    {
-//                        _teamProjectsCsvOutput = contents;
-//                    }
+            _command = new InventoryReportCommand(TestHelpers.CreateMock<OctoLogger>().Object, _mockAdoApiFactory.Object, _mockAdoInspector.Object, _mockOrgsCsvGenerator.Object, _mockTeamProjectsCsvGenerator.Object, _mockReposCsvGenerator.Object, _mockPipelinesCsvGenerator.Object)
+            {
+                WriteToFile = (path, contents) =>
+                {
+                    if (path == "orgs.csv")
+                    {
+                        _orgsCsvOutput = contents;
+                    }
 
-//                    if (path == "repos.csv")
-//                    {
-//                        _reposCsvOutput = contents;
-//                    }
+                    if (path == "team-projects.csv")
+                    {
+                        _teamProjectsCsvOutput = contents;
+                    }
 
-//                    if (path == "pipelines.csv")
-//                    {
-//                        _pipelinesCsvOutput = contents;
-//                    }
+                    if (path == "repos.csv")
+                    {
+                        _reposCsvOutput = contents;
+                    }
 
-//                    return Task.CompletedTask;
-//                }
-//            };
-//        }
+                    if (path == "pipelines.csv")
+                    {
+                        _pipelinesCsvOutput = contents;
+                    }
 
-//        [Fact]
-//        public void Should_Have_Options()
-//        {
-//            Assert.NotNull(_command);
-//            Assert.Equal("inventory-report", _command.Name);
-//            Assert.Equal(3, _command.Options.Count);
+                    return Task.CompletedTask;
+                }
+            };
+        }
 
-//            TestHelpers.VerifyCommandOption(_command.Options, "ado-org", false);
-//            TestHelpers.VerifyCommandOption(_command.Options, "ado-pat", false);
-//            TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
-//        }
+        [Fact]
+        public void Should_Have_Options()
+        {
+            Assert.NotNull(_command);
+            Assert.Equal("inventory-report", _command.Name);
+            Assert.Equal(3, _command.Options.Count);
 
-//        [Fact]
-//        public async Task Happy_Path()
-//        {
-//            var expectedOrgsCsv = "csv stuff";
-//            var expectedTeamProjectsCsv = "more csv stuff";
-//            var expectedReposCsv = "repo csv stuff";
-//            var expectedPipelinesCsv = "pipelines csv stuff";
+            TestHelpers.VerifyCommandOption(_command.Options, "ado-org", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "ado-pat", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
+        }
 
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+        [Fact]
+        public async Task Happy_Path()
+        {
+            var expectedOrgsCsv = "csv stuff";
+            var expectedTeamProjectsCsv = "more csv stuff";
+            var expectedReposCsv = "repo csv stuff";
+            var expectedPipelinesCsv = "pipelines csv stuff";
 
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, null)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-//            _mockOrgsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedOrgsCsv);
-//            _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(ADO_PIPELINES)).Returns(expectedTeamProjectsCsv);
-//            _mockReposCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedReposCsv);
-//            _mockPipelinesCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedPipelinesCsv);
+            _mockOrgsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedOrgsCsv);
+            _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedTeamProjectsCsv);
+            _mockReposCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedReposCsv);
+            _mockPipelinesCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedPipelinesCsv);
 
-//            await _command.Invoke(null, null);
+            await _command.Invoke(null);
 
-//            _orgsCsvOutput.Should().Be(expectedOrgsCsv);
-//            _teamProjectsCsvOutput.Should().Be(expectedTeamProjectsCsv);
-//            _reposCsvOutput.Should().Be(expectedReposCsv);
-//            _pipelinesCsvOutput.Should().Be(expectedPipelinesCsv);
-//        }
+            _orgsCsvOutput.Should().Be(expectedOrgsCsv);
+            _teamProjectsCsvOutput.Should().Be(expectedTeamProjectsCsv);
+            _reposCsvOutput.Should().Be(expectedReposCsv);
+            _pipelinesCsvOutput.Should().Be(expectedPipelinesCsv);
 
-//        [Fact]
-//        public async Task Scoped_To_Single_Org()
-//        {
-//            var expectedOrgsCsv = "csv stuff";
-//            var expectedTeamProjectsCsv = "more csv stuff";
-//            var expectedReposCsv = "repo csv stuff";
-//            var expectedPipelinesCsv = "pipelines csv stuff";
+            _mockAdoInspector.Object.AdoApi.Should().Be(_mockAdoApi.Object);
+        }
 
-//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+        [Fact]
+        public async Task Scoped_To_Single_Org()
+        {
+            var expectedOrgsCsv = "csv stuff";
+            var expectedTeamProjectsCsv = "more csv stuff";
+            var expectedReposCsv = "repo csv stuff";
+            var expectedPipelinesCsv = "pipelines csv stuff";
 
-//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-//            _mockOrgsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedOrgsCsv);
-//            _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(ADO_PIPELINES)).Returns(expectedTeamProjectsCsv);
-//            _mockReposCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedReposCsv);
-//            _mockPipelinesCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedPipelinesCsv);
+            _mockOrgsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedOrgsCsv);
+            _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedTeamProjectsCsv);
+            _mockReposCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedReposCsv);
+            _mockPipelinesCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object)).ReturnsAsync(expectedPipelinesCsv);
 
-//            await _command.Invoke(ADO_ORG, null);
+            await _command.Invoke(ADO_ORG);
 
-//            _orgsCsvOutput.Should().Be(expectedOrgsCsv);
-//            _teamProjectsCsvOutput.Should().Be(expectedTeamProjectsCsv);
-//            _reposCsvOutput.Should().Be(expectedReposCsv);
-//            _pipelinesCsvOutput.Should().Be(expectedPipelinesCsv);
-//        }
+            _orgsCsvOutput.Should().Be(expectedOrgsCsv);
+            _teamProjectsCsvOutput.Should().Be(expectedTeamProjectsCsv);
+            _reposCsvOutput.Should().Be(expectedReposCsv);
+            _pipelinesCsvOutput.Should().Be(expectedPipelinesCsv);
 
-//        [Fact]
-//        public async Task It_Uses_The_Ado_Pat_When_Provided()
-//        {
-//            const string adoPat = "ado-pat";
+            _mockAdoInspector.Object.OrgFilter.Should().Be(ADO_ORG);
+        }
 
-//            await _command.Invoke("some org", adoPat);
+        [Fact]
+        public async Task It_Uses_The_Ado_Pat_When_Provided()
+        {
+            const string adoPat = "ado-pat";
 
-//            _mockAdoApiFactory.Verify(m => m.Create(adoPat));
-//        }
-//    }
-//}
+            await _command.Invoke("some org", adoPat);
+
+            _mockAdoApiFactory.Verify(m => m.Create(adoPat));
+        }
+    }
+}

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
@@ -1,151 +1,151 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using FluentAssertions;
-using Moq;
-using OctoshiftCLI.AdoToGithub;
-using OctoshiftCLI.AdoToGithub.Commands;
-using Xunit;
+//using System.Collections.Generic;
+//using System.Threading.Tasks;
+//using FluentAssertions;
+//using Moq;
+//using OctoshiftCLI.AdoToGithub;
+//using OctoshiftCLI.AdoToGithub.Commands;
+//using Xunit;
 
-namespace OctoshiftCLI.Tests.AdoToGithub.Commands
-{
-    public class InventoryReportCommandTests
-    {
-        private const string ADO_ORG = "foo-org";
-        private const string ADO_TEAM_PROJECT = "foo-tp";
-        private const string FOO_REPO = "foo-repo";
-        private const string FOO_PIPELINE = "foo-pipeline";
-        private readonly IList<string> ADO_ORGS = new List<string>() { ADO_ORG };
-        private readonly IDictionary<string, IEnumerable<string>> ADO_TEAM_PROJECTS = new Dictionary<string, IEnumerable<string>>() { { ADO_ORG, new List<string>() { ADO_TEAM_PROJECT } } };
-        private readonly IDictionary<string, IDictionary<string, IEnumerable<string>>> ADO_REPOS = new Dictionary<string, IDictionary<string, IEnumerable<string>>>() { { ADO_ORG, new Dictionary<string, IEnumerable<string>>() { { ADO_TEAM_PROJECT, new List<string>() { FOO_REPO } } } } };
-        private readonly IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> ADO_PIPELINES =
-    new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
-    { { ADO_ORG, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
-                         { { ADO_TEAM_PROJECT, new Dictionary<string, IEnumerable<string>>()
-                                               { { FOO_REPO, new List<string>()
-                                                             { FOO_PIPELINE } } } } } } };
+//namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+//{
+//    public class InventoryReportCommandTests
+//    {
+//        private const string ADO_ORG = "foo-org";
+//        private const string ADO_TEAM_PROJECT = "foo-tp";
+//        private const string FOO_REPO = "foo-repo";
+//        private const string FOO_PIPELINE = "foo-pipeline";
+//        private readonly IList<string> ADO_ORGS = new List<string>() { ADO_ORG };
+//        private readonly IDictionary<string, IEnumerable<string>> ADO_TEAM_PROJECTS = new Dictionary<string, IEnumerable<string>>() { { ADO_ORG, new List<string>() { ADO_TEAM_PROJECT } } };
+//        private readonly IDictionary<string, IDictionary<string, IEnumerable<string>>> ADO_REPOS = new Dictionary<string, IDictionary<string, IEnumerable<string>>>() { { ADO_ORG, new Dictionary<string, IEnumerable<string>>() { { ADO_TEAM_PROJECT, new List<string>() { FOO_REPO } } } } };
+//        private readonly IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> ADO_PIPELINES =
+//    new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
+//    { { ADO_ORG, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
+//                         { { ADO_TEAM_PROJECT, new Dictionary<string, IEnumerable<string>>()
+//                                               { { FOO_REPO, new List<string>()
+//                                                             { FOO_PIPELINE } } } } } } };
 
-        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
-        private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
-        private readonly Mock<AdoInspectorService> _mockAdoInspector = TestHelpers.CreateMock<AdoInspectorService>();
-        private readonly Mock<OrgsCsvGeneratorService> _mockOrgsCsvGenerator = TestHelpers.CreateMock<OrgsCsvGeneratorService>();
-        private readonly Mock<TeamProjectsCsvGeneratorService> _mockTeamProjectsCsvGenerator = TestHelpers.CreateMock<TeamProjectsCsvGeneratorService>();
-        private readonly Mock<ReposCsvGeneratorService> _mockReposCsvGenerator = TestHelpers.CreateMock<ReposCsvGeneratorService>();
-        private readonly Mock<PipelinesCsvGeneratorService> _mockPipelinesCsvGenerator = TestHelpers.CreateMock<PipelinesCsvGeneratorService>();
+//        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
+//        private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
+//        private readonly Mock<AdoInspectorService> _mockAdoInspector = TestHelpers.CreateMock<AdoInspectorService>();
+//        private readonly Mock<OrgsCsvGeneratorService> _mockOrgsCsvGenerator = TestHelpers.CreateMock<OrgsCsvGeneratorService>();
+//        private readonly Mock<TeamProjectsCsvGeneratorService> _mockTeamProjectsCsvGenerator = TestHelpers.CreateMock<TeamProjectsCsvGeneratorService>();
+//        private readonly Mock<ReposCsvGeneratorService> _mockReposCsvGenerator = TestHelpers.CreateMock<ReposCsvGeneratorService>();
+//        private readonly Mock<PipelinesCsvGeneratorService> _mockPipelinesCsvGenerator = TestHelpers.CreateMock<PipelinesCsvGeneratorService>();
 
-        private string _orgsCsvOutput = "";
-        private string _teamProjectsCsvOutput = "";
-        private string _reposCsvOutput = "";
-        private string _pipelinesCsvOutput = "";
+//        private string _orgsCsvOutput = "";
+//        private string _teamProjectsCsvOutput = "";
+//        private string _reposCsvOutput = "";
+//        private string _pipelinesCsvOutput = "";
 
-        private readonly InventoryReportCommand _command;
+//        private readonly InventoryReportCommand _command;
 
-        public InventoryReportCommandTests()
-        {
-            _command = new InventoryReportCommand(TestHelpers.CreateMock<OctoLogger>().Object, _mockAdoApiFactory.Object, _mockAdoInspector.Object, _mockOrgsCsvGenerator.Object, _mockTeamProjectsCsvGenerator.Object, _mockReposCsvGenerator.Object, _mockPipelinesCsvGenerator.Object)
-            {
-                WriteToFile = (path, contents) =>
-                {
-                    if (path == "orgs.csv")
-                    {
-                        _orgsCsvOutput = contents;
-                    }
+//        public InventoryReportCommandTests()
+//        {
+//            _command = new InventoryReportCommand(TestHelpers.CreateMock<OctoLogger>().Object, _mockAdoApiFactory.Object, _mockAdoInspector.Object, _mockOrgsCsvGenerator.Object, _mockTeamProjectsCsvGenerator.Object, _mockReposCsvGenerator.Object, _mockPipelinesCsvGenerator.Object)
+//            {
+//                WriteToFile = (path, contents) =>
+//                {
+//                    if (path == "orgs.csv")
+//                    {
+//                        _orgsCsvOutput = contents;
+//                    }
 
-                    if (path == "team-projects.csv")
-                    {
-                        _teamProjectsCsvOutput = contents;
-                    }
+//                    if (path == "team-projects.csv")
+//                    {
+//                        _teamProjectsCsvOutput = contents;
+//                    }
 
-                    if (path == "repos.csv")
-                    {
-                        _reposCsvOutput = contents;
-                    }
+//                    if (path == "repos.csv")
+//                    {
+//                        _reposCsvOutput = contents;
+//                    }
 
-                    if (path == "pipelines.csv")
-                    {
-                        _pipelinesCsvOutput = contents;
-                    }
+//                    if (path == "pipelines.csv")
+//                    {
+//                        _pipelinesCsvOutput = contents;
+//                    }
 
-                    return Task.CompletedTask;
-                }
-            };
-        }
+//                    return Task.CompletedTask;
+//                }
+//            };
+//        }
 
-        [Fact]
-        public void Should_Have_Options()
-        {
-            Assert.NotNull(_command);
-            Assert.Equal("inventory-report", _command.Name);
-            Assert.Equal(3, _command.Options.Count);
+//        [Fact]
+//        public void Should_Have_Options()
+//        {
+//            Assert.NotNull(_command);
+//            Assert.Equal("inventory-report", _command.Name);
+//            Assert.Equal(3, _command.Options.Count);
 
-            TestHelpers.VerifyCommandOption(_command.Options, "ado-org", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "ado-pat", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
-        }
+//            TestHelpers.VerifyCommandOption(_command.Options, "ado-org", false);
+//            TestHelpers.VerifyCommandOption(_command.Options, "ado-pat", false);
+//            TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
+//        }
 
-        [Fact]
-        public async Task Happy_Path()
-        {
-            var expectedOrgsCsv = "csv stuff";
-            var expectedTeamProjectsCsv = "more csv stuff";
-            var expectedReposCsv = "repo csv stuff";
-            var expectedPipelinesCsv = "pipelines csv stuff";
+//        [Fact]
+//        public async Task Happy_Path()
+//        {
+//            var expectedOrgsCsv = "csv stuff";
+//            var expectedTeamProjectsCsv = "more csv stuff";
+//            var expectedReposCsv = "repo csv stuff";
+//            var expectedPipelinesCsv = "pipelines csv stuff";
 
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, null)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, null)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
 
-            _mockOrgsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedOrgsCsv);
-            _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(ADO_PIPELINES)).Returns(expectedTeamProjectsCsv);
-            _mockReposCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedReposCsv);
-            _mockPipelinesCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedPipelinesCsv);
+//            _mockOrgsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedOrgsCsv);
+//            _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(ADO_PIPELINES)).Returns(expectedTeamProjectsCsv);
+//            _mockReposCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedReposCsv);
+//            _mockPipelinesCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedPipelinesCsv);
 
-            await _command.Invoke(null, null);
+//            await _command.Invoke(null, null);
 
-            _orgsCsvOutput.Should().Be(expectedOrgsCsv);
-            _teamProjectsCsvOutput.Should().Be(expectedTeamProjectsCsv);
-            _reposCsvOutput.Should().Be(expectedReposCsv);
-            _pipelinesCsvOutput.Should().Be(expectedPipelinesCsv);
-        }
+//            _orgsCsvOutput.Should().Be(expectedOrgsCsv);
+//            _teamProjectsCsvOutput.Should().Be(expectedTeamProjectsCsv);
+//            _reposCsvOutput.Should().Be(expectedReposCsv);
+//            _pipelinesCsvOutput.Should().Be(expectedPipelinesCsv);
+//        }
 
-        [Fact]
-        public async Task Scoped_To_Single_Org()
-        {
-            var expectedOrgsCsv = "csv stuff";
-            var expectedTeamProjectsCsv = "more csv stuff";
-            var expectedReposCsv = "repo csv stuff";
-            var expectedPipelinesCsv = "pipelines csv stuff";
+//        [Fact]
+//        public async Task Scoped_To_Single_Org()
+//        {
+//            var expectedOrgsCsv = "csv stuff";
+//            var expectedTeamProjectsCsv = "more csv stuff";
+//            var expectedReposCsv = "repo csv stuff";
+//            var expectedPipelinesCsv = "pipelines csv stuff";
 
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+//            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
-            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
+//            _mockAdoInspector.Setup(m => m.GetOrgs(_mockAdoApi.Object, ADO_ORG)).ReturnsAsync(ADO_ORGS);
+//            _mockAdoInspector.Setup(m => m.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS, null)).ReturnsAsync(ADO_TEAM_PROJECTS);
+//            _mockAdoInspector.Setup(m => m.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, null)).ReturnsAsync(ADO_REPOS);
+//            _mockAdoInspector.Setup(m => m.GetPipelines(_mockAdoApi.Object, ADO_REPOS)).ReturnsAsync(ADO_PIPELINES);
 
-            _mockOrgsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedOrgsCsv);
-            _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(ADO_PIPELINES)).Returns(expectedTeamProjectsCsv);
-            _mockReposCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedReposCsv);
-            _mockPipelinesCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedPipelinesCsv);
+//            _mockOrgsCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedOrgsCsv);
+//            _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(ADO_PIPELINES)).Returns(expectedTeamProjectsCsv);
+//            _mockReposCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedReposCsv);
+//            _mockPipelinesCsvGenerator.Setup(m => m.Generate(_mockAdoApi.Object, ADO_PIPELINES)).ReturnsAsync(expectedPipelinesCsv);
 
-            await _command.Invoke(ADO_ORG, null);
+//            await _command.Invoke(ADO_ORG, null);
 
-            _orgsCsvOutput.Should().Be(expectedOrgsCsv);
-            _teamProjectsCsvOutput.Should().Be(expectedTeamProjectsCsv);
-            _reposCsvOutput.Should().Be(expectedReposCsv);
-            _pipelinesCsvOutput.Should().Be(expectedPipelinesCsv);
-        }
+//            _orgsCsvOutput.Should().Be(expectedOrgsCsv);
+//            _teamProjectsCsvOutput.Should().Be(expectedTeamProjectsCsv);
+//            _reposCsvOutput.Should().Be(expectedReposCsv);
+//            _pipelinesCsvOutput.Should().Be(expectedPipelinesCsv);
+//        }
 
-        [Fact]
-        public async Task It_Uses_The_Ado_Pat_When_Provided()
-        {
-            const string adoPat = "ado-pat";
+//        [Fact]
+//        public async Task It_Uses_The_Ado_Pat_When_Provided()
+//        {
+//            const string adoPat = "ado-pat";
 
-            await _command.Invoke("some org", adoPat);
+//            await _command.Invoke("some org", adoPat);
 
-            _mockAdoApiFactory.Verify(m => m.Create(adoPat));
-        }
-    }
-}
+//            _mockAdoApiFactory.Verify(m => m.Create(adoPat));
+//        }
+//    }
+//}

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/AdoInspectorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/AdoInspectorServiceTests.cs
@@ -18,9 +18,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private const string ADO_ORG = "ADO_ORG";
         private const string ADO_TEAM_PROJECT = "ADO_TEAM_PROJECT";
         private const string FOO_REPO = "FOO_REPO";
-
-        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
-        private readonly IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
         private readonly IEnumerable<string> ADO_REPOS = new List<string>() { FOO_REPO };
 
         public AdoInspectorServiceTests() => _service = new(_logger);

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/AdoInspectorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/AdoInspectorServiceTests.cs
@@ -1,288 +1,288 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using FluentAssertions;
-using Moq;
-using OctoshiftCLI.AdoToGithub;
-using Xunit;
+//using System;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Threading.Tasks;
+//using FluentAssertions;
+//using Moq;
+//using OctoshiftCLI.AdoToGithub;
+//using Xunit;
 
-namespace OctoshiftCLI.Tests.AdoToGithub.Commands
-{
-    public class AdoInspectorServiceTests
-    {
-        private readonly OctoLogger _logger = TestHelpers.CreateMock<OctoLogger>().Object;
-        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
-        private readonly AdoInspectorService _service;
+//namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+//{
+//    public class AdoInspectorServiceTests
+//    {
+//        private readonly OctoLogger _logger = TestHelpers.CreateMock<OctoLogger>().Object;
+//        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
+//        private readonly AdoInspectorService _service;
 
-        private const string ADO_ORG = "ADO_ORG";
-        private const string ADO_TEAM_PROJECT = "ADO_TEAM_PROJECT";
-        private const string FOO_REPO = "FOO_REPO";
+//        private const string ADO_ORG = "ADO_ORG";
+//        private const string ADO_TEAM_PROJECT = "ADO_TEAM_PROJECT";
+//        private const string FOO_REPO = "FOO_REPO";
 
-        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
-        private readonly IDictionary<string, IEnumerable<string>> ADO_TEAM_PROJECTS = new Dictionary<string, IEnumerable<string>>() { { ADO_ORG, new List<string>() { ADO_TEAM_PROJECT } } };
-        private readonly IDictionary<string, IDictionary<string, IEnumerable<string>>> ADO_REPOS = new Dictionary<string, IDictionary<string, IEnumerable<string>>>() { { ADO_ORG, new Dictionary<string, IEnumerable<string>>() { { ADO_TEAM_PROJECT, new List<string>() { FOO_REPO } } } } };
+//        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
+//        private readonly IDictionary<string, IEnumerable<string>> ADO_TEAM_PROJECTS = new Dictionary<string, IEnumerable<string>>() { { ADO_ORG, new List<string>() { ADO_TEAM_PROJECT } } };
+//        private readonly IDictionary<string, IDictionary<string, IEnumerable<string>>> ADO_REPOS = new Dictionary<string, IDictionary<string, IEnumerable<string>>>() { { ADO_ORG, new Dictionary<string, IEnumerable<string>>() { { ADO_TEAM_PROJECT, new List<string>() { FOO_REPO } } } } };
 
-        public AdoInspectorServiceTests() => _service = new(_logger);
+//        public AdoInspectorServiceTests() => _service = new(_logger);
 
-        [Fact]
-        public async Task GetOrgs_Should_Return_All_Orgs()
-        {
-            // Arrange
-            var org1 = "my-org";
-            var org2 = "other-org";
-            var orgs = new List<string>() { org1, org2 };
-            var userId = Guid.NewGuid().ToString();
+//        [Fact]
+//        public async Task GetOrgs_Should_Return_All_Orgs()
+//        {
+//            // Arrange
+//            var org1 = "my-org";
+//            var org2 = "other-org";
+//            var orgs = new List<string>() { org1, org2 };
+//            var userId = Guid.NewGuid().ToString();
 
-            _mockAdoApi.Setup(m => m.GetUserId()).ReturnsAsync(userId);
-            _mockAdoApi.Setup(m => m.GetOrganizations(userId)).ReturnsAsync(orgs);
+//            _mockAdoApi.Setup(m => m.GetUserId()).ReturnsAsync(userId);
+//            _mockAdoApi.Setup(m => m.GetOrganizations(userId)).ReturnsAsync(orgs);
 
-            // Act
-            var result = await _service.GetOrgs(_mockAdoApi.Object);
+//            // Act
+//            var result = await _service.GetOrgs(_mockAdoApi.Object);
 
-            // Assert
-            result.Should().BeEquivalentTo(orgs);
-        }
+//            // Assert
+//            result.Should().BeEquivalentTo(orgs);
+//        }
 
-        [Fact]
-        public async Task GetOrgs_Should_Return_Single_Org_Collection_When_Org_Passed()
-        {
-            // Arrange
-            var org1 = "my-org";
+//        [Fact]
+//        public async Task GetOrgs_Should_Return_Single_Org_Collection_When_Org_Passed()
+//        {
+//            // Arrange
+//            var org1 = "my-org";
 
-            // Act
-            var result = await _service.GetOrgs(null, org1);
+//            // Act
+//            var result = await _service.GetOrgs(null, org1);
 
-            // Assert
-            result.Count().Should().Be(1);
-            result.First().Should().Be(org1);
+//            // Assert
+//            result.Count().Should().Be(1);
+//            result.First().Should().Be(org1);
 
-            _mockAdoApi.VerifyNoOtherCalls();
-        }
+//            _mockAdoApi.VerifyNoOtherCalls();
+//        }
 
-        [Fact]
-        public async Task GetOrgs_Should_Return_Empty_List_When_Null_AdoApi_Passed()
-        {
-            var result = await _service.GetOrgs(null);
-            result.Should().BeEmpty();
-        }
+//        [Fact]
+//        public async Task GetOrgs_Should_Return_Empty_List_When_Null_AdoApi_Passed()
+//        {
+//            var result = await _service.GetOrgs(null);
+//            result.Should().BeEmpty();
+//        }
 
-        [Fact]
-        public async Task GetTeamProjects_Should_Return_All_TeamProjects_With_One_Org()
-        {
-            // Arrange
-            var teamProject1 = "foo";
-            var teamProject2 = "bar";
-            var teamProjects = new List<string>() { teamProject1, teamProject2 };
+//        [Fact]
+//        public async Task GetTeamProjects_Should_Return_All_TeamProjects_With_One_Org()
+//        {
+//            // Arrange
+//            var teamProject1 = "foo";
+//            var teamProject2 = "bar";
+//            var teamProjects = new List<string>() { teamProject1, teamProject2 };
 
-            _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(teamProjects);
+//            _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(teamProjects);
 
-            // Act
-            var result = await _service.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS);
+//            // Act
+//            var result = await _service.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS);
 
-            // Assert
-            result.Should().HaveCount(1);
-            result.First().Key.Should().Be(ADO_ORG);
-            result[ADO_ORG].Should().BeEquivalentTo(teamProjects);
-        }
+//            // Assert
+//            result.Should().HaveCount(1);
+//            result.First().Key.Should().Be(ADO_ORG);
+//            result[ADO_ORG].Should().BeEquivalentTo(teamProjects);
+//        }
 
-        [Fact]
-        public async Task GetTeamProjects_Should_Return_All_TeamProjects_With_Multiple_Orgs()
-        {
-            // Arrange
-            var org1 = "my-org";
-            var org2 = "some-org";
-            var orgs = new List<string>() { org1, org2 };
-            var teamProject1 = "foo";
-            var teamProject2 = "bar";
-            var teamProjects1 = new List<string>() { teamProject1, teamProject2 };
-            var teamProject3 = "sales";
-            var teamProject4 = "shipping";
-            var teamProjects2 = new List<string>() { teamProject3, teamProject4 };
+//        [Fact]
+//        public async Task GetTeamProjects_Should_Return_All_TeamProjects_With_Multiple_Orgs()
+//        {
+//            // Arrange
+//            var org1 = "my-org";
+//            var org2 = "some-org";
+//            var orgs = new List<string>() { org1, org2 };
+//            var teamProject1 = "foo";
+//            var teamProject2 = "bar";
+//            var teamProjects1 = new List<string>() { teamProject1, teamProject2 };
+//            var teamProject3 = "sales";
+//            var teamProject4 = "shipping";
+//            var teamProjects2 = new List<string>() { teamProject3, teamProject4 };
 
-            _mockAdoApi.Setup(m => m.GetTeamProjects(org1)).ReturnsAsync(teamProjects1);
-            _mockAdoApi.Setup(m => m.GetTeamProjects(org2)).ReturnsAsync(teamProjects2);
+//            _mockAdoApi.Setup(m => m.GetTeamProjects(org1)).ReturnsAsync(teamProjects1);
+//            _mockAdoApi.Setup(m => m.GetTeamProjects(org2)).ReturnsAsync(teamProjects2);
 
-            // Act
-            var result = await _service.GetTeamProjects(_mockAdoApi.Object, orgs);
+//            // Act
+//            var result = await _service.GetTeamProjects(_mockAdoApi.Object, orgs);
 
-            // Assert
-            result.Should().HaveCount(2);
-            result[org1].Should().BeEquivalentTo(teamProjects1);
-            result[org2].Should().BeEquivalentTo(teamProjects2);
-        }
+//            // Assert
+//            result.Should().HaveCount(2);
+//            result[org1].Should().BeEquivalentTo(teamProjects1);
+//            result[org2].Should().BeEquivalentTo(teamProjects2);
+//        }
 
-        [Fact]
-        public async Task GetTeamProjects_Should_Return_Single_TeamProject_When_TeamProject_Passed()
-        {
-            var result = await _service.GetTeamProjects(null, ADO_ORGS, ADO_TEAM_PROJECT);
-            result[ADO_ORG].Single().Should().Be(ADO_TEAM_PROJECT);
-        }
+//        [Fact]
+//        public async Task GetTeamProjects_Should_Return_Single_TeamProject_When_TeamProject_Passed()
+//        {
+//            var result = await _service.GetTeamProjects(null, ADO_ORGS, ADO_TEAM_PROJECT);
+//            result[ADO_ORG].Single().Should().Be(ADO_TEAM_PROJECT);
+//        }
 
-        [Fact]
-        public async Task GetTeamProjects_Should_Throw_Exception_When_Multiple_Orgs_But_One_TeamProject_Passed()
-        {
-            // Arrange
-            var org1 = "my-org";
-            var org2 = "other-org";
-            var orgs = new List<string>() { org1, org2 };
+//        [Fact]
+//        public async Task GetTeamProjects_Should_Throw_Exception_When_Multiple_Orgs_But_One_TeamProject_Passed()
+//        {
+//            // Arrange
+//            var org1 = "my-org";
+//            var org2 = "other-org";
+//            var orgs = new List<string>() { org1, org2 };
 
-            // Act
-            await FluentActions
-                .Invoking(async () => await _service.GetTeamProjects(null, orgs, ADO_TEAM_PROJECT))
-                .Should()
-                .ThrowExactlyAsync<ArgumentException>();
-        }
+//            // Act
+//            await FluentActions
+//                .Invoking(async () => await _service.GetTeamProjects(null, orgs, ADO_TEAM_PROJECT))
+//                .Should()
+//                .ThrowExactlyAsync<ArgumentException>();
+//        }
 
-        [Fact]
-        public async Task GetTeamProjects_Should_Throw_Exception_When_Empty_Orgs_But_One_TeamProject_Passed()
-        {
-            var orgs = new List<string>();
+//        [Fact]
+//        public async Task GetTeamProjects_Should_Throw_Exception_When_Empty_Orgs_But_One_TeamProject_Passed()
+//        {
+//            var orgs = new List<string>();
 
-            await FluentActions
-                .Invoking(async () => await _service.GetTeamProjects(null, orgs, ADO_TEAM_PROJECT))
-                .Should()
-                .ThrowExactlyAsync<ArgumentException>();
-        }
+//            await FluentActions
+//                .Invoking(async () => await _service.GetTeamProjects(null, orgs, ADO_TEAM_PROJECT))
+//                .Should()
+//                .ThrowExactlyAsync<ArgumentException>();
+//        }
 
-        [Fact]
-        public async Task GetTeamProjects_Should_Return_Empty_When_Null_AdoApi_Passed()
-        {
-            var result = await _service.GetTeamProjects(null, ADO_ORGS, null);
+//        [Fact]
+//        public async Task GetTeamProjects_Should_Return_Empty_When_Null_AdoApi_Passed()
+//        {
+//            var result = await _service.GetTeamProjects(null, ADO_ORGS, null);
 
-            result.Should().BeEmpty();
-        }
+//            result.Should().BeEmpty();
+//        }
 
-        [Fact]
-        public async Task GetTeamProjects_Should_Return_Empty_When_Null_Orgs_Passed()
-        {
-            var result = await _service.GetTeamProjects(_mockAdoApi.Object, null);
+//        [Fact]
+//        public async Task GetTeamProjects_Should_Return_Empty_When_Null_Orgs_Passed()
+//        {
+//            var result = await _service.GetTeamProjects(_mockAdoApi.Object, null);
 
-            result.Should().BeEmpty();
-        }
+//            result.Should().BeEmpty();
+//        }
 
-        [Fact]
-        public async Task GetRepos_Should_Return_All_Repos()
-        {
-            // Arrange
-            var repo1 = "foo";
-            var repo2 = "bar";
-            var repos = new List<string>() { repo1, repo2 };
+//        [Fact]
+//        public async Task GetRepos_Should_Return_All_Repos()
+//        {
+//            // Arrange
+//            var repo1 = "foo";
+//            var repo2 = "bar";
+//            var repos = new List<string>() { repo1, repo2 };
 
-            _mockAdoApi.Setup(m => m.GetEnabledRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(repos);
+//            _mockAdoApi.Setup(m => m.GetEnabledRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(repos);
 
-            // Act
-            var result = await _service.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS);
+//            // Act
+//            var result = await _service.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS);
 
-            // Assert
-            result[ADO_ORG][ADO_TEAM_PROJECT].Should().BeEquivalentTo(repos);
-        }
+//            // Assert
+//            result[ADO_ORG][ADO_TEAM_PROJECT].Should().BeEquivalentTo(repos);
+//        }
 
-        [Fact]
-        public async Task GetRepos_Should_Return_One_Repo_When_Repo_Passed()
-        {
-            var result = await _service.GetRepos(null, ADO_TEAM_PROJECTS, FOO_REPO);
-            result[ADO_ORG][ADO_TEAM_PROJECT].Single().Should().Be(FOO_REPO);
-        }
+//        [Fact]
+//        public async Task GetRepos_Should_Return_One_Repo_When_Repo_Passed()
+//        {
+//            var result = await _service.GetRepos(null, ADO_TEAM_PROJECTS, FOO_REPO);
+//            result[ADO_ORG][ADO_TEAM_PROJECT].Single().Should().Be(FOO_REPO);
+//        }
 
-        [Fact]
-        public async Task GetRepos_Should_Return_Empty_When_AdoApi_Is_Null()
-        {
-            var result = await _service.GetRepos(null, ADO_TEAM_PROJECTS);
-            result.Should().BeEmpty();
-        }
+//        [Fact]
+//        public async Task GetRepos_Should_Return_Empty_When_AdoApi_Is_Null()
+//        {
+//            var result = await _service.GetRepos(null, ADO_TEAM_PROJECTS);
+//            result.Should().BeEmpty();
+//        }
 
-        [Fact]
-        public async Task GetRepos_Should_Return_Empty_When_TeamProjects_Is_Null()
-        {
-            var result = await _service.GetRepos(_mockAdoApi.Object, null);
-            result.Should().BeEmpty();
-        }
+//        [Fact]
+//        public async Task GetRepos_Should_Return_Empty_When_TeamProjects_Is_Null()
+//        {
+//            var result = await _service.GetRepos(_mockAdoApi.Object, null);
+//            result.Should().BeEmpty();
+//        }
 
-        [Fact]
-        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Is_Null()
-        {
-            await FluentActions
-                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, null, FOO_REPO))
-                .Should()
-                .ThrowExactlyAsync<ArgumentException>();
-        }
+//        [Fact]
+//        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Is_Null()
+//        {
+//            await FluentActions
+//                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, null, FOO_REPO))
+//                .Should()
+//                .ThrowExactlyAsync<ArgumentException>();
+//        }
 
-        [Fact]
-        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Is_Empty()
-        {
-            var emptyTeamProjects = new Dictionary<string, IEnumerable<string>>();
+//        [Fact]
+//        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Is_Empty()
+//        {
+//            var emptyTeamProjects = new Dictionary<string, IEnumerable<string>>();
 
-            await FluentActions
-                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, emptyTeamProjects, FOO_REPO))
-                .Should()
-                .ThrowExactlyAsync<ArgumentException>();
-        }
+//            await FluentActions
+//                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, emptyTeamProjects, FOO_REPO))
+//                .Should()
+//                .ThrowExactlyAsync<ArgumentException>();
+//        }
 
-        [Fact]
-        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Has_More_Than_One_Org()
-        {
-            ADO_TEAM_PROJECTS.Add("blah", new List<string>());
+//        [Fact]
+//        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Has_More_Than_One_Org()
+//        {
+//            ADO_TEAM_PROJECTS.Add("blah", new List<string>());
 
-            await FluentActions
-                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, FOO_REPO))
-                .Should()
-                .ThrowExactlyAsync<ArgumentException>();
-        }
+//            await FluentActions
+//                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, FOO_REPO))
+//                .Should()
+//                .ThrowExactlyAsync<ArgumentException>();
+//        }
 
-        [Fact]
-        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Has_More_Than_One_TeamProject()
-        {
-            ADO_TEAM_PROJECTS[ADO_ORG] = new List<string>() { "foo", "bar" };
+//        [Fact]
+//        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Has_More_Than_One_TeamProject()
+//        {
+//            ADO_TEAM_PROJECTS[ADO_ORG] = new List<string>() { "foo", "bar" };
 
-            await FluentActions
-                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, FOO_REPO))
-                .Should()
-                .ThrowExactlyAsync<ArgumentException>();
-        }
+//            await FluentActions
+//                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, FOO_REPO))
+//                .Should()
+//                .ThrowExactlyAsync<ArgumentException>();
+//        }
 
-        [Fact]
-        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Has_An_Org_But_No_TeamProjects()
-        {
-            ADO_TEAM_PROJECTS[ADO_ORG] = new List<string>();
+//        [Fact]
+//        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Has_An_Org_But_No_TeamProjects()
+//        {
+//            ADO_TEAM_PROJECTS[ADO_ORG] = new List<string>();
 
-            await FluentActions
-                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, FOO_REPO))
-                .Should()
-                .ThrowExactlyAsync<ArgumentException>();
-        }
+//            await FluentActions
+//                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, FOO_REPO))
+//                .Should()
+//                .ThrowExactlyAsync<ArgumentException>();
+//        }
 
-        [Fact]
-        public async Task GetPipelines_Should_Return_All_Pipelines()
-        {
-            // Arrange
-            var repoId = Guid.NewGuid().ToString();
-            var pipeline1 = "foo";
-            var pipeline2 = "bar";
-            var pipelines = new List<string>() { pipeline1, pipeline2 };
+//        [Fact]
+//        public async Task GetPipelines_Should_Return_All_Pipelines()
+//        {
+//            // Arrange
+//            var repoId = Guid.NewGuid().ToString();
+//            var pipeline1 = "foo";
+//            var pipeline2 = "bar";
+//            var pipelines = new List<string>() { pipeline1, pipeline2 };
 
-            _mockAdoApi.Setup(m => m.GetRepoId(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(repoId);
-            _mockAdoApi.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, repoId)).ReturnsAsync(pipelines);
+//            _mockAdoApi.Setup(m => m.GetRepoId(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(repoId);
+//            _mockAdoApi.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, repoId)).ReturnsAsync(pipelines);
 
-            // Act
-            var result = await _service.GetPipelines(_mockAdoApi.Object, ADO_REPOS);
+//            // Act
+//            var result = await _service.GetPipelines(_mockAdoApi.Object, ADO_REPOS);
 
-            // Assert
-            result[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO].Should().BeEquivalentTo(pipelines);
-        }
+//            // Assert
+//            result[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO].Should().BeEquivalentTo(pipelines);
+//        }
 
-        [Fact]
-        public async Task GetPipelines_Should_Return_Empty_When_AdoApi_Is_Null()
-        {
-            var result = await _service.GetPipelines(null, ADO_REPOS);
-            result.Should().BeEmpty();
-        }
+//        [Fact]
+//        public async Task GetPipelines_Should_Return_Empty_When_AdoApi_Is_Null()
+//        {
+//            var result = await _service.GetPipelines(null, ADO_REPOS);
+//            result.Should().BeEmpty();
+//        }
 
-        [Fact]
-        public async Task GetPipelines_Should_Return_Empty_When_Repos_Is_Null()
-        {
-            var result = await _service.GetPipelines(_mockAdoApi.Object, null);
-            result.Should().BeEmpty();
-        }
-    }
-}
+//        [Fact]
+//        public async Task GetPipelines_Should_Return_Empty_When_Repos_Is_Null()
+//        {
+//            var result = await _service.GetPipelines(_mockAdoApi.Object, null);
+//            result.Should().BeEmpty();
+//        }
+//    }
+//}

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/AdoInspectorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/AdoInspectorServiceTests.cs
@@ -1,288 +1,171 @@
-//using System;
-//using System.Collections.Generic;
-//using System.Linq;
-//using System.Threading.Tasks;
-//using FluentAssertions;
-//using Moq;
-//using OctoshiftCLI.AdoToGithub;
-//using Xunit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using OctoshiftCLI.AdoToGithub;
+using Xunit;
 
-//namespace OctoshiftCLI.Tests.AdoToGithub.Commands
-//{
-//    public class AdoInspectorServiceTests
-//    {
-//        private readonly OctoLogger _logger = TestHelpers.CreateMock<OctoLogger>().Object;
-//        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
-//        private readonly AdoInspectorService _service;
+namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+{
+    public class AdoInspectorServiceTests
+    {
+        private readonly OctoLogger _logger = TestHelpers.CreateMock<OctoLogger>().Object;
+        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
+        private readonly AdoInspectorService _service;
 
-//        private const string ADO_ORG = "ADO_ORG";
-//        private const string ADO_TEAM_PROJECT = "ADO_TEAM_PROJECT";
-//        private const string FOO_REPO = "FOO_REPO";
+        private const string ADO_ORG = "ADO_ORG";
+        private const string ADO_TEAM_PROJECT = "ADO_TEAM_PROJECT";
+        private const string FOO_REPO = "FOO_REPO";
 
-//        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
-//        private readonly IDictionary<string, IEnumerable<string>> ADO_TEAM_PROJECTS = new Dictionary<string, IEnumerable<string>>() { { ADO_ORG, new List<string>() { ADO_TEAM_PROJECT } } };
-//        private readonly IDictionary<string, IDictionary<string, IEnumerable<string>>> ADO_REPOS = new Dictionary<string, IDictionary<string, IEnumerable<string>>>() { { ADO_ORG, new Dictionary<string, IEnumerable<string>>() { { ADO_TEAM_PROJECT, new List<string>() { FOO_REPO } } } } };
+        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
+        private readonly IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
+        private readonly IEnumerable<string> ADO_REPOS = new List<string>() { FOO_REPO };
 
-//        public AdoInspectorServiceTests() => _service = new(_logger);
+        public AdoInspectorServiceTests() => _service = new(_logger);
 
-//        [Fact]
-//        public async Task GetOrgs_Should_Return_All_Orgs()
-//        {
-//            // Arrange
-//            var org1 = "my-org";
-//            var org2 = "other-org";
-//            var orgs = new List<string>() { org1, org2 };
-//            var userId = Guid.NewGuid().ToString();
+        [Fact]
+        public async Task GetOrgs_Should_Return_All_Orgs()
+        {
+            // Arrange
+            var org1 = "my-org";
+            var org2 = "other-org";
+            var orgs = new List<string>() { org1, org2 };
+            var userId = Guid.NewGuid().ToString();
 
-//            _mockAdoApi.Setup(m => m.GetUserId()).ReturnsAsync(userId);
-//            _mockAdoApi.Setup(m => m.GetOrganizations(userId)).ReturnsAsync(orgs);
+            _mockAdoApi.Setup(m => m.GetUserId()).ReturnsAsync(userId);
+            _mockAdoApi.Setup(m => m.GetOrganizations(userId)).ReturnsAsync(orgs);
 
-//            // Act
-//            var result = await _service.GetOrgs(_mockAdoApi.Object);
+            _service.AdoApi = _mockAdoApi.Object;
 
-//            // Assert
-//            result.Should().BeEquivalentTo(orgs);
-//        }
+            // Act
+            var result = await _service.GetOrgs();
 
-//        [Fact]
-//        public async Task GetOrgs_Should_Return_Single_Org_Collection_When_Org_Passed()
-//        {
-//            // Arrange
-//            var org1 = "my-org";
+            // Assert
+            result.Should().BeEquivalentTo(orgs);
+        }
 
-//            // Act
-//            var result = await _service.GetOrgs(null, org1);
+        [Fact]
+        public async Task GetOrgs_Should_Return_Single_Org_Collection_When_Org_Passed()
+        {
+            // Arrange
+            _service.OrgFilter = ADO_ORG;
+            _service.AdoApi = _mockAdoApi.Object;
 
-//            // Assert
-//            result.Count().Should().Be(1);
-//            result.First().Should().Be(org1);
+            // Act
+            var result = await _service.GetOrgs();
 
-//            _mockAdoApi.VerifyNoOtherCalls();
-//        }
+            // Assert
+            result.Count().Should().Be(1);
+            result.First().Should().Be(ADO_ORG);
 
-//        [Fact]
-//        public async Task GetOrgs_Should_Return_Empty_List_When_Null_AdoApi_Passed()
-//        {
-//            var result = await _service.GetOrgs(null);
-//            result.Should().BeEmpty();
-//        }
+            _mockAdoApi.VerifyNoOtherCalls();
+        }
 
-//        [Fact]
-//        public async Task GetTeamProjects_Should_Return_All_TeamProjects_With_One_Org()
-//        {
-//            // Arrange
-//            var teamProject1 = "foo";
-//            var teamProject2 = "bar";
-//            var teamProjects = new List<string>() { teamProject1, teamProject2 };
+        [Fact]
+        public async Task GetOrgs_Should_Throw_Exception_When_AdoApi_Not_Set()
+        {
+            await FluentActions
+                .Invoking(async () => await _service.GetOrgs())
+                .Should()
+                .ThrowAsync<Exception>();
+        }
 
-//            _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(teamProjects);
+        [Fact]
+        public async Task GetTeamProjects_Should_Return_All_TeamProjects()
+        {
+            // Arrange
+            var teamProject1 = "foo";
+            var teamProject2 = "bar";
+            var teamProjects = new List<string>() { teamProject1, teamProject2 };
 
-//            // Act
-//            var result = await _service.GetTeamProjects(_mockAdoApi.Object, ADO_ORGS);
+            _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(teamProjects);
+            _service.AdoApi = _mockAdoApi.Object;
 
-//            // Assert
-//            result.Should().HaveCount(1);
-//            result.First().Key.Should().Be(ADO_ORG);
-//            result[ADO_ORG].Should().BeEquivalentTo(teamProjects);
-//        }
+            // Act
+            var result = await _service.GetTeamProjects(ADO_ORG);
 
-//        [Fact]
-//        public async Task GetTeamProjects_Should_Return_All_TeamProjects_With_Multiple_Orgs()
-//        {
-//            // Arrange
-//            var org1 = "my-org";
-//            var org2 = "some-org";
-//            var orgs = new List<string>() { org1, org2 };
-//            var teamProject1 = "foo";
-//            var teamProject2 = "bar";
-//            var teamProjects1 = new List<string>() { teamProject1, teamProject2 };
-//            var teamProject3 = "sales";
-//            var teamProject4 = "shipping";
-//            var teamProjects2 = new List<string>() { teamProject3, teamProject4 };
+            // Assert
+            result.Should().BeEquivalentTo(teamProjects);
+        }
 
-//            _mockAdoApi.Setup(m => m.GetTeamProjects(org1)).ReturnsAsync(teamProjects1);
-//            _mockAdoApi.Setup(m => m.GetTeamProjects(org2)).ReturnsAsync(teamProjects2);
+        [Fact]
+        public async Task GetTeamProjects_Should_Return_Single_TeamProject_When_TeamProjectFilter_Set()
+        {
+            _service.AdoApi = _mockAdoApi.Object;
+            _service.TeamProjectFilter = ADO_TEAM_PROJECT;
 
-//            // Act
-//            var result = await _service.GetTeamProjects(_mockAdoApi.Object, orgs);
+            var result = await _service.GetTeamProjects(ADO_ORG);
 
-//            // Assert
-//            result.Should().HaveCount(2);
-//            result[org1].Should().BeEquivalentTo(teamProjects1);
-//            result[org2].Should().BeEquivalentTo(teamProjects2);
-//        }
+            result.Count().Should().Be(1);
+            result.First().Should().Be(ADO_TEAM_PROJECT);
+        }
 
-//        [Fact]
-//        public async Task GetTeamProjects_Should_Return_Single_TeamProject_When_TeamProject_Passed()
-//        {
-//            var result = await _service.GetTeamProjects(null, ADO_ORGS, ADO_TEAM_PROJECT);
-//            result[ADO_ORG].Single().Should().Be(ADO_TEAM_PROJECT);
-//        }
+        [Fact]
+        public async Task GetTeamProjects_Should_Throw_Exception_When_AdoApi_Not_Set()
+        {
+            await FluentActions
+                .Invoking(async () => await _service.GetTeamProjects(ADO_ORG))
+                .Should()
+                .ThrowAsync<Exception>();
+        }
 
-//        [Fact]
-//        public async Task GetTeamProjects_Should_Throw_Exception_When_Multiple_Orgs_But_One_TeamProject_Passed()
-//        {
-//            // Arrange
-//            var org1 = "my-org";
-//            var org2 = "other-org";
-//            var orgs = new List<string>() { org1, org2 };
+        [Fact]
+        public async Task GetRepos_Should_Return_All_Repos()
+        {
+            // Arrange
+            var repo1 = "foo";
+            var repo2 = "bar";
+            var repos = new List<string>() { repo1, repo2 };
 
-//            // Act
-//            await FluentActions
-//                .Invoking(async () => await _service.GetTeamProjects(null, orgs, ADO_TEAM_PROJECT))
-//                .Should()
-//                .ThrowExactlyAsync<ArgumentException>();
-//        }
+            _mockAdoApi.Setup(m => m.GetEnabledRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(repos);
+            _service.AdoApi = _mockAdoApi.Object;
 
-//        [Fact]
-//        public async Task GetTeamProjects_Should_Throw_Exception_When_Empty_Orgs_But_One_TeamProject_Passed()
-//        {
-//            var orgs = new List<string>();
+            // Act
+            var result = await _service.GetRepos(ADO_ORG, ADO_TEAM_PROJECT);
 
-//            await FluentActions
-//                .Invoking(async () => await _service.GetTeamProjects(null, orgs, ADO_TEAM_PROJECT))
-//                .Should()
-//                .ThrowExactlyAsync<ArgumentException>();
-//        }
+            // Assert
+            result.Should().BeEquivalentTo(repos);
+        }
 
-//        [Fact]
-//        public async Task GetTeamProjects_Should_Return_Empty_When_Null_AdoApi_Passed()
-//        {
-//            var result = await _service.GetTeamProjects(null, ADO_ORGS, null);
+        [Fact]
+        public async Task GetRepos_Should_Throw_Exception_When_AdoApi_Not_Set()
+        {
+            await FluentActions
+                .Invoking(async () => await _service.GetRepos(ADO_ORG, ADO_TEAM_PROJECT))
+                .Should()
+                .ThrowAsync<Exception>();
+        }
 
-//            result.Should().BeEmpty();
-//        }
+        [Fact]
+        public async Task GetPipelines_Should_Return_All_Pipelines()
+        {
+            // Arrange
+            var repoId = Guid.NewGuid().ToString();
+            var pipeline1 = "foo";
+            var pipeline2 = "bar";
+            var pipelines = new List<string>() { pipeline1, pipeline2 };
 
-//        [Fact]
-//        public async Task GetTeamProjects_Should_Return_Empty_When_Null_Orgs_Passed()
-//        {
-//            var result = await _service.GetTeamProjects(_mockAdoApi.Object, null);
+            _mockAdoApi.Setup(m => m.GetRepoId(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(repoId);
+            _mockAdoApi.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, repoId)).ReturnsAsync(pipelines);
 
-//            result.Should().BeEmpty();
-//        }
+            _service.AdoApi = _mockAdoApi.Object;
 
-//        [Fact]
-//        public async Task GetRepos_Should_Return_All_Repos()
-//        {
-//            // Arrange
-//            var repo1 = "foo";
-//            var repo2 = "bar";
-//            var repos = new List<string>() { repo1, repo2 };
+            // Act
+            var result = await _service.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO);
 
-//            _mockAdoApi.Setup(m => m.GetEnabledRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(repos);
+            // Assert
+            result.Should().BeEquivalentTo(pipelines);
+        }
 
-//            // Act
-//            var result = await _service.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS);
-
-//            // Assert
-//            result[ADO_ORG][ADO_TEAM_PROJECT].Should().BeEquivalentTo(repos);
-//        }
-
-//        [Fact]
-//        public async Task GetRepos_Should_Return_One_Repo_When_Repo_Passed()
-//        {
-//            var result = await _service.GetRepos(null, ADO_TEAM_PROJECTS, FOO_REPO);
-//            result[ADO_ORG][ADO_TEAM_PROJECT].Single().Should().Be(FOO_REPO);
-//        }
-
-//        [Fact]
-//        public async Task GetRepos_Should_Return_Empty_When_AdoApi_Is_Null()
-//        {
-//            var result = await _service.GetRepos(null, ADO_TEAM_PROJECTS);
-//            result.Should().BeEmpty();
-//        }
-
-//        [Fact]
-//        public async Task GetRepos_Should_Return_Empty_When_TeamProjects_Is_Null()
-//        {
-//            var result = await _service.GetRepos(_mockAdoApi.Object, null);
-//            result.Should().BeEmpty();
-//        }
-
-//        [Fact]
-//        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Is_Null()
-//        {
-//            await FluentActions
-//                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, null, FOO_REPO))
-//                .Should()
-//                .ThrowExactlyAsync<ArgumentException>();
-//        }
-
-//        [Fact]
-//        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Is_Empty()
-//        {
-//            var emptyTeamProjects = new Dictionary<string, IEnumerable<string>>();
-
-//            await FluentActions
-//                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, emptyTeamProjects, FOO_REPO))
-//                .Should()
-//                .ThrowExactlyAsync<ArgumentException>();
-//        }
-
-//        [Fact]
-//        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Has_More_Than_One_Org()
-//        {
-//            ADO_TEAM_PROJECTS.Add("blah", new List<string>());
-
-//            await FluentActions
-//                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, FOO_REPO))
-//                .Should()
-//                .ThrowExactlyAsync<ArgumentException>();
-//        }
-
-//        [Fact]
-//        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Has_More_Than_One_TeamProject()
-//        {
-//            ADO_TEAM_PROJECTS[ADO_ORG] = new List<string>() { "foo", "bar" };
-
-//            await FluentActions
-//                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, FOO_REPO))
-//                .Should()
-//                .ThrowExactlyAsync<ArgumentException>();
-//        }
-
-//        [Fact]
-//        public async Task GetRepos_Should_Throw_Exception_When_TeamProject_Provided_And_TeamProjects_Has_An_Org_But_No_TeamProjects()
-//        {
-//            ADO_TEAM_PROJECTS[ADO_ORG] = new List<string>();
-
-//            await FluentActions
-//                .Invoking(async () => await _service.GetRepos(_mockAdoApi.Object, ADO_TEAM_PROJECTS, FOO_REPO))
-//                .Should()
-//                .ThrowExactlyAsync<ArgumentException>();
-//        }
-
-//        [Fact]
-//        public async Task GetPipelines_Should_Return_All_Pipelines()
-//        {
-//            // Arrange
-//            var repoId = Guid.NewGuid().ToString();
-//            var pipeline1 = "foo";
-//            var pipeline2 = "bar";
-//            var pipelines = new List<string>() { pipeline1, pipeline2 };
-
-//            _mockAdoApi.Setup(m => m.GetRepoId(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(repoId);
-//            _mockAdoApi.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, repoId)).ReturnsAsync(pipelines);
-
-//            // Act
-//            var result = await _service.GetPipelines(_mockAdoApi.Object, ADO_REPOS);
-
-//            // Assert
-//            result[ADO_ORG][ADO_TEAM_PROJECT][FOO_REPO].Should().BeEquivalentTo(pipelines);
-//        }
-
-//        [Fact]
-//        public async Task GetPipelines_Should_Return_Empty_When_AdoApi_Is_Null()
-//        {
-//            var result = await _service.GetPipelines(null, ADO_REPOS);
-//            result.Should().BeEmpty();
-//        }
-
-//        [Fact]
-//        public async Task GetPipelines_Should_Return_Empty_When_Repos_Is_Null()
-//        {
-//            var result = await _service.GetPipelines(_mockAdoApi.Object, null);
-//            result.Should().BeEmpty();
-//        }
-//    }
-//}
+        [Fact]
+        public async Task GetPipelines_Should_Throw_Exception_When_AdoApi_Not_Set()
+        {
+            await FluentActions
+                .Invoking(async () => await _service.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO))
+                .Should()
+                .ThrowAsync<Exception>();
+        }
+    }
+}

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/AdoInspectorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/AdoInspectorServiceTests.cs
@@ -18,7 +18,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private const string ADO_ORG = "ADO_ORG";
         private const string ADO_TEAM_PROJECT = "ADO_TEAM_PROJECT";
         private const string FOO_REPO = "FOO_REPO";
-        private readonly IEnumerable<string> ADO_REPOS = new List<string>() { FOO_REPO };
 
         public AdoInspectorServiceTests() => _service = new(_logger);
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/AdoInspectorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/AdoInspectorServiceTests.cs
@@ -19,7 +19,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private const string ADO_TEAM_PROJECT = "ADO_TEAM_PROJECT";
         private const string FOO_REPO = "FOO_REPO";
 
-        public AdoInspectorServiceTests() => _service = new(_logger);
+        public AdoInspectorServiceTests() => _service = new(_logger, _mockAdoApi.Object);
 
         [Fact]
         public async Task GetOrgs_Should_Return_All_Orgs()
@@ -33,8 +33,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockAdoApi.Setup(m => m.GetUserId()).ReturnsAsync(userId);
             _mockAdoApi.Setup(m => m.GetOrganizations(userId)).ReturnsAsync(orgs);
 
-            _service.AdoApi = _mockAdoApi.Object;
-
             // Act
             var result = await _service.GetOrgs();
 
@@ -47,7 +45,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         {
             // Arrange
             _service.OrgFilter = ADO_ORG;
-            _service.AdoApi = _mockAdoApi.Object;
 
             // Act
             var result = await _service.GetOrgs();
@@ -60,15 +57,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         }
 
         [Fact]
-        public async Task GetOrgs_Should_Throw_Exception_When_AdoApi_Not_Set()
-        {
-            await FluentActions
-                .Invoking(async () => await _service.GetOrgs())
-                .Should()
-                .ThrowAsync<Exception>();
-        }
-
-        [Fact]
         public async Task GetTeamProjects_Should_Return_All_TeamProjects()
         {
             // Arrange
@@ -77,7 +65,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var teamProjects = new List<string>() { teamProject1, teamProject2 };
 
             _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(teamProjects);
-            _service.AdoApi = _mockAdoApi.Object;
 
             // Act
             var result = await _service.GetTeamProjects(ADO_ORG);
@@ -89,22 +76,12 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         [Fact]
         public async Task GetTeamProjects_Should_Return_Single_TeamProject_When_TeamProjectFilter_Set()
         {
-            _service.AdoApi = _mockAdoApi.Object;
             _service.TeamProjectFilter = ADO_TEAM_PROJECT;
 
             var result = await _service.GetTeamProjects(ADO_ORG);
 
             result.Count().Should().Be(1);
             result.First().Should().Be(ADO_TEAM_PROJECT);
-        }
-
-        [Fact]
-        public async Task GetTeamProjects_Should_Throw_Exception_When_AdoApi_Not_Set()
-        {
-            await FluentActions
-                .Invoking(async () => await _service.GetTeamProjects(ADO_ORG))
-                .Should()
-                .ThrowAsync<Exception>();
         }
 
         [Fact]
@@ -116,22 +93,12 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var repos = new List<string>() { repo1, repo2 };
 
             _mockAdoApi.Setup(m => m.GetEnabledRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(repos);
-            _service.AdoApi = _mockAdoApi.Object;
 
             // Act
             var result = await _service.GetRepos(ADO_ORG, ADO_TEAM_PROJECT);
 
             // Assert
             result.Should().BeEquivalentTo(repos);
-        }
-
-        [Fact]
-        public async Task GetRepos_Should_Throw_Exception_When_AdoApi_Not_Set()
-        {
-            await FluentActions
-                .Invoking(async () => await _service.GetRepos(ADO_ORG, ADO_TEAM_PROJECT))
-                .Should()
-                .ThrowAsync<Exception>();
         }
 
         [Fact]
@@ -146,22 +113,11 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockAdoApi.Setup(m => m.GetRepoId(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(repoId);
             _mockAdoApi.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, repoId)).ReturnsAsync(pipelines);
 
-            _service.AdoApi = _mockAdoApi.Object;
-
             // Act
             var result = await _service.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO);
 
             // Assert
             result.Should().BeEquivalentTo(pipelines);
-        }
-
-        [Fact]
-        public async Task GetPipelines_Should_Throw_Exception_When_AdoApi_Not_Set()
-        {
-            await FluentActions
-                .Invoking(async () => await _service.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO))
-                .Should()
-                .ThrowAsync<Exception>();
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/OrgsCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/OrgsCsvGeneratorServiceTests.cs
@@ -13,6 +13,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private const string CSV_HEADER = "name,url,owner,teamproject-count,repo-count,pipeline-count,pr-count";
         private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
         private readonly Mock<AdoInspectorService> _mockAdoInspectorService = TestHelpers.CreateMock<AdoInspectorService>();
+        private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
         private const string ADO_ORG = "foo-org";
         private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
@@ -21,7 +22,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
         public OrgsCsvGeneratorServiceTests()
         {
-            _service = new OrgsCsvGeneratorService(_mockAdoInspectorService.Object);
+            _mockAdoInspectorServiceFactory.Setup(m => m.Create(_mockAdoApi.Object)).Returns(_mockAdoInspectorService.Object);
+            _service = new OrgsCsvGeneratorService(_mockAdoInspectorServiceFactory.Object);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/OrgsCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/OrgsCsvGeneratorServiceTests.cs
@@ -1,57 +1,57 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using FluentAssertions;
-using Moq;
-using OctoshiftCLI.AdoToGithub;
-using Xunit;
+//using System;
+//using System.Collections.Generic;
+//using System.Threading.Tasks;
+//using FluentAssertions;
+//using Moq;
+//using OctoshiftCLI.AdoToGithub;
+//using Xunit;
 
-namespace OctoshiftCLI.Tests.AdoToGithub.Commands
-{
-    public class OrgsCsvGeneratorServiceTests
-    {
-        private const string CSV_HEADER = "name,url,owner,teamproject-count,repo-count,pipeline-count";
+//namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+//{
+//    public class OrgsCsvGeneratorServiceTests
+//    {
+//        private const string CSV_HEADER = "name,url,owner,teamproject-count,repo-count,pipeline-count";
 
-        [Fact]
-        public async Task Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
-        {
-            // Arrange
-            var org = "my-org";
-            var teamProject = "foo-tp";
-            var repo = "foo-repo";
-            var pipeline = "foo-pipeline";
-            var pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
-                { { org, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
-                             { { teamProject, new Dictionary<string, IEnumerable<string>>()
-                                                   { { repo, new List<string>()
-                                                                 { pipeline } } } } } } };
-            var ownerName = "Suzy";
-            var ownerEmail = "Suzy (suzy@gmail.com)";
-            var adoApi = TestHelpers.CreateMock<AdoApi>();
+//        [Fact]
+//        public async Task Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
+//        {
+//            // Arrange
+//            var org = "my-org";
+//            var teamProject = "foo-tp";
+//            var repo = "foo-repo";
+//            var pipeline = "foo-pipeline";
+//            var pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
+//                { { org, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
+//                             { { teamProject, new Dictionary<string, IEnumerable<string>>()
+//                                                   { { repo, new List<string>()
+//                                                                 { pipeline } } } } } } };
+//            var ownerName = "Suzy";
+//            var ownerEmail = "Suzy (suzy@gmail.com)";
+//            var adoApi = TestHelpers.CreateMock<AdoApi>();
 
-            adoApi.Setup(m => m.GetOrgOwner(org)).ReturnsAsync($"{ownerName} ({ownerEmail})");
+//            adoApi.Setup(m => m.GetOrgOwner(org)).ReturnsAsync($"{ownerName} ({ownerEmail})");
 
-            // Act
-            var service = new OrgsCsvGeneratorService();
-            var result = await service.Generate(adoApi.Object, pipelines);
+//            // Act
+//            var service = new OrgsCsvGeneratorService();
+//            var result = await service.Generate(adoApi.Object, pipelines);
 
-            // Assert
-            var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            expected += $"{org},https://dev.azure.com/{org},{ownerName} ({ownerEmail}),1,1,1{Environment.NewLine}";
+//            // Assert
+//            var expected = $"{CSV_HEADER}{Environment.NewLine}";
+//            expected += $"{org},https://dev.azure.com/{org},{ownerName} ({ownerEmail}),1,1,1{Environment.NewLine}";
 
-            result.Should().Be(expected);
-        }
+//            result.Should().Be(expected);
+//        }
 
-        [Fact]
-        public async Task Generate_Should_Return_Correct_Csv_When_Passed_Null_Orgs()
-        {
-            // Act
-            var service = new OrgsCsvGeneratorService();
-            var result = await service.Generate(null, null);
+//        [Fact]
+//        public async Task Generate_Should_Return_Correct_Csv_When_Passed_Null_Orgs()
+//        {
+//            // Act
+//            var service = new OrgsCsvGeneratorService();
+//            var result = await service.Generate(null, null);
 
-            // Assert
-            var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            result.Should().Be(expected);
-        }
-    }
-}
+//            // Assert
+//            var expected = $"{CSV_HEADER}{Environment.NewLine}";
+//            result.Should().Be(expected);
+//        }
+//    }
+//}

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
@@ -13,6 +13,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private const string CSV_HEADER = "org,teamproject,repo,pipeline,url";
         private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
         private readonly Mock<AdoInspectorService> _mockAdoInspectorService = TestHelpers.CreateMock<AdoInspectorService>();
+        private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
         private const string ADO_ORG = "foo-org";
         private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
@@ -27,7 +28,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
         public PipelinesCsvGeneratorServiceTests()
         {
-            _service = new PipelinesCsvGeneratorService(_mockAdoInspectorService.Object);
+            _mockAdoInspectorServiceFactory.Setup(m => m.Create(_mockAdoApi.Object)).Returns(_mockAdoInspectorService.Object);
+            _service = new PipelinesCsvGeneratorService(_mockAdoInspectorServiceFactory.Object);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
@@ -1,56 +1,65 @@
-//using System;
-//using System.Collections.Generic;
-//using System.Threading.Tasks;
-//using FluentAssertions;
-//using Moq;
-//using OctoshiftCLI.AdoToGithub;
-//using Xunit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using OctoshiftCLI.AdoToGithub;
+using Xunit;
 
-//namespace OctoshiftCLI.Tests.AdoToGithub.Commands
-//{
-//    public class PipelinesCsvGeneratorServiceTests
-//    {
-//        private const string CSV_HEADER = "org,teamproject,repo,pipeline,url";
+namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+{
+    public class PipelinesCsvGeneratorServiceTests
+    {
+        private const string CSV_HEADER = "org,teamproject,repo,pipeline,url";
+        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
+        private readonly Mock<AdoInspectorService> _mockAdoInspectorService = TestHelpers.CreateMock<AdoInspectorService>();
 
-//        [Fact]
-//        public async Task Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
-//        {
-//            // Arrange
-//            var org = "my-org";
-//            var teamProject = "foo-tp";
-//            var repo = "foo-repo";
-//            var pipeline = "foo-pipeline";
-//            var pipelineId = 23;
-//            var pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
-//                { { org, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
-//                             { { teamProject, new Dictionary<string, IEnumerable<string>>()
-//                                                   { { repo, new List<string>()
-//                                                                 { pipeline } } } } } } };
+        private const string ADO_ORG = "foo-org";
+        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
+        private const string ADO_TEAM_PROJECT = "foo-tp";
+        private readonly IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
+        private const string ADO_REPO = "foo-repo";
+        private readonly IEnumerable<string> ADO_REPOS = new List<string>() { ADO_REPO };
+        private const string ADO_PIPELINE = "foo-pipeline";
+        private readonly IEnumerable<string> ADO_PIPELINES = new List<string>() { ADO_PIPELINE };
 
-//            var mockAdoApi = TestHelpers.CreateMock<AdoApi>();
-//            mockAdoApi.Setup(m => m.GetPipelineId(org, teamProject, pipeline)).ReturnsAsync(pipelineId);
+        private readonly PipelinesCsvGeneratorService _service;
 
-//            // Act
-//            var service = new PipelinesCsvGeneratorService();
-//            var result = await service.Generate(mockAdoApi.Object, pipelines);
+        public PipelinesCsvGeneratorServiceTests()
+        {
+            _service = new PipelinesCsvGeneratorService(_mockAdoInspectorService.Object);
+        }
 
-//            // Assert
-//            var expected = $"{CSV_HEADER}{Environment.NewLine}";
-//            expected += $"{org},{teamProject},{repo},{pipeline},https://dev.azure.com/{org}/{teamProject}/_build?definitionId={pipelineId}{Environment.NewLine}";
+        [Fact]
+        public async Task Generate_Should_Return_Correct_Csv_For_One_Pipeline()
+        {
+            // Arrange
+            var pipelineId = 123;
 
-//            result.Should().Be(expected);
-//        }
+            _mockAdoApi.Setup(m => m.GetPipelineId(ADO_ORG, ADO_TEAM_PROJECT, ADO_PIPELINE)).ReturnsAsync(pipelineId);
 
-//        [Fact]
-//        public async Task Generate_Should_Return_Correct_Csv_When_Passed_Null_Orgs()
-//        {
-//            // Act
-//            var service = new PipelinesCsvGeneratorService();
-//            var result = await service.Generate(null, null);
+            _mockAdoInspectorService.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspectorService.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspectorService.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+            _mockAdoInspectorService.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO)).ReturnsAsync(ADO_PIPELINES);
 
-//            // Assert
-//            var expected = $"{CSV_HEADER}{Environment.NewLine}";
-//            result.Should().Be(expected);
-//        }
-//    }
-//}
+            // Act
+            var result = await _service.Generate(_mockAdoApi.Object);
+
+            // Assert
+            var expected = $"{CSV_HEADER}{Environment.NewLine}";
+            expected += $"\"{ADO_ORG}\",\"{ADO_TEAM_PROJECT}\",\"{ADO_REPO}\",\"{ADO_PIPELINE}\",\"https://dev.azure.com/{ADO_ORG}/{ADO_TEAM_PROJECT}/_build?definitionId={pipelineId}\"{Environment.NewLine}";
+
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public async Task Generate_Should_Throw_Exception_When_Passed_Null_AdoApi()
+        {
+            await FluentActions
+                .Invoking(async () => await _service.Generate(null))
+                .Should()
+                .ThrowAsync<ArgumentNullException>();
+        }
+    }
+}

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
@@ -1,56 +1,56 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using FluentAssertions;
-using Moq;
-using OctoshiftCLI.AdoToGithub;
-using Xunit;
+//using System;
+//using System.Collections.Generic;
+//using System.Threading.Tasks;
+//using FluentAssertions;
+//using Moq;
+//using OctoshiftCLI.AdoToGithub;
+//using Xunit;
 
-namespace OctoshiftCLI.Tests.AdoToGithub.Commands
-{
-    public class PipelinesCsvGeneratorServiceTests
-    {
-        private const string CSV_HEADER = "org,teamproject,repo,pipeline,url";
+//namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+//{
+//    public class PipelinesCsvGeneratorServiceTests
+//    {
+//        private const string CSV_HEADER = "org,teamproject,repo,pipeline,url";
 
-        [Fact]
-        public async Task Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
-        {
-            // Arrange
-            var org = "my-org";
-            var teamProject = "foo-tp";
-            var repo = "foo-repo";
-            var pipeline = "foo-pipeline";
-            var pipelineId = 23;
-            var pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
-                { { org, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
-                             { { teamProject, new Dictionary<string, IEnumerable<string>>()
-                                                   { { repo, new List<string>()
-                                                                 { pipeline } } } } } } };
+//        [Fact]
+//        public async Task Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
+//        {
+//            // Arrange
+//            var org = "my-org";
+//            var teamProject = "foo-tp";
+//            var repo = "foo-repo";
+//            var pipeline = "foo-pipeline";
+//            var pipelineId = 23;
+//            var pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
+//                { { org, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
+//                             { { teamProject, new Dictionary<string, IEnumerable<string>>()
+//                                                   { { repo, new List<string>()
+//                                                                 { pipeline } } } } } } };
 
-            var mockAdoApi = TestHelpers.CreateMock<AdoApi>();
-            mockAdoApi.Setup(m => m.GetPipelineId(org, teamProject, pipeline)).ReturnsAsync(pipelineId);
+//            var mockAdoApi = TestHelpers.CreateMock<AdoApi>();
+//            mockAdoApi.Setup(m => m.GetPipelineId(org, teamProject, pipeline)).ReturnsAsync(pipelineId);
 
-            // Act
-            var service = new PipelinesCsvGeneratorService();
-            var result = await service.Generate(mockAdoApi.Object, pipelines);
+//            // Act
+//            var service = new PipelinesCsvGeneratorService();
+//            var result = await service.Generate(mockAdoApi.Object, pipelines);
 
-            // Assert
-            var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            expected += $"{org},{teamProject},{repo},{pipeline},https://dev.azure.com/{org}/{teamProject}/_build?definitionId={pipelineId}{Environment.NewLine}";
+//            // Assert
+//            var expected = $"{CSV_HEADER}{Environment.NewLine}";
+//            expected += $"{org},{teamProject},{repo},{pipeline},https://dev.azure.com/{org}/{teamProject}/_build?definitionId={pipelineId}{Environment.NewLine}";
 
-            result.Should().Be(expected);
-        }
+//            result.Should().Be(expected);
+//        }
 
-        [Fact]
-        public async Task Generate_Should_Return_Correct_Csv_When_Passed_Null_Orgs()
-        {
-            // Act
-            var service = new PipelinesCsvGeneratorService();
-            var result = await service.Generate(null, null);
+//        [Fact]
+//        public async Task Generate_Should_Return_Correct_Csv_When_Passed_Null_Orgs()
+//        {
+//            // Act
+//            var service = new PipelinesCsvGeneratorService();
+//            var result = await service.Generate(null, null);
 
-            // Assert
-            var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            result.Should().Be(expected);
-        }
-    }
-}
+//            // Assert
+//            var expected = $"{CSV_HEADER}{Environment.NewLine}";
+//            result.Should().Be(expected);
+//        }
+//    }
+//}

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
@@ -1,55 +1,55 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using FluentAssertions;
-using Moq;
-using OctoshiftCLI.AdoToGithub;
-using Xunit;
+//using System;
+//using System.Collections.Generic;
+//using System.Threading.Tasks;
+//using FluentAssertions;
+//using Moq;
+//using OctoshiftCLI.AdoToGithub;
+//using Xunit;
 
-namespace OctoshiftCLI.Tests.AdoToGithub.Commands
-{
-    public class ReposCsvGeneratorServiceTests
-    {
-        private const string CSV_HEADER = "org,teamproject,repo,url,pipeline-count,pr-count";
+//namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+//{
+//    public class ReposCsvGeneratorServiceTests
+//    {
+//        private const string CSV_HEADER = "org,teamproject,repo,url,pipeline-count,pr-count";
 
-        [Fact]
-        public async Task Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
-        {
-            // Arrange
-            var org = "my org";
-            var teamProject = "foo tp";
-            var repo = "foo repo";
-            var pipeline = "foo-pipeline";
-            var pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
-                { { org, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
-                             { { teamProject, new Dictionary<string, IEnumerable<string>>()
-                                                   { { repo, new List<string>()
-                                                                 { pipeline } } } } } } };
+//        [Fact]
+//        public async Task Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
+//        {
+//            // Arrange
+//            var org = "my org";
+//            var teamProject = "foo tp";
+//            var repo = "foo repo";
+//            var pipeline = "foo-pipeline";
+//            var pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
+//                { { org, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
+//                             { { teamProject, new Dictionary<string, IEnumerable<string>>()
+//                                                   { { repo, new List<string>()
+//                                                                 { pipeline } } } } } } };
 
-            var mockAdoApi = TestHelpers.CreateMock<AdoApi>();
-            mockAdoApi.Setup(m => m.GetPullRequestCount(org, teamProject, repo)).ReturnsAsync(3);
+//            var mockAdoApi = TestHelpers.CreateMock<AdoApi>();
+//            mockAdoApi.Setup(m => m.GetPullRequestCount(org, teamProject, repo)).ReturnsAsync(3);
 
-            // Act
-            var service = new ReposCsvGeneratorService();
-            var result = await service.Generate(mockAdoApi.Object, pipelines);
+//            // Act
+//            var service = new ReposCsvGeneratorService();
+//            var result = await service.Generate(mockAdoApi.Object, pipelines);
 
-            // Assert
-            var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            expected += $"{org},{teamProject},{repo},https://dev.azure.com/my%20org/foo%20tp/_git/foo%20repo,1,3{Environment.NewLine}";
+//            // Assert
+//            var expected = $"{CSV_HEADER}{Environment.NewLine}";
+//            expected += $"{org},{teamProject},{repo},https://dev.azure.com/my%20org/foo%20tp/_git/foo%20repo,1,3{Environment.NewLine}";
 
-            result.Should().Be(expected);
-        }
+//            result.Should().Be(expected);
+//        }
 
-        [Fact]
-        public async Task Generate_Should_Return_Correct_Csv_When_Passed_Null_Orgs()
-        {
-            // Act
-            var service = new ReposCsvGeneratorService();
-            var result = await service.Generate(null, null);
+//        [Fact]
+//        public async Task Generate_Should_Return_Correct_Csv_When_Passed_Null_Orgs()
+//        {
+//            // Act
+//            var service = new ReposCsvGeneratorService();
+//            var result = await service.Generate(null, null);
 
-            // Assert
-            var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            result.Should().Be(expected);
-        }
-    }
-}
+//            // Assert
+//            var expected = $"{CSV_HEADER}{Environment.NewLine}";
+//            result.Should().Be(expected);
+//        }
+//    }
+//}

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
@@ -1,55 +1,63 @@
-//using System;
-//using System.Collections.Generic;
-//using System.Threading.Tasks;
-//using FluentAssertions;
-//using Moq;
-//using OctoshiftCLI.AdoToGithub;
-//using Xunit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using OctoshiftCLI.AdoToGithub;
+using Xunit;
 
-//namespace OctoshiftCLI.Tests.AdoToGithub.Commands
-//{
-//    public class ReposCsvGeneratorServiceTests
-//    {
-//        private const string CSV_HEADER = "org,teamproject,repo,url,pipeline-count,pr-count";
+namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+{
+    public class ReposCsvGeneratorServiceTests
+    {
+        private const string CSV_HEADER = "org,teamproject,repo,url,pipeline-count,pr-count";
+        private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
+        private readonly Mock<AdoInspectorService> _mockAdoInspectorService = TestHelpers.CreateMock<AdoInspectorService>();
 
-//        [Fact]
-//        public async Task Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
-//        {
-//            // Arrange
-//            var org = "my org";
-//            var teamProject = "foo tp";
-//            var repo = "foo repo";
-//            var pipeline = "foo-pipeline";
-//            var pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
-//                { { org, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
-//                             { { teamProject, new Dictionary<string, IEnumerable<string>>()
-//                                                   { { repo, new List<string>()
-//                                                                 { pipeline } } } } } } };
+        private const string ADO_ORG = "foo-org";
+        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
+        private const string ADO_TEAM_PROJECT = "foo-tp";
+        private readonly IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
+        private const string ADO_REPO = "foo-repo";
+        private readonly IEnumerable<string> ADO_REPOS = new List<string>() { ADO_REPO };
 
-//            var mockAdoApi = TestHelpers.CreateMock<AdoApi>();
-//            mockAdoApi.Setup(m => m.GetPullRequestCount(org, teamProject, repo)).ReturnsAsync(3);
+        private readonly ReposCsvGeneratorService _service;
 
-//            // Act
-//            var service = new ReposCsvGeneratorService();
-//            var result = await service.Generate(mockAdoApi.Object, pipelines);
+        public ReposCsvGeneratorServiceTests()
+        {
+            _service = new ReposCsvGeneratorService(_mockAdoInspectorService.Object);
+        }
 
-//            // Assert
-//            var expected = $"{CSV_HEADER}{Environment.NewLine}";
-//            expected += $"{org},{teamProject},{repo},https://dev.azure.com/my%20org/foo%20tp/_git/foo%20repo,1,3{Environment.NewLine}";
+        [Fact]
+        public async Task Generate_Should_Return_Correct_Csv_For_One_Repo()
+        {
+            // Arrange
+            var pipelineCount = 41;
+            var prCount = 822;
 
-//            result.Should().Be(expected);
-//        }
+            _mockAdoInspectorService.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspectorService.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspectorService.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+            _mockAdoInspectorService.Setup(m => m.GetPipelineCount(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO)).ReturnsAsync(pipelineCount);
+            _mockAdoInspectorService.Setup(m => m.GetPullRequestCount(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO)).ReturnsAsync(prCount);
 
-//        [Fact]
-//        public async Task Generate_Should_Return_Correct_Csv_When_Passed_Null_Orgs()
-//        {
-//            // Act
-//            var service = new ReposCsvGeneratorService();
-//            var result = await service.Generate(null, null);
+            // Act
+            var result = await _service.Generate(_mockAdoApi.Object);
 
-//            // Assert
-//            var expected = $"{CSV_HEADER}{Environment.NewLine}";
-//            result.Should().Be(expected);
-//        }
-//    }
-//}
+            // Assert
+            var expected = $"{CSV_HEADER}{Environment.NewLine}";
+            expected += $"\"{ADO_ORG}\",\"{ADO_TEAM_PROJECT}\",\"{ADO_REPO}\",\"https://dev.azure.com/{ADO_ORG}/{ADO_TEAM_PROJECT}/_git/{ADO_REPO}\",{pipelineCount},{prCount}{Environment.NewLine}";
+
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public async Task Generate_Should_Throw_Exception_When_Passed_Null_AdoApi()
+        {
+            await FluentActions
+                .Invoking(async () => await _service.Generate(null))
+                .Should()
+                .ThrowAsync<ArgumentNullException>();
+        }
+    }
+}

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
@@ -13,6 +13,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private const string CSV_HEADER = "org,teamproject,repo,url,pipeline-count,pr-count";
         private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
         private readonly Mock<AdoInspectorService> _mockAdoInspectorService = TestHelpers.CreateMock<AdoInspectorService>();
+        private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
         private const string ADO_ORG = "foo-org";
         private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
@@ -25,7 +26,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
         public ReposCsvGeneratorServiceTests()
         {
-            _service = new ReposCsvGeneratorService(_mockAdoInspectorService.Object);
+            _mockAdoInspectorServiceFactory.Setup(m => m.Create(_mockAdoApi.Object)).Returns(_mockAdoInspectorService.Object);
+            _service = new ReposCsvGeneratorService(_mockAdoInspectorServiceFactory.Object);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/TeamProjectsCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/TeamProjectsCsvGeneratorServiceTests.cs
@@ -13,6 +13,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private const string CSV_HEADER = "org,teamproject,url,repo-count,pipeline-count,pr-count";
         private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
         private readonly Mock<AdoInspectorService> _mockAdoInspectorService = TestHelpers.CreateMock<AdoInspectorService>();
+        private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
         private const string ADO_ORG = "foo-org";
         private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
@@ -23,7 +24,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
         public TeamProjectsCsvGeneratorServiceTests()
         {
-            _service = new TeamProjectsCsvGeneratorService(_mockAdoInspectorService.Object);
+            _mockAdoInspectorServiceFactory.Setup(m => m.Create(_mockAdoApi.Object)).Returns(_mockAdoInspectorService.Object);
+            _service = new TeamProjectsCsvGeneratorService(_mockAdoInspectorServiceFactory.Object);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/TeamProjectsCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/TeamProjectsCsvGeneratorServiceTests.cs
@@ -12,6 +12,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
     {
         private const string CSV_HEADER = "org,teamproject,url,repo-count,pipeline-count,pr-count";
         private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
+        private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
         private readonly Mock<AdoInspectorService> _mockAdoInspectorService = TestHelpers.CreateMock<AdoInspectorService>();
         private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
@@ -25,7 +26,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         public TeamProjectsCsvGeneratorServiceTests()
         {
             _mockAdoInspectorServiceFactory.Setup(m => m.Create(_mockAdoApi.Object)).Returns(_mockAdoInspectorService.Object);
-            _service = new TeamProjectsCsvGeneratorService(_mockAdoInspectorServiceFactory.Object);
+            _service = new TeamProjectsCsvGeneratorService(_mockAdoInspectorServiceFactory.Object, _mockAdoApiFactory.Object);
         }
 
         [Fact]
@@ -36,6 +37,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var pipelineCount = 41;
             var prCount = 822;
 
+            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
+
             _mockAdoInspectorService.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
             _mockAdoInspectorService.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
             _mockAdoInspectorService.Setup(m => m.GetRepoCount(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(repoCount);
@@ -43,7 +46,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockAdoInspectorService.Setup(m => m.GetPullRequestCount(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(prCount);
 
             // Act
-            var result = await _service.Generate(_mockAdoApi.Object);
+            var result = await _service.Generate(null);
 
             // Assert
             var expected = $"{CSV_HEADER}{Environment.NewLine}";
@@ -53,12 +56,15 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         }
 
         [Fact]
-        public async Task Generate_Should_Throw_Exception_When_Passed_Null_AdoApi()
+        public async Task Generate_Should_Use_Pat_When_Passed()
         {
-            await FluentActions
-                .Invoking(async () => await _service.Generate(null))
-                .Should()
-                .ThrowAsync<ArgumentNullException>();
+            var adoPat = Guid.NewGuid().ToString();
+
+            _mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(_mockAdoApi.Object);
+
+            await _service.Generate(adoPat);
+
+            _mockAdoApiFactory.Verify(m => m.Create(adoPat));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/TeamProjectsCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/TeamProjectsCsvGeneratorServiceTests.cs
@@ -1,50 +1,50 @@
-using System;
-using System.Collections.Generic;
-using FluentAssertions;
-using OctoshiftCLI.AdoToGithub;
-using Xunit;
+//using System;
+//using System.Collections.Generic;
+//using FluentAssertions;
+//using OctoshiftCLI.AdoToGithub;
+//using Xunit;
 
-namespace OctoshiftCLI.Tests.AdoToGithub.Commands
-{
-    public class TeamProjectsCsvGeneratorServiceTests
-    {
-        private const string CSV_HEADER = "org,teamproject,url,repo-count,pipeline-count";
+//namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+//{
+//    public class TeamProjectsCsvGeneratorServiceTests
+//    {
+//        private const string CSV_HEADER = "org,teamproject,url,repo-count,pipeline-count";
 
-        [Fact]
-        public void Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
-        {
-            // Arrange
-            var org = "my-org";
-            var teamProject = "foo-tp";
-            var repo = "foo-repo";
-            var pipeline = "foo-pipeline";
-            var pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
-                { { org, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
-                             { { teamProject, new Dictionary<string, IEnumerable<string>>()
-                                                   { { repo, new List<string>()
-                                                                 { pipeline } } } } } } };
+//        [Fact]
+//        public void Generate_Should_Return_Correct_Csv_When_Passed_One_Org()
+//        {
+//            // Arrange
+//            var org = "my-org";
+//            var teamProject = "foo-tp";
+//            var repo = "foo-repo";
+//            var pipeline = "foo-pipeline";
+//            var pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>()
+//                { { org, new Dictionary<string, IDictionary<string, IEnumerable<string>>>()
+//                             { { teamProject, new Dictionary<string, IEnumerable<string>>()
+//                                                   { { repo, new List<string>()
+//                                                                 { pipeline } } } } } } };
 
-            // Act
-            var service = new TeamProjectsCsvGeneratorService();
-            var result = service.Generate(pipelines);
+//            // Act
+//            var service = new TeamProjectsCsvGeneratorService();
+//            var result = service.Generate(pipelines);
 
-            // Assert
-            var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            expected += $"{org},{teamProject},https://dev.azure.com/{org}/{teamProject},1,1{Environment.NewLine}";
+//            // Assert
+//            var expected = $"{CSV_HEADER}{Environment.NewLine}";
+//            expected += $"{org},{teamProject},https://dev.azure.com/{org}/{teamProject},1,1{Environment.NewLine}";
 
-            result.Should().Be(expected);
-        }
+//            result.Should().Be(expected);
+//        }
 
-        [Fact]
-        public void Generate_Should_Return_Correct_Csv_When_Passed_Null_Orgs()
-        {
-            // Act
-            var service = new TeamProjectsCsvGeneratorService();
-            var result = service.Generate(null);
+//        [Fact]
+//        public void Generate_Should_Return_Correct_Csv_When_Passed_Null_Orgs()
+//        {
+//            // Act
+//            var service = new TeamProjectsCsvGeneratorService();
+//            var result = service.Generate(null);
 
-            // Assert
-            var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            result.Should().Be(expected);
-        }
-    }
-}
+//            // Assert
+//            var expected = $"{CSV_HEADER}{Environment.NewLine}";
+//            result.Should().Be(expected);
+//        }
+//    }
+//}

--- a/src/ado2gh/AdoInspectorServiceFactory.cs
+++ b/src/ado2gh/AdoInspectorServiceFactory.cs
@@ -1,0 +1,11 @@
+namespace OctoshiftCLI.AdoToGithub
+{
+    public class AdoInspectorServiceFactory
+    {
+        private readonly OctoLogger _octoLogger;
+
+        public AdoInspectorServiceFactory(OctoLogger octoLogger) => _octoLogger = octoLogger;
+
+        public virtual AdoInspectorService Create(AdoApi adoApi) => new(_octoLogger, adoApi);
+    }
+}

--- a/src/ado2gh/AdoInspectorServiceFactory.cs
+++ b/src/ado2gh/AdoInspectorServiceFactory.cs
@@ -3,9 +3,18 @@ namespace OctoshiftCLI.AdoToGithub
     public class AdoInspectorServiceFactory
     {
         private readonly OctoLogger _octoLogger;
+        private AdoInspectorService _instance;
 
         public AdoInspectorServiceFactory(OctoLogger octoLogger) => _octoLogger = octoLogger;
 
-        public virtual AdoInspectorService Create(AdoApi adoApi) => new(_octoLogger, adoApi);
+        public virtual AdoInspectorService Create(AdoApi adoApi)
+        {
+            if (_instance is null)
+            {
+                _instance = new(_octoLogger, adoApi);
+            }
+
+            return _instance;
+        }
     }
 }

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -18,14 +18,16 @@ namespace OctoshiftCLI.AdoToGithub.Commands
         private readonly AdoApiFactory _adoApiFactory;
         private GenerateScriptOptions _generateScriptOptions;
         private readonly IVersionProvider _versionProvider;
-        private readonly AdoInspectorService _adoInspectorService;
+        private readonly AdoInspectorServiceFactory _adoInspectorServiceFactory;
 
-        public GenerateScriptCommand(OctoLogger log, AdoApiFactory adoApiFactory, IVersionProvider versionProvider, AdoInspectorService adoInspectorService) : base("generate-script")
+        private AdoInspectorService _adoInspectorService;
+
+        public GenerateScriptCommand(OctoLogger log, AdoApiFactory adoApiFactory, IVersionProvider versionProvider, AdoInspectorServiceFactory adoInspectorServiceFactory) : base("generate-script")
         {
             _log = log;
             _adoApiFactory = adoApiFactory;
             _versionProvider = versionProvider;
-            _adoInspectorService = adoInspectorService;
+            _adoInspectorServiceFactory = adoInspectorServiceFactory;
 
             Description = "Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it.";
             Description += Environment.NewLine;
@@ -144,7 +146,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             };
 
             var ado = _adoApiFactory.Create(args.AdoPat);
-            _adoInspectorService.AdoApi = ado;
+            _adoInspectorService = _adoInspectorServiceFactory.Create(ado);
             _adoInspectorService.OrgFilter = args.AdoOrg;
             _adoInspectorService.TeamProjectFilter = args.AdoTeamProject;
 

--- a/src/ado2gh/Commands/InventoryReportCommand.cs
+++ b/src/ado2gh/Commands/InventoryReportCommand.cs
@@ -101,22 +101,22 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _log.LogInformation($"Found {pipelineCount} Pipelines");
 
             _log.LogInformation("Generating orgs.csv...");
-            var orgsCsvText = await _orgsCsvGenerator.Generate(ado);
+            var orgsCsvText = await _orgsCsvGenerator.Generate(adoPat);
             await WriteToFile("orgs.csv", orgsCsvText);
             _log.LogSuccess("orgs.csv generated");
 
             _log.LogInformation("Generating teamprojects.csv...");
-            var teamProjectsCsvText = await _teamProjectsCsvGenerator.Generate(ado);
+            var teamProjectsCsvText = await _teamProjectsCsvGenerator.Generate(adoPat);
             await WriteToFile("team-projects.csv", teamProjectsCsvText);
             _log.LogSuccess("team-projects.csv generated");
 
             _log.LogInformation("Generating repos.csv...");
-            var reposCsvText = await _reposCsvGenerator.Generate(ado);
+            var reposCsvText = await _reposCsvGenerator.Generate(adoPat);
             await WriteToFile("repos.csv", reposCsvText);
             _log.LogSuccess("repos.csv generated");
 
             _log.LogInformation("Generating pipelines.csv...");
-            var pipelinesCsvText = await _pipelinesCsvGenerator.Generate(ado);
+            var pipelinesCsvText = await _pipelinesCsvGenerator.Generate(adoPat);
             await WriteToFile("pipelines.csv", pipelinesCsvText);
             _log.LogSuccess("pipelines.csv generated");
         }

--- a/src/ado2gh/Commands/InventoryReportCommand.cs
+++ b/src/ado2gh/Commands/InventoryReportCommand.cs
@@ -2,6 +2,7 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using OctoshiftCLI.Extensions;
 
@@ -76,21 +77,21 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _adoInspectorService.AdoApi = ado;
             _adoInspectorService.OrgFilter = adoOrg;
 
-            //_log.LogInformation("Finding Orgs...");
-            //var orgs = await _adoInspectorService.GetOrgs();
-            //_log.LogInformation($"Found {orgs?.Count()} Orgs");
+            _log.LogInformation("Finding Orgs...");
+            var orgs = await _adoInspectorService.GetOrgs();
+            _log.LogInformation($"Found {orgs.Count()} Orgs");
 
-            //_log.LogInformation("Finding Team Projects...");
-            //var teamProjects = await _adoInspectorService.GetTeamProjects(orgs);
-            //_log.LogInformation($"Found {teamProjects?.Sum(org => org.Value.Count())} Team Projects");
+            _log.LogInformation("Finding Team Projects...");
+            var teamProjectCount = await _adoInspectorService.GetTeamProjectCount();
+            _log.LogInformation($"Found {teamProjectCount} Team Projects");
 
-            //_log.LogInformation("Finding Repos...");
-            //var repos = await _adoInspectorService.GetRepos(teamProjects);
-            //_log.LogInformation($"Found {repos?.Sum(org => org.Value.Sum(tp => tp.Value.Count()))} Repos");
+            _log.LogInformation("Finding Repos...");
+            var repoCount = await _adoInspectorService.GetRepoCount();
+            _log.LogInformation($"Found {repoCount} Repos");
 
-            //_log.LogInformation("Finding Pipelines...");
-            //var pipelines = await _adoInspectorService.GetPipelines(repos);
-            //_log.LogInformation($"Found {pipelines?.Sum(org => org.Value.Sum(tp => tp.Value.Sum(repo => repo.Value.Count())))} Pipelines");
+            _log.LogInformation("Finding Pipelines...");
+            var pipelineCount = await _adoInspectorService.GetPipelineCount();
+            _log.LogInformation($"Found {pipelineCount} Pipelines");
 
             _log.LogInformation("Generating orgs.csv...");
             var orgsCsvText = await _orgsCsvGenerator.Generate(ado);

--- a/src/ado2gh/Commands/InventoryReportCommand.cs
+++ b/src/ado2gh/Commands/InventoryReportCommand.cs
@@ -14,17 +14,24 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
         private readonly OctoLogger _log;
         private readonly AdoApiFactory _adoApiFactory;
-        private readonly AdoInspectorService _adoInspectorService;
+        private readonly AdoInspectorServiceFactory _adoInspectorServiceFactory;
         private readonly OrgsCsvGeneratorService _orgsCsvGenerator;
         private readonly TeamProjectsCsvGeneratorService _teamProjectsCsvGenerator;
         private readonly ReposCsvGeneratorService _reposCsvGenerator;
         private readonly PipelinesCsvGeneratorService _pipelinesCsvGenerator;
 
-        public InventoryReportCommand(OctoLogger log, AdoApiFactory adoApiFactory, AdoInspectorService adoInspectorService, OrgsCsvGeneratorService orgsCsvGeneratorService, TeamProjectsCsvGeneratorService teamProjectsCsvGeneratorService, ReposCsvGeneratorService reposCsvGeneratorService, PipelinesCsvGeneratorService pipelinesCsvGeneratorService) : base("inventory-report")
+        public InventoryReportCommand(
+            OctoLogger log,
+            AdoApiFactory adoApiFactory,
+            AdoInspectorServiceFactory adoInspectorServiceFactory,
+            OrgsCsvGeneratorService orgsCsvGeneratorService,
+            TeamProjectsCsvGeneratorService teamProjectsCsvGeneratorService,
+            ReposCsvGeneratorService reposCsvGeneratorService,
+            PipelinesCsvGeneratorService pipelinesCsvGeneratorService) : base("inventory-report")
         {
             _log = log;
             _adoApiFactory = adoApiFactory;
-            _adoInspectorService = adoInspectorService;
+            _adoInspectorServiceFactory = adoInspectorServiceFactory;
             _orgsCsvGenerator = orgsCsvGeneratorService;
             _teamProjectsCsvGenerator = teamProjectsCsvGeneratorService;
             _reposCsvGenerator = reposCsvGeneratorService;
@@ -74,23 +81,23 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             }
 
             var ado = _adoApiFactory.Create(adoPat);
-            _adoInspectorService.AdoApi = ado;
-            _adoInspectorService.OrgFilter = adoOrg;
+            var inspector = _adoInspectorServiceFactory.Create(ado);
+            inspector.OrgFilter = adoOrg;
 
             _log.LogInformation("Finding Orgs...");
-            var orgs = await _adoInspectorService.GetOrgs();
+            var orgs = await inspector.GetOrgs();
             _log.LogInformation($"Found {orgs.Count()} Orgs");
 
             _log.LogInformation("Finding Team Projects...");
-            var teamProjectCount = await _adoInspectorService.GetTeamProjectCount();
+            var teamProjectCount = await inspector.GetTeamProjectCount();
             _log.LogInformation($"Found {teamProjectCount} Team Projects");
 
             _log.LogInformation("Finding Repos...");
-            var repoCount = await _adoInspectorService.GetRepoCount();
+            var repoCount = await inspector.GetRepoCount();
             _log.LogInformation($"Found {repoCount} Repos");
 
             _log.LogInformation("Finding Pipelines...");
-            var pipelineCount = await _adoInspectorService.GetPipelineCount();
+            var pipelineCount = await inspector.GetPipelineCount();
             _log.LogInformation($"Found {pipelineCount} Pipelines");
 
             _log.LogInformation("Generating orgs.csv...");

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -34,6 +34,7 @@ namespace OctoshiftCLI.AdoToGithub
                 .AddSingleton<ReposCsvGeneratorService>()
                 .AddSingleton<PipelinesCsvGeneratorService>()
                 .AddSingleton<AdoInspectorService>()
+                .AddSingleton<AdoInspectorServiceFactory>()
                 .AddSingleton<IVersionProvider, VersionChecker>(sp => sp.GetRequiredService<VersionChecker>())
                 .AddHttpClient();
 

--- a/src/ado2gh/Services/AdoInspectorService.cs
+++ b/src/ado2gh/Services/AdoInspectorService.cs
@@ -72,6 +72,18 @@ namespace OctoshiftCLI.AdoToGithub
             return (await GetTeamProjects(org)).Count();
         }
 
+        public virtual async Task<int> GetTeamProjectCount()
+        {
+            var orgs = await GetOrgs();
+            return orgs.Sum(o => GetTeamProjectCount(o).Result);
+        }
+
+        public virtual async Task<int> GetPipelineCount()
+        {
+            var orgs = await GetOrgs();
+            return orgs.Sum(o => GetPipelineCount(o).Result);
+        }
+
         public virtual async Task<int> GetPipelineCount(string org)
         {
             var teamProjects = await GetTeamProjects(org);

--- a/src/ado2gh/Services/OrgsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/OrgsCsvGeneratorService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/src/ado2gh/Services/OrgsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/OrgsCsvGeneratorService.cs
@@ -28,12 +28,10 @@ namespace OctoshiftCLI.AdoToGithub
             foreach (var org in await _adoInspectorService.GetOrgs())
             {
                 var owner = await adoApi.GetOrgOwner(org);
-                var teamProjects = await _adoInspectorService.GetTeamProjects(org);
-                var teamProjectCount = teamProjects.Count();
-                var repoCount = teamProjects.SelectMany(tp => _adoInspectorService.GetRepos(org, tp).Result).Count();
-                var pipelineCount = teamProjects.SelectMany(tp => _adoInspectorService.GetRepos(org, tp).Result
-                                                                .SelectMany(r => _adoInspectorService.GetPipelines(org, tp, r).Result)).Count();
-                var prCount = teamProjects.Sum(tp => _adoInspectorService.GetRepos(org, tp).Result.Sum(r => _adoInspectorService.GetPullRequestCount(org, tp, r).Result));
+                var teamProjectCount = await _adoInspectorService.GetTeamProjectCount(org);
+                var repoCount = await _adoInspectorService.GetRepoCount(org);
+                var pipelineCount = await _adoInspectorService.GetPipelineCount(org);
+                var prCount = _adoInspectorService.GetPullRequestCount(org);
                 var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}";
 
                 result.AppendLine($"\"{org}\",\"{url}\",\"{owner}\",\"{teamProjectCount}\",\"{repoCount}\",\"{pipelineCount}\",\"{prCount}\"");

--- a/src/ado2gh/Services/OrgsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/OrgsCsvGeneratorService.cs
@@ -6,12 +6,9 @@ namespace OctoshiftCLI.AdoToGithub
 {
     public class OrgsCsvGeneratorService
     {
-        private readonly AdoInspectorService _adoInspectorService;
+        private readonly AdoInspectorServiceFactory _adoInspectorServiceFactory;
 
-        public OrgsCsvGeneratorService(AdoInspectorService adoInspectorService)
-        {
-            _adoInspectorService = adoInspectorService;
-        }
+        public OrgsCsvGeneratorService(AdoInspectorServiceFactory adoInspectorServiceFactory) => _adoInspectorServiceFactory = adoInspectorServiceFactory;
 
         public virtual async Task<string> Generate(AdoApi adoApi)
         {
@@ -20,17 +17,18 @@ namespace OctoshiftCLI.AdoToGithub
                 throw new ArgumentNullException(nameof(adoApi));
             }
 
+            var inspector = _adoInspectorServiceFactory.Create(adoApi);
             var result = new StringBuilder();
 
             result.AppendLine("name,url,owner,teamproject-count,repo-count,pipeline-count,pr-count");
 
-            foreach (var org in await _adoInspectorService.GetOrgs())
+            foreach (var org in await inspector.GetOrgs())
             {
                 var owner = await adoApi.GetOrgOwner(org);
-                var teamProjectCount = await _adoInspectorService.GetTeamProjectCount(org);
-                var repoCount = await _adoInspectorService.GetRepoCount(org);
-                var pipelineCount = await _adoInspectorService.GetPipelineCount(org);
-                var prCount = await _adoInspectorService.GetPullRequestCount(org);
+                var teamProjectCount = await inspector.GetTeamProjectCount(org);
+                var repoCount = await inspector.GetRepoCount(org);
+                var pipelineCount = await inspector.GetPipelineCount(org);
+                var prCount = await inspector.GetPullRequestCount(org);
                 var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}";
 
                 result.AppendLine($"\"{org}\",\"{url}\",\"{owner}\",{teamProjectCount},{repoCount},{pipelineCount},{prCount}");

--- a/src/ado2gh/Services/OrgsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/OrgsCsvGeneratorService.cs
@@ -30,10 +30,10 @@ namespace OctoshiftCLI.AdoToGithub
                 var teamProjectCount = await _adoInspectorService.GetTeamProjectCount(org);
                 var repoCount = await _adoInspectorService.GetRepoCount(org);
                 var pipelineCount = await _adoInspectorService.GetPipelineCount(org);
-                var prCount = _adoInspectorService.GetPullRequestCount(org);
+                var prCount = await _adoInspectorService.GetPullRequestCount(org);
                 var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}";
 
-                result.AppendLine($"\"{org}\",\"{url}\",\"{owner}\",\"{teamProjectCount}\",\"{repoCount}\",\"{pipelineCount}\",\"{prCount}\"");
+                result.AppendLine($"\"{org}\",\"{url}\",\"{owner}\",{teamProjectCount},{repoCount},{pipelineCount},{prCount}");
             }
 
             return result.ToString();

--- a/src/ado2gh/Services/OrgsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/OrgsCsvGeneratorService.cs
@@ -7,16 +7,17 @@ namespace OctoshiftCLI.AdoToGithub
     public class OrgsCsvGeneratorService
     {
         private readonly AdoInspectorServiceFactory _adoInspectorServiceFactory;
+        private readonly AdoApiFactory _adoApiFactory;
 
-        public OrgsCsvGeneratorService(AdoInspectorServiceFactory adoInspectorServiceFactory) => _adoInspectorServiceFactory = adoInspectorServiceFactory;
-
-        public virtual async Task<string> Generate(AdoApi adoApi)
+        public OrgsCsvGeneratorService(AdoInspectorServiceFactory adoInspectorServiceFactory, AdoApiFactory adoApiFactory)
         {
-            if (adoApi is null)
-            {
-                throw new ArgumentNullException(nameof(adoApi));
-            }
+            _adoInspectorServiceFactory = adoInspectorServiceFactory;
+            _adoApiFactory = adoApiFactory;
+        }
 
+        public virtual async Task<string> Generate(string adoPat)
+        {
+            var adoApi = _adoApiFactory.Create(adoPat);
             var inspector = _adoInspectorServiceFactory.Create(adoApi);
             var result = new StringBuilder();
 

--- a/src/ado2gh/Services/OrgsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/OrgsCsvGeneratorService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -8,26 +7,36 @@ namespace OctoshiftCLI.AdoToGithub
 {
     public class OrgsCsvGeneratorService
     {
-        public virtual async Task<string> Generate(
-            AdoApi ado,
-            IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> pipelines)
+        private readonly AdoInspectorService _adoInspectorService;
+
+        public OrgsCsvGeneratorService(AdoInspectorService adoInspectorService)
         {
+            _adoInspectorService = adoInspectorService;
+        }
+
+        public virtual async Task<string> Generate(AdoApi adoApi)
+        {
+            if (adoApi is null)
+            {
+                throw new ArgumentNullException(nameof(adoApi));
+            }
+
             var result = new StringBuilder();
 
-            result.AppendLine("name,url,owner,teamproject-count,repo-count,pipeline-count");
+            result.AppendLine("name,url,owner,teamproject-count,repo-count,pipeline-count,pr-count");
 
-            if (ado != null && pipelines != null)
+            foreach (var org in await _adoInspectorService.GetOrgs())
             {
-                foreach (var org in pipelines.Keys)
-                {
-                    var owner = await ado.GetOrgOwner(org);
-                    var teamProjectCount = pipelines[org].Count;
-                    var repoCount = pipelines[org].Sum(tp => tp.Value.Count);
-                    var pipelineCount = pipelines[org].Sum(tp => tp.Value.Sum(repo => repo.Value.Count()));
-                    var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}";
+                var owner = await adoApi.GetOrgOwner(org);
+                var teamProjects = await _adoInspectorService.GetTeamProjects(org);
+                var teamProjectCount = teamProjects.Count();
+                var repoCount = teamProjects.SelectMany(tp => _adoInspectorService.GetRepos(org, tp).Result).Count();
+                var pipelineCount = teamProjects.SelectMany(tp => _adoInspectorService.GetRepos(org, tp).Result
+                                                                .SelectMany(r => _adoInspectorService.GetPipelines(org, tp, r).Result)).Count();
+                var prCount = teamProjects.Sum(tp => _adoInspectorService.GetRepos(org, tp).Result.Sum(r => _adoInspectorService.GetPullRequestCount(org, tp, r).Result));
+                var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}";
 
-                    result.AppendLine($"{org},{url},{owner},{teamProjectCount},{repoCount},{pipelineCount}");
-                }
+                result.AppendLine($"\"{org}\",\"{url}\",\"{owner}\",\"{teamProjectCount}\",\"{repoCount}\",\"{pipelineCount}\",\"{prCount}\"");
             }
 
             return result.ToString();

--- a/src/ado2gh/Services/PipelinesCsvGeneratorService.cs
+++ b/src/ado2gh/Services/PipelinesCsvGeneratorService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -7,26 +6,35 @@ namespace OctoshiftCLI.AdoToGithub
 {
     public class PipelinesCsvGeneratorService
     {
-        public virtual async Task<string> Generate(AdoApi ado, IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> pipelines)
+        private readonly AdoInspectorService _adoInspectorService;
+
+        public PipelinesCsvGeneratorService(AdoInspectorService adoInspectorService)
         {
+            _adoInspectorService = adoInspectorService;
+        }
+
+        public virtual async Task<string> Generate(AdoApi adoApi)
+        {
+            if (adoApi is null)
+            {
+                throw new ArgumentNullException(nameof(adoApi));
+            }
+
             var result = new StringBuilder();
 
             result.AppendLine("org,teamproject,repo,pipeline,url");
 
-            if (ado != null & pipelines != null)
+            foreach (var org in await _adoInspectorService.GetOrgs())
             {
-                foreach (var org in pipelines.Keys)
+                foreach (var teamProject in await _adoInspectorService.GetTeamProjects(org))
                 {
-                    foreach (var teamProject in pipelines[org].Keys)
+                    foreach (var repo in await _adoInspectorService.GetRepos(org, teamProject))
                     {
-                        foreach (var repo in pipelines[org][teamProject].Keys)
+                        foreach (var pipeline in await _adoInspectorService.GetPipelines(org, teamProject, repo))
                         {
-                            foreach (var pipeline in pipelines[org][teamProject][repo])
-                            {
-                                var pipelineId = await ado.GetPipelineId(org, teamProject, pipeline);
-                                var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}/_build?definitionId={pipelineId}";
-                                result.AppendLine($"{org},{teamProject},{repo},{pipeline},{url}");
-                            }
+                            var pipelineId = await adoApi.GetPipelineId(org, teamProject, pipeline);
+                            var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}/_build?definitionId={pipelineId}";
+                            result.AppendLine($"\"{org}\",\"{teamProject}\",\"{repo}\",\"{pipeline}\",\"{url}\"");
                         }
                     }
                 }

--- a/src/ado2gh/Services/PipelinesCsvGeneratorService.cs
+++ b/src/ado2gh/Services/PipelinesCsvGeneratorService.cs
@@ -7,16 +7,17 @@ namespace OctoshiftCLI.AdoToGithub
     public class PipelinesCsvGeneratorService
     {
         private readonly AdoInspectorServiceFactory _adoInspectorServiceFactory;
+        private readonly AdoApiFactory _adoApiFactory;
 
-        public PipelinesCsvGeneratorService(AdoInspectorServiceFactory adoInspectorServiceFactory) => _adoInspectorServiceFactory = adoInspectorServiceFactory;
-
-        public virtual async Task<string> Generate(AdoApi adoApi)
+        public PipelinesCsvGeneratorService(AdoInspectorServiceFactory adoInspectorServiceFactory, AdoApiFactory adoApiFactory)
         {
-            if (adoApi is null)
-            {
-                throw new ArgumentNullException(nameof(adoApi));
-            }
+            _adoInspectorServiceFactory = adoInspectorServiceFactory;
+            _adoApiFactory = adoApiFactory;
+        }
 
+        public virtual async Task<string> Generate(string adoPat)
+        {
+            var adoApi = _adoApiFactory.Create(adoPat);
             var inspector = _adoInspectorServiceFactory.Create(adoApi);
             var result = new StringBuilder();
 

--- a/src/ado2gh/Services/ReposCsvGeneratorService.cs
+++ b/src/ado2gh/Services/ReposCsvGeneratorService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/src/ado2gh/Services/ReposCsvGeneratorService.cs
+++ b/src/ado2gh/Services/ReposCsvGeneratorService.cs
@@ -7,16 +7,17 @@ namespace OctoshiftCLI.AdoToGithub
     public class ReposCsvGeneratorService
     {
         private readonly AdoInspectorServiceFactory _adoInspectorServiceFactory;
+        private readonly AdoApiFactory _adoApiFactory;
 
-        public ReposCsvGeneratorService(AdoInspectorServiceFactory adoInspectorServiceFactory) => _adoInspectorServiceFactory = adoInspectorServiceFactory;
-
-        public virtual async Task<string> Generate(AdoApi adoApi)
+        public ReposCsvGeneratorService(AdoInspectorServiceFactory adoInspectorServiceFactory, AdoApiFactory adoApiFactory)
         {
-            if (adoApi is null)
-            {
-                throw new ArgumentNullException(nameof(adoApi));
-            }
+            _adoInspectorServiceFactory = adoInspectorServiceFactory;
+            _adoApiFactory = adoApiFactory;
+        }
 
+        public virtual async Task<string> Generate(string adoPat)
+        {
+            var adoApi = _adoApiFactory.Create(adoPat);
             var inspector = _adoInspectorServiceFactory.Create(adoApi);
             var result = new StringBuilder();
 

--- a/src/ado2gh/Services/ReposCsvGeneratorService.cs
+++ b/src/ado2gh/Services/ReposCsvGeneratorService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -8,26 +7,35 @@ namespace OctoshiftCLI.AdoToGithub
 {
     public class ReposCsvGeneratorService
     {
-        public virtual async Task<string> Generate(AdoApi ado, IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> pipelines)
+        private readonly AdoInspectorService _adoInspectorService;
+
+        public ReposCsvGeneratorService(AdoInspectorService adoInspectorService)
         {
+            _adoInspectorService = adoInspectorService;
+        }
+
+        public virtual async Task<string> Generate(AdoApi adoApi)
+        {
+            if (adoApi is null)
+            {
+                throw new ArgumentNullException(nameof(adoApi));
+            }
+
             var result = new StringBuilder();
 
             result.AppendLine("org,teamproject,repo,url,pipeline-count,pr-count");
 
-            if (ado != null && pipelines != null)
+            foreach (var org in await _adoInspectorService.GetOrgs())
             {
-                foreach (var org in pipelines.Keys)
+                foreach (var teamProject in await _adoInspectorService.GetTeamProjects(org))
                 {
-                    foreach (var teamProject in pipelines[org].Keys)
+                    foreach (var repo in await _adoInspectorService.GetRepos(org, teamProject))
                     {
-                        foreach (var repo in pipelines[org][teamProject].Keys)
-                        {
-                            var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}/_git/{Uri.EscapeDataString(repo)}";
-                            var pipelineCount = pipelines[org][teamProject][repo].Count();
-                            var prCount = await ado.GetPullRequestCount(org, teamProject, repo);
+                        var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}/_git/{Uri.EscapeDataString(repo)}";
+                        var pipelineCount = (await _adoInspectorService.GetPipelines(org, teamProject, repo)).Count();
+                        var prCount = await _adoInspectorService.GetPullRequestCount(org, teamProject, repo);
 
-                            result.AppendLine($"{org},{teamProject},{repo},{url},{pipelineCount},{prCount}");
-                        }
+                        result.AppendLine($"\"{org}\",\"{teamProject}\",\"{repo}\",\"{url}\",\"{pipelineCount}\",\"{prCount}\"");
                     }
                 }
             }

--- a/src/ado2gh/Services/ReposCsvGeneratorService.cs
+++ b/src/ado2gh/Services/ReposCsvGeneratorService.cs
@@ -34,7 +34,7 @@ namespace OctoshiftCLI.AdoToGithub
                         var pipelineCount = await _adoInspectorService.GetPipelineCount(org, teamProject, repo);
                         var prCount = await _adoInspectorService.GetPullRequestCount(org, teamProject, repo);
 
-                        result.AppendLine($"\"{org}\",\"{teamProject}\",\"{repo}\",\"{url}\",\"{pipelineCount}\",\"{prCount}\"");
+                        result.AppendLine($"\"{org}\",\"{teamProject}\",\"{repo}\",\"{url}\",{pipelineCount},{prCount}");
                     }
                 }
             }

--- a/src/ado2gh/Services/ReposCsvGeneratorService.cs
+++ b/src/ado2gh/Services/ReposCsvGeneratorService.cs
@@ -32,7 +32,7 @@ namespace OctoshiftCLI.AdoToGithub
                     foreach (var repo in await _adoInspectorService.GetRepos(org, teamProject))
                     {
                         var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}/_git/{Uri.EscapeDataString(repo)}";
-                        var pipelineCount = (await _adoInspectorService.GetPipelines(org, teamProject, repo)).Count();
+                        var pipelineCount = await _adoInspectorService.GetPipelineCount(org, teamProject, repo);
                         var prCount = await _adoInspectorService.GetPullRequestCount(org, teamProject, repo);
 
                         result.AppendLine($"\"{org}\",\"{teamProject}\",\"{repo}\",\"{url}\",\"{pipelineCount}\",\"{prCount}\"");

--- a/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
@@ -29,10 +29,9 @@ namespace OctoshiftCLI.AdoToGithub
             {
                 foreach (var teamProject in await _adoInspectorService.GetTeamProjects(org))
                 {
-                    var repos = await _adoInspectorService.GetRepos(org, teamProject);
-                    var repoCount = repos.Count();
-                    var pipelineCount = repos.SelectMany(r => _adoInspectorService.GetPipelines(org, teamProject, r).Result).Count();
-                    var prCount = repos.Sum(r => _adoInspectorService.GetPullRequestCount(org, teamProject, r).Result);
+                    var repoCount = await _adoInspectorService.GetRepoCount(org, teamProject);
+                    var pipelineCount = _adoInspectorService.GetPipelineCount(org, teamProject);
+                    var prCount = _adoInspectorService.GetPullRequestCount(org, teamProject);
                     var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}";
                     result.AppendLine($"\"{org}\",\"{teamProject}\",\"{url}\",\"{repoCount}\",\"{pipelineCount}\",\"{prCount}\"");
                 }

--- a/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
@@ -7,16 +7,17 @@ namespace OctoshiftCLI.AdoToGithub
     public class TeamProjectsCsvGeneratorService
     {
         private readonly AdoInspectorServiceFactory _adoInspectorServiceFactory;
+        private readonly AdoApiFactory _adoApiFactory;
 
-        public TeamProjectsCsvGeneratorService(AdoInspectorServiceFactory adoInspectorServiceFactory) => _adoInspectorServiceFactory = adoInspectorServiceFactory;
-
-        public virtual async Task<string> Generate(AdoApi adoApi)
+        public TeamProjectsCsvGeneratorService(AdoInspectorServiceFactory adoInspectorServiceFactory, AdoApiFactory adoApiFactory)
         {
-            if (adoApi is null)
-            {
-                throw new ArgumentNullException(nameof(adoApi));
-            }
+            _adoInspectorServiceFactory = adoInspectorServiceFactory;
+            _adoApiFactory = adoApiFactory;
+        }
 
+        public virtual async Task<string> Generate(string adoPat)
+        {
+            var adoApi = _adoApiFactory.Create(adoPat);
             var inspector = _adoInspectorServiceFactory.Create(adoApi);
             var result = new StringBuilder();
 

--- a/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
@@ -29,10 +29,10 @@ namespace OctoshiftCLI.AdoToGithub
                 foreach (var teamProject in await _adoInspectorService.GetTeamProjects(org))
                 {
                     var repoCount = await _adoInspectorService.GetRepoCount(org, teamProject);
-                    var pipelineCount = _adoInspectorService.GetPipelineCount(org, teamProject);
-                    var prCount = _adoInspectorService.GetPullRequestCount(org, teamProject);
+                    var pipelineCount = await _adoInspectorService.GetPipelineCount(org, teamProject);
+                    var prCount = await _adoInspectorService.GetPullRequestCount(org, teamProject);
                     var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}";
-                    result.AppendLine($"\"{org}\",\"{teamProject}\",\"{url}\",\"{repoCount}\",\"{pipelineCount}\",\"{prCount}\"");
+                    result.AppendLine($"\"{org}\",\"{teamProject}\",\"{url}\",{repoCount},{pipelineCount},{prCount}");
                 }
             }
 

--- a/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
+++ b/src/ado2gh/Services/TeamProjectsCsvGeneratorService.cs
@@ -6,12 +6,9 @@ namespace OctoshiftCLI.AdoToGithub
 {
     public class TeamProjectsCsvGeneratorService
     {
-        private readonly AdoInspectorService _adoInspectorService;
+        private readonly AdoInspectorServiceFactory _adoInspectorServiceFactory;
 
-        public TeamProjectsCsvGeneratorService(AdoInspectorService adoInspectorService)
-        {
-            _adoInspectorService = adoInspectorService;
-        }
+        public TeamProjectsCsvGeneratorService(AdoInspectorServiceFactory adoInspectorServiceFactory) => _adoInspectorServiceFactory = adoInspectorServiceFactory;
 
         public virtual async Task<string> Generate(AdoApi adoApi)
         {
@@ -20,17 +17,18 @@ namespace OctoshiftCLI.AdoToGithub
                 throw new ArgumentNullException(nameof(adoApi));
             }
 
+            var inspector = _adoInspectorServiceFactory.Create(adoApi);
             var result = new StringBuilder();
 
             result.AppendLine("org,teamproject,url,repo-count,pipeline-count,pr-count");
 
-            foreach (var org in await _adoInspectorService.GetOrgs())
+            foreach (var org in await inspector.GetOrgs())
             {
-                foreach (var teamProject in await _adoInspectorService.GetTeamProjects(org))
+                foreach (var teamProject in await inspector.GetTeamProjects(org))
                 {
-                    var repoCount = await _adoInspectorService.GetRepoCount(org, teamProject);
-                    var pipelineCount = await _adoInspectorService.GetPipelineCount(org, teamProject);
-                    var prCount = await _adoInspectorService.GetPullRequestCount(org, teamProject);
+                    var repoCount = await inspector.GetRepoCount(org, teamProject);
+                    var pipelineCount = await inspector.GetPipelineCount(org, teamProject);
+                    var prCount = await inspector.GetPullRequestCount(org, teamProject);
                     var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}";
                     result.AppendLine($"\"{org}\",\"{teamProject}\",\"{url}\",{repoCount},{pipelineCount},{prCount}");
                 }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Issue #317 

Refactored AdoInspectorService to handle caching of the results, and only return simple lists of strings.

This makes it easier to consume without the consumers having to worry about not duplicating API calls and being inefficient about retrieving the same data multiple times.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->