### PR TITLE
Optimize repo exists check

### DIFF
--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -97,6 +97,21 @@ namespace OctoshiftCLI
             return await _client.GetAllAsync(url).Select(x => (string)x["name"]).ToListAsync();
         }
 
+        public virtual async Task<bool> RepoExists(string org, string repo)
+        {
+            var url = $"{_apiUrl}/repos/{org}/{repo}";
+
+            try
+            {
+                await _client.GetAsync(url);
+                return true;
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.NotFound)
+            {
+                return false;
+            }
+        }
+
         public virtual async Task RemoveTeamMember(string org, string teamSlug, string member)
         {
             var url = $"{_apiUrl}/orgs/{org}/teams/{teamSlug}/memberships/{member}";

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -141,7 +141,7 @@ namespace OctoshiftCLI
             }
             else if (response.StatusCode != status)
             {
-                throw new HttpRequestException($"Expected status code {status} but got {response.StatusCode}");
+                throw new HttpRequestException($"Expected status code {status} but got {response.StatusCode}", null, response.StatusCode);
             }
 
             return (content, response.Headers.ToArray());

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
@@ -58,7 +58,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         public async Task Happy_Path()
         {
             // Arrange
-            _mockGithubApi.Setup(x => x.GetRepos(GITHUB_ORG).Result).Returns(new List<string>());
+            _mockGithubApi.Setup(x => x.RepoExists(GITHUB_ORG, GITHUB_REPO).Result).Returns(false);
             _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
             _mockGithubApi.Setup(x => x.CreateAdoMigrationSource(GITHUB_ORG_ID, null).Result).Returns(MIGRATION_SOURCE_ID);
             _mockGithubApi
@@ -102,7 +102,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await _command.Invoke(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO, GITHUB_ORG, GITHUB_REPO, wait: false);
 
             // Assert
-            _mockGithubApi.Verify(m => m.GetRepos(GITHUB_ORG));
+            _mockGithubApi.Verify(m => m.RepoExists(GITHUB_ORG, GITHUB_REPO));
             _mockGithubApi.Verify(m => m.GetOrganizationId(GITHUB_ORG));
             _mockGithubApi.Verify(m => m.CreateAdoMigrationSource(GITHUB_ORG_ID, null));
             _mockGithubApi.Verify(m => m.StartMigration(MIGRATION_SOURCE_ID, ADO_REPO_URL, GITHUB_ORG_ID, GITHUB_REPO, ADO_TOKEN, GITHUB_TOKEN, null, null, false));
@@ -118,9 +118,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         public async Task Idempotency_Stop_If_Target_Exists()
         {
             // Arrange
-            var githubRepos = new List<string> { GITHUB_REPO };
-
-            _mockGithubApi.Setup(x => x.GetRepos(GITHUB_ORG).Result).Returns(githubRepos);
+            _mockGithubApi.Setup(x => x.RepoExists(GITHUB_ORG, GITHUB_REPO).Result).Returns(true);
             _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
 
             _mockEnvironmentVariableProvider
@@ -140,7 +138,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             await _command.Invoke(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO, GITHUB_ORG, GITHUB_REPO, wait: false);
 
             // Assert
-            _mockGithubApi.Verify(m => m.GetRepos(GITHUB_ORG));
+            _mockGithubApi.Verify(m => m.RepoExists(GITHUB_ORG, GITHUB_REPO));
 
             _mockOctoLogger.Verify(m => m.LogWarning(It.IsAny<string>()), Times.Exactly(1));
             actualLogOutput.Should().Contain(expectedLogOutput);

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -141,7 +141,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var targetGithubPat = Guid.NewGuid().ToString();
             var githubRepoUrl = $"https://github.com/{SOURCE_ORG}/{SOURCE_REPO}";
             var migrationId = Guid.NewGuid().ToString();
-            var githubRepos = new List<string> { TARGET_REPO };
 
             _mockGithubApi.Setup(x => x.RepoExists(TARGET_ORG, TARGET_REPO).Result).Returns(true);
             _mockGithubApi.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, "", "", false).Result).Returns(migrationId);

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -82,7 +82,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var githubRepoUrl = $"https://github.com/{SOURCE_ORG}/{SOURCE_REPO}";
             var migrationId = Guid.NewGuid().ToString();
 
