### PR TITLE
Log azure storage connection string when provided

### DIFF
--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -321,7 +321,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         }
 
         [Fact]
-        public async Task Happy_Path_GithubSource_GHES()
+        public async Task Happy_Path_GithubSource_Ghes()
         {
             var githubOrgId = Guid.NewGuid().ToString();
             var migrationSourceId = Guid.NewGuid().ToString();
@@ -390,6 +390,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await _command.Invoke(args);
 
             _mockGithubApi.Verify(x => x.GetMigrationState(migrationId));
+            _mockOctoLogger.Verify(x => x.LogInformation($"GHES API URL: {GHES_API_URL}"), Times.Once);
+            _mockOctoLogger.Verify(x => x.LogInformation($"AZURE STORAGE CONNECTION STRING: {AZURE_CONNECTION_STRING}"), Times.Once);
         }
 
         [Fact]
@@ -708,6 +710,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             _mockAzureApiFactory.Verify(x => x.CreateClientNoSsl(AZURE_CONNECTION_STRING));
             _mockGithubApi.Verify(x => x.GetMigrationState(migrationId));
+            _mockOctoLogger.Verify(x => x.LogInformation("SSL verification disabled"));
         }
 
         [Fact]

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -288,6 +288,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                     throw new OctoshiftCliException("Please set either --azure-storage-connection-string or AZURE_STORAGE_CONNECTION_STRING");
                 }
             }
+            else
+            {
+                _log.LogInformation($"AZURE STORAGE CONNECTION STRING: {azureStorageConnectionString}");
+            }
 
             if (noSslVerify)
             {


### PR DESCRIPTION
Fixes #412 

Logging the Azure storage connection string in the `gh-gei`'s `migrate-repo` command.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
