### PR TITLE
Skip releases for ghes

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Support excluding releases when `--skip-releases` flag is provided in `gh gei migrate-repo` command for GHES migration path.

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -484,7 +484,7 @@ namespace OctoshiftCLI
             return (int)data["id"];
         }
 
-        public virtual async Task<int> StartMetadataArchiveGeneration(string org, string repo)
+        public virtual async Task<int> StartMetadataArchiveGeneration(string org, string repo, bool skipReleases)
         {
             var url = $"{_apiUrl}/orgs/{org}/migrations";
 
@@ -492,7 +492,7 @@ namespace OctoshiftCLI
             {
                 repositories = new[] { repo },
                 exclude_git_data = true,
-                exclude_releases = true,
+                exclude_releases = skipReleases,
                 exclude_owner_projects = true
             };
 

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -1597,6 +1597,79 @@ namespace OctoshiftCLI.Tests
                 .ThrowAsync<InvalidOperationException>();
         }
 
+        [Fact]
+        public async Task StartMetadataArchiveGeneration_Returns_The_Initiated_Migration_Id()
+        {
+            // Arrange
+            const string url = $"https://api.github.com/orgs/{GITHUB_ORG}/migrations";
+            var payload = new
+            {
+                repositories = new[] { GITHUB_REPO },
+                exclude_git_data = true,
+                exclude_releases = false,
+                exclude_owner_projects = true
+            };
+            const int expectedMigrationId = 1;
+            var response = new { id = expectedMigrationId };
+
+            _githubClientMock
+                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())))
+                .ReturnsAsync(response.ToJson());
+
+            // Act
+            var actualMigrationId = await _githubApi.StartMetadataArchiveGeneration(GITHUB_ORG, GITHUB_REPO, false);
+
+            // Assert
+            actualMigrationId.Should().Be(expectedMigrationId);
+        }
+
+        [Fact]
+        public async Task StartMetadataArchiveGeneration_Excludes_Releases_When_Skip_Releases_Is_True()
+        {
+            // Arrange
+            const string url = $"https://api.github.com/orgs/{GITHUB_ORG}/migrations";
+            var payload = new
+            {
+                repositories = new[] { GITHUB_REPO },
+                exclude_git_data = true,
+                exclude_releases = true,
+                exclude_owner_projects = true
+            };
+            var response = new { id = 1 };
+
+            _githubClientMock.Setup(m => m.PostAsync(url, It.IsAny<object>())).ReturnsAsync(response.ToJson());
+
+            // Act
+            await _githubApi.StartMetadataArchiveGeneration(GITHUB_ORG, GITHUB_REPO, true);
+
+            // Assert
+            _githubClientMock.Verify(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
+        }
+
+        [Fact]
+        public async Task StartGitArchiveGeneration_Returns_The_Initiated_Migration_Id()
+        {
+            // Arrange
+            const string url = $"https://api.github.com/orgs/{GITHUB_ORG}/migrations";
+            var payload = new
+            {
+                repositories = new[] { GITHUB_REPO },
+                exclude_metadata = true
+            };
+            const int expectedMigrationId = 1;
+            var response = new { id = expectedMigrationId };
+
+            _githubClientMock
+                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())))
+                .ReturnsAsync(response.ToJson());
+
+            // Act
+            var actualMigrationId = await _githubApi.StartGitArchiveGeneration(GITHUB_ORG, GITHUB_REPO);
+
+            // Assert
+            actualMigrationId.Should().Be(expectedMigrationId);
+        }
+
         private string Compact(string source) =>
             source
                 .Replace("\r", "")

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -356,7 +356,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             _mockGithubApi.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
             _mockGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
@@ -604,7 +604,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             _mockGithubApi.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
             _mockGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
@@ -676,7 +676,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             _mockGithubApi.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
             _mockGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
@@ -720,7 +720,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var metadataArchiveId = 2;
 
             _mockGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Failed);
 
             _mockSourceGithubApiFactory.Setup(m => m.Create(GHES_API_URL, It.IsAny<string>())).Returns(_mockGithubApi.Object);
@@ -948,6 +948,37 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 true));
+        }
+
+        [Fact]
+        public async Task It_Skips_Releases_When_Option_Is_True_For_Ghes_Migration_Path()
+        {
+            // Arrange
+            _mockGithubApi.Setup(m => m.GetArchiveMigrationStatus(It.IsAny<string>(), It.IsAny<int>()).Result).Returns(ArchiveMigrationStatus.Exported);
+
+            _mockSourceGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
+            _mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
+            _mockAzureApiFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(_mockAzureApi.Object);
+
+            _mockAzureApi.Setup(x => x.DownloadArchive(It.IsAny<string>()).Result).Returns(Array.Empty<byte>());
+            _mockAzureApi.Setup(x => x.UploadToBlob(It.IsAny<string>(), It.IsAny<byte[]>()).Result).Returns(new Uri("https://example.com/resource"));
+
+            // Act
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                TargetApiUrl = TARGET_API_URL,
+                GhesApiUrl = GHES_API_URL,
+                AzureStorageConnectionString = AZURE_CONNECTION_STRING,
+                SkipReleases = true
+            };
+            await _command.Invoke(args);
+
+            // Assert
+            _mockGithubApi.Verify(m => m.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, true));
         }
 
         [Fact]

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -181,6 +181,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                   args.SourceRepo,
                   args.AzureStorageConnectionString,
                   args.GithubSourcePat,
+                  args.SkipReleases,
                   args.NoSslVerify
                 );
 
@@ -274,6 +275,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
           string sourceRepo,
           string azureStorageConnectionString,
           string githubSourcePat,
+          bool skipReleases,
           bool noSslVerify = false)
         {
             _log.LogInformation($"GHES API URL: {ghesApiUrl}");
@@ -303,7 +305,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             var gitDataArchiveId = await ghesApi.StartGitArchiveGeneration(githubSourceOrg, sourceRepo);
             _log.LogInformation($"Archive generation of git data started with id: {gitDataArchiveId}");
-            var metadataArchiveId = await ghesApi.StartMetadataArchiveGeneration(githubSourceOrg, sourceRepo);
+            var metadataArchiveId = await ghesApi.StartMetadataArchiveGeneration(githubSourceOrg, sourceRepo, skipReleases);
             _log.LogInformation($"Archive generation of metadata started with id: {metadataArchiveId}");
 
             var timeNow = $"{DateTime.Now:yyyy-MM-dd_HH-mm-ss}";


### PR DESCRIPTION
Closes https://github.com/github/octoshift/issues/4346

### Description
Before this PR, we hardcoded the `exclude_releases` to `true` but since we added the `--skip-releases` flag we can now leverage its value when making the metadata archive generation call. 

### Bones
Added missing test coverage for `GithubApi#StartGitArchiveGeneration` and `GithubApi#StartMetadataArchiveGeneration` methods.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created) --> @dylan-smith  not sure if we need a doc update for this? 
