### PR TITLE
Add .projections.json to support alternate files

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -1,0 +1,25 @@
+{
+  "src/Octoshift/*.cs": {
+    "alternate": "src/OctoshiftCLI.Tests/{}Tests.cs"
+  },
+
+  "src/OctoshiftCLI.Tests/*Tests.cs": {
+    "alternate": "src/Octoshift/{}.cs"
+  },
+
+  "src/gei/*.cs": {
+    "alternate": "src/OctoshiftCLI.Tests/gei/{}Tests.cs"
+  },
+
+  "src/OctoshiftCLI.Tests/gei/*Tests.cs": {
+    "alternate": "src/gei/{}.cs"
+  },
+
+  "src/ado2gh/*.cs": {
+    "alternate": "src/OctoshiftCLI.Tests/ado2gh/{}Tests.cs"
+  },
+
+  "src/OctoshiftCLI.Tests/ado2gh/*Tests.cs": {
+    "alternate": "src/ado2gh/{}.cs"
+  }
+}


### PR DESCRIPTION
Closes https://github.com/github/gh-gei/issues/432!

This PR adds `.projections.json` to configure alternate files.  This allows us to easily switch between functional code and their tests.

From the the related issue:

> If we add a `.projections.json` file, we can quickly and easily switch between functional code and its tests.  This file and its contents are well-supported, and works in many editors:
> 
> - VS Code: https://marketplace.visualstudio.com/items?itemName=will-wow.vscode-alternate-file
> - Vim: https://github.com/tpope/vim-projectionist
> 
> Here's an example of this configuration at work with VS Code:
> 
> ![vscode-alternate-file](https://user-images.githubusercontent.com/820984/172441798-8e6ebe42-c00c-4e32-92d2-abd35ef73255.gif)

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] ~~Did you write/update appropriate tests~~ (n/a)
- [ ] ~~Release notes updated (if appropriate)~~ (n/a)
- [ ] ~~Appropriate logging output~~ (n/a)
- [x] Issue linked
- [ ] ~~Docs updated (or issue created)~~ (n/a)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->