-            _mockGithubApi.Setup(x => x.GetRepos(TARGET_ORG).Result).Returns(new List<string>());
+            _mockGithubApi.Setup(x => x.RepoExists(TARGET_ORG, TARGET_REPO).Result).Returns(false);
             _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             _mockGithubApi.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
             _mockGithubApi.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false).Result).Returns(migrationId);
@@ -119,7 +119,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await _command.Invoke(args);
 
             // Assert
-            _mockGithubApi.Verify(m => m.GetRepos(TARGET_ORG));
+            _mockGithubApi.Verify(m => m.RepoExists(TARGET_ORG, TARGET_REPO));
             _mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG));
             _mockGithubApi.Verify(m => m.CreateGhecMigrationSource(githubOrgId));
             _mockGithubApi.Verify(m => m.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false));
@@ -143,7 +143,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var migrationId = Guid.NewGuid().ToString();
             var githubRepos = new List<string> { TARGET_REPO };
 
-            _mockGithubApi.Setup(x => x.GetRepos(TARGET_ORG).Result).Returns(githubRepos);
+            _mockGithubApi.Setup(x => x.RepoExists(TARGET_ORG, TARGET_REPO).Result).Returns(true);
             _mockGithubApi.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, "", "", false).Result).Returns(migrationId);
 
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken()).Returns(sourceGithubPat);
@@ -170,7 +170,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await _command.Invoke(args);
 
             // Assert
-            _mockGithubApi.Verify(m => m.GetRepos(TARGET_ORG));
+            _mockGithubApi.Verify(m => m.RepoExists(TARGET_ORG, TARGET_REPO));
 
             _mockOctoLogger.Verify(m => m.LogWarning(It.IsAny<string>()), Times.Exactly(1));
             actualLogOutput.Should().Contain(expectedLogWarningOutput);

--- a/src/ado2gh/Commands/MigrateRepoCommand.cs
+++ b/src/ado2gh/Commands/MigrateRepoCommand.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace OctoshiftCLI.AdoToGithub.Commands
@@ -112,7 +111,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             githubPat ??= _environmentVariableProvider.GithubPersonalAccessToken();
             var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
-            if (await RepoExists(githubApi, githubOrg, githubRepo))
+            if (await githubApi.RepoExists(githubOrg, githubRepo))
             {
                 _log.LogWarning($"The Org '{githubOrg}' already contains a repository with the name '{githubRepo}'. No operation will be performed");
                 return;
@@ -149,12 +148,6 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             }
 
             _log.LogSuccess($"Migration completed (ID: {migrationId})! State: {migrationState}");
-        }
-
-        private async Task<bool> RepoExists(GithubApi githubApi, string org, string repo)
-        {
-            var repos = await githubApi.GetRepos(org);
-            return repos.Contains(repo, StringComparer.OrdinalIgnoreCase);
         }
 
         private string GetAdoRepoUrl(string org, string project, string repo) => $"https://dev.azure.com/{org}/{project}/_git/{repo}".Replace(" ", "%20");

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using OctoshiftCLI.Extensions;
@@ -190,7 +189,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             var githubApi = _targetGithubApiFactory.Create(args.TargetApiUrl, args.GithubTargetPat);
 
-            if (await RepoExists(githubApi, args.GithubTargetOrg, args.TargetRepo))
+            if (await githubApi.RepoExists(args.GithubTargetOrg, args.TargetRepo))
             {
                 _log.LogWarning($"The Org '{args.GithubTargetOrg}' already contains a repository with the name '{args.TargetRepo}'. No operation will be performed");
                 return;
@@ -239,12 +238,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             }
 
             _log.LogSuccess($"Migration completed (ID: {migrationId})! State: {migrationState}");
-        }
-
-        private async Task<bool> RepoExists(GithubApi githubApi, string org, string repo)
-        {
-            var repos = await githubApi.GetRepos(org);
-            return repos.Contains(repo, StringComparer.OrdinalIgnoreCase);
         }
 
         private string GetSourceToken(MigrateRepoCommandArgs args) =>


### PR DESCRIPTION
Closes #378 

Our repo exists logic was not efficient since it was using `GithubApi#GetRepos` to find out if a repo exists. Since the GitHub's REST api already has a [get repo](https://docs.github.com/en/rest/repos/repos#get-a-repository) endpoint, we just need to call it and if it returns `200` status code it means that the repo exists and if it returns `404` it means that it doesn't exist. 

_NOTE:_ There is a caveat here that is if the PAT is not SSO enabled for and org the get repo call will return 404, so we need to make sure that the PAT is SSO enabled for the org.   

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
