### PR TITLE
Log GitHub request id header

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Log GitHub request id into the verbose log for each GitHub API call.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-- Log GitHub request id into the verbose log for each GitHub API call.
+- Log GitHub request id into the verbose log for each GitHub API call (this can be useful for GitHub support if something goes wrong)

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -132,6 +132,7 @@ namespace OctoshiftCLI
                 "PATCH" => await _httpClient.PatchAsync(url, payload),
                 _ => throw new ArgumentOutOfRangeException($"{httpMethod} is not supported.")
             };
+            _log.LogVerbose($"GITHUB REQUEST ID: {ExtractHeaderValue("X-GitHub-Request-Id", response.Headers)}");
             var content = await response.Content.ReadAsStringAsync();
             _log.LogVerbose($"RESPONSE ({response.StatusCode}): {content}");
 
@@ -166,7 +167,10 @@ namespace OctoshiftCLI
             return nextUrl;
         }
 
-        private string ExtractLinkHeader(KeyValuePair<string, IEnumerable<string>>[] headers) =>
-            headers.SingleOrDefault(kvp => kvp.Key == "Link").Value?.FirstOrDefault();
+        private string ExtractLinkHeader(IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers) =>
+            ExtractHeaderValue("Link", headers);
+
+        private string ExtractHeaderValue(string key, IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers) =>
+            headers.SingleOrDefault(kvp => kvp.Key.Equals(key, StringComparison.OrdinalIgnoreCase)).Value?.FirstOrDefault();
     }
 }

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -93,6 +93,26 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task GetAsync_Logs_The_GitHub_Request_Id_Header_Value()
+        {
+            // Arrange
+            using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            const string githubRequestId = "123-456-789";
+            _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
+
+            const string expectedLogMessage = $"GITHUB REQUEST ID: {githubRequestId}";
+
+            // Act
+            await githubClient.GetAsync("http://example.com");
+
+            // Assert
+            _mockOctoLogger.Verify(m =>
+                m.LogVerbose(It.Is<string>(actualLogMessage => actualLogMessage == expectedLogMessage)));
+        }
+
+        [Fact]
         public async Task GetAsync_Logs_The_Response_Status_Code_And_Content()
         {
             // Arrange
@@ -182,6 +202,26 @@ namespace OctoshiftCLI.Tests
 
             // Act
             await githubClient.PostAsync(url, _rawRequestBody);
+
+            // Assert
+            _mockOctoLogger.Verify(m =>
+                m.LogVerbose(It.Is<string>(actualLogMessage => actualLogMessage == expectedLogMessage)));
+        }
+
+        [Fact]
+        public async Task PostAsync_Logs_The_GitHub_Request_Id_Header_Value()
+        {
+            // Arrange
+            using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            const string githubRequestId = "123-456-789";
+            _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
+
+            const string expectedLogMessage = $"GITHUB REQUEST ID: {githubRequestId}";
+
+            // Act
+            await githubClient.PostAsync("http://example.com", _rawRequestBody);
 
             // Assert
             _mockOctoLogger.Verify(m =>
@@ -307,6 +347,26 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task PutAsync_Logs_The_GitHub_Request_Id_Header_Value()
+        {
+            // Arrange
+            using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            const string githubRequestId = "123-456-789";
+            _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
+
+            const string expectedLogMessage = $"GITHUB REQUEST ID: {githubRequestId}";
+
+            // Act
+            await githubClient.PutAsync("http://example.com", _rawRequestBody);
+
+            // Assert
+            _mockOctoLogger.Verify(m =>
+                m.LogVerbose(It.Is<string>(actualLogMessage => actualLogMessage == expectedLogMessage)));
+        }
+
+        [Fact]
         public async Task PutAsync_Logs_The_Request_Body()
         {
             // Arrange
@@ -418,6 +478,26 @@ namespace OctoshiftCLI.Tests
 
             // Act
             await githubClient.PatchAsync(url, _rawRequestBody);
+
+            // Assert
+            _mockOctoLogger.Verify(m =>
+                m.LogVerbose(It.Is<string>(actualLogMessage => actualLogMessage == expectedLogMessage)));
+        }
+
+        [Fact]
+        public async Task PatchAsync_Logs_The_GitHub_Request_Id_Header_Value()
+        {
+            // Arrange
+            using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            const string githubRequestId = "123-456-789";
+            _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
+
+            const string expectedLogMessage = $"GITHUB REQUEST ID: {githubRequestId}";
+
+            // Act
+            await githubClient.PatchAsync("http://example.com", _rawRequestBody);
 
             // Assert
             _mockOctoLogger.Verify(m =>
@@ -543,6 +623,26 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task DeleteAsync_Logs_The_GitHub_Request_Id_Header_Value()
+        {
+            // Arrange
+            using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            const string githubRequestId = "123-456-789";
+            _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
+
+            const string expectedLogMessage = $"GITHUB REQUEST ID: {githubRequestId}";
+
+            // Act
+            await githubClient.DeleteAsync("http://example.com");
+
+            // Assert
+            _mockOctoLogger.Verify(m =>
+                m.LogVerbose(It.Is<string>(actualLogMessage => actualLogMessage == expectedLogMessage)));
+        }
+
+        [Fact]
         public async Task GetNonSuccessAsync_Is_Unsuccessful()
         {
             // Arrange
@@ -586,6 +686,25 @@ namespace OctoshiftCLI.Tests
 
             // Assert
             // If it doesn't crash, we are good
+        }
+
+        [Fact]
+        public async Task GetNonSuccessAsync_Logs_The_GitHub_Request_Id_Header_Value()
+        {
+            // Arrange
+            using var httpResponse = new HttpResponseMessage(HttpStatusCode.Moved);
+            const string githubRequestId = "123-456-789";
+            httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
+            var handlerMock = MockHttpHandler(req => req.Method == HttpMethod.Get, httpResponse);
+
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            // Act
+            await githubClient.GetNonSuccessAsync("http://example.com", HttpStatusCode.Moved);
+
+            // Assert
+            _mockOctoLogger.Verify(m => m.LogVerbose($"GITHUB REQUEST ID: {githubRequestId}"));
         }
 
         [Fact]
@@ -764,6 +883,56 @@ namespace OctoshiftCLI.Tests
             // Assert
             _mockOctoLogger.Verify(m => m.LogVerbose(It.Is<string>(actual => actual == $"HTTP GET: {url}")));
             _mockOctoLogger.Verify(m => m.LogVerbose(It.Is<string>(actual => actual == $"HTTP GET: {url}&page=2")));
+        }
+
+        [Fact]
+        public async Task GetAllAsync_Logs_The_GitHub_Request_Id_Header_Value_Per_Each_Page_Request()
+        {
+            // Arrange
+            const string url = "https://example.com/resource";
+
+            using var firstResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[\"first\"]"),
+            };
+            firstResponse.Headers.Add("Link", new[]
+            {
+                $"<{url}&page=2>; rel=\"next\", " +
+                $"<{url}&page=2>; rel=\"last\""
+            });
+            const string firstGithubRequestId = "123-456";
+            firstResponse.Headers.Add("X-GitHub-Request-Id", firstGithubRequestId);
+
+            using var secondResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[\"second\"]"),
+            };
+            const string secondGithubRequestId = "456-789";
+            secondResponse.Headers.Add("X-GitHub-Request-Id", secondGithubRequestId);
+
+            var handlerMock = new Mock<HttpMessageHandler>();
+
+            // first request
+            MockHttpHandler(
+                req => req.Method == HttpMethod.Get && req.RequestUri.ToString() == url,
+                firstResponse,
+                handlerMock);
+
+            // second request
+            MockHttpHandler(
+                req => req.Method == HttpMethod.Get && req.RequestUri.ToString() == $"{url}&page=2",
+                secondResponse,
+                handlerMock);
+
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            // Act
+            await foreach (var _ in githubClient.GetAllAsync(url)) { }
+
+            // Assert
+            _mockOctoLogger.Verify(m => m.LogVerbose(It.Is<string>(actual => actual == $"GITHUB REQUEST ID: {firstGithubRequestId}")));
+            _mockOctoLogger.Verify(m => m.LogVerbose(It.Is<string>(actual => actual == $"GITHUB REQUEST ID: {secondGithubRequestId}")));
         }
 
         [Fact]
@@ -1436,6 +1605,89 @@ query($id: ID!, $first: Int, $after: String) {
                 .Should()
                 .ThrowAsync<ArgumentNullException>()
                 .WithParameterName("pageInfoSelector");
+        }
+
+        [Fact]
+        public async Task PostGraphQLWithPaginationAsync_Logs_The_GitHub_Request_Id_Header_Value_Per_Each_Page()
+        {
+            // Arrange
+            const string url = "https://example.com/graphql";
+            const string orgId = "ORG_ID";
+            const string query = "QUERY";
+
+            // first request/response
+            var firstRequestVariables = new { id = orgId, first = 2, after = (string)null };
+            var firstRequestBody = new { query, variables = firstRequestVariables };
+            var firstResponseEndCursor = Guid.NewGuid().ToString();
+            var firstResponseContent = new
+            {
+                data = new
+                {
+                    node = new
+                    {
+                        repositoryMigrations = new
+                        {
+                            pageInfo = new { endCursor = firstResponseEndCursor, hasNextPage = true },
+                            nodes = new[] { 1, 2 }
+                        }
+                    }
+                }
+            };
+            using var firstResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(firstResponseContent.ToJson())
+            };
+            const string firstGithubRequestId = "123-456";
+            firstResponse.Headers.Add("X-GitHub-Request-Id", firstGithubRequestId);
+
+            // second request/response
+            var secondRequestVariables = new { id = orgId, first = 2, after = firstResponseEndCursor };
+            var secondResponseEndCursor = Guid.NewGuid().ToString();
+            var secondResponseContent = new
+            {
+                data = new
+                {
+                    node = new
+                    {
+                        repositoryMigrations = new
+                        {
+                            pageInfo = new { endCursor = secondResponseEndCursor, hasNextPage = false },
+                            nodes = new[] { 3, 4 }
+                        }
+                    }
+                }
+            };
+            using var secondResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(secondResponseContent.ToJson())
+            };
+            const string secondGithubRequestId = "456-789";
+            secondResponse.Headers.Add("X-GitHub-Request-Id", secondGithubRequestId);
+            var secondRequestBody = new { query, variables = secondRequestVariables };
+
+            var handlerMock = MockHttpHandler(
+                req => req.Method == HttpMethod.Post && req.RequestUri.ToString() == url && req.Content.ReadAsStringAsync().Result == firstRequestBody.ToJson(),
+                firstResponse); // first request
+            MockHttpHandler(
+                req => req.Method == HttpMethod.Post && req.RequestUri.ToString() == url && req.Content.ReadAsStringAsync().Result == secondRequestBody.ToJson(),
+                secondResponse,
+                handlerMock); // second request
+
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            // Act
+            _ = await githubClient.PostGraphQLWithPaginationAsync(
+                    url,
+                    firstRequestBody,
+                    obj => (JArray)obj["data"]["node"]["repositoryMigrations"]["nodes"],
+                    obj => (JObject)obj["data"]["node"]["repositoryMigrations"]["pageInfo"],
+                    2)
+                .ToListAsync();
+
+            // Assert
+            _mockOctoLogger.Verify(m => m.LogVerbose($"GITHUB REQUEST ID: {firstGithubRequestId}"));
+            _mockOctoLogger.Verify(m => m.LogVerbose($"GITHUB REQUEST ID: {secondGithubRequestId}"));
         }
 
         [Fact]


### PR DESCRIPTION
Closes #256 

In order to be able to trace GitHub API requests we need to log the `X-GitHub-Request-Id` header that is being send as part of all GitHub API call responses.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
