### PR TITLE
Add INT test for GHES to GHEC migration path

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -159,8 +159,8 @@ jobs:
     - name: Integration Test
       env: 
         ADO_PAT: ${{ secrets.ADO_PAT }}
-        GH_PAT: ${{ secrets.GH_PAT }}
-        GH_SOURCE_PAT: ${{ secrets.GH_SOURCE_PAT }}
+        GHEC_PAT: ${{ secrets.GHEC_PAT }}
+        GHES_PAT: ${{ secrets.GHES_PAT }}
         AZURE_STORAGE_CONNECTION_STRING_LINUX: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_LINUX }}
         AZURE_STORAGE_CONNECTION_STRING_MACOS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_MACOS }}
         AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -160,6 +160,10 @@ jobs:
       env: 
         ADO_PAT: ${{ secrets.ADO_PAT }}
         GH_PAT: ${{ secrets.GH_PAT }}
+        GH_SOURCE_PAT: ${{ secrets.GH_SOURCE_PAT }}
+        AZURE_STORAGE_CONNECTION_STRING_LINUX: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_LINUX }}
+        AZURE_STORAGE_CONNECTION_STRING_MACOS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_MACOS }}
+        AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}
       run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
 
     - name: Publish Integration Test Results
@@ -173,7 +177,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: always()
       with:
-        name: integration-test-logs-${{ matrix.runner-os }}
+        name: integration-test-logs-${{ matrix.runner-os}}
         path: dist/**/*.log
 
     - name: Test Logs

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -90,8 +90,8 @@ jobs:
     - name: Integration Test
       env: 
         ADO_PAT: ${{ secrets.ADO_PAT }}
-        GH_PAT: ${{ secrets.GH_PAT }}
-        GH_SOURCE_PAT: ${{ secrets.GH_SOURCE_PAT }}
+        GHEC_PAT: ${{ secrets.GHEC_PAT }}
+        GHES_PAT: ${{ secrets.GHES_PAT }}
         AZURE_STORAGE_CONNECTION_STRING_LINUX: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_LINUX }}
         AZURE_STORAGE_CONNECTION_STRING_MACOS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_MACOS }}
         AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -91,6 +91,10 @@ jobs:
       env: 
         ADO_PAT: ${{ secrets.ADO_PAT }}
         GH_PAT: ${{ secrets.GH_PAT }}
+        GH_SOURCE_PAT: ${{ secrets.GH_SOURCE_PAT }}
+        AZURE_STORAGE_CONNECTION_STRING_LINUX: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_LINUX }}
+        AZURE_STORAGE_CONNECTION_STRING_MACOS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_MACOS }}
+        AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}
       run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
 
     - name: Publish Integration Test Results

--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
@@ -16,6 +17,7 @@ namespace OctoshiftCLI.IntegrationTests
         private readonly HttpClient _githubHttpClient;
         private readonly HttpClient _versionClient;
         private bool disposedValue;
+        private readonly Dictionary<string, string> _tokens;
 
         public AdoToGithub(ITestOutputHelper output)
         {
@@ -29,10 +31,16 @@ namespace OctoshiftCLI.IntegrationTests
             var adoClient = new AdoClient(logger, _adoHttpClient, new VersionChecker(_versionClient, logger), adoToken);
             var adoApi = new AdoApi(adoClient, "https://dev.azure.com", logger);
 
-            var githubToken = Environment.GetEnvironmentVariable("GH_PAT");
+            var githubToken = Environment.GetEnvironmentVariable("GHEC_PAT");
             _githubHttpClient = new HttpClient();
             var githubClient = new GithubClient(logger, _githubHttpClient, new VersionChecker(_versionClient, logger), githubToken);
             var githubApi = new GithubApi(githubClient, "https://api.github.com", new RetryPolicy(logger));
+
+            _tokens = new Dictionary<string, string>
+            {
+                ["GH_PAT"] = githubToken,
+                ["ADO_PAT"] = adoToken
+            };
 
             _helper = new TestHelper(_output, adoApi, githubApi, adoClient, githubClient);
         }
@@ -60,7 +68,7 @@ namespace OctoshiftCLI.IntegrationTests
             commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject2, adoRepo2);
             await _helper.CreatePipeline(adoOrg, teamProject2, adoRepo2, pipeline2, commitId);
 
-            await _helper.RunAdoToGithubCliMigration($"generate-script --github-org {githubOrg} --ado-org {adoOrg} --all");
+            await _helper.RunAdoToGithubCliMigration($"generate-script --github-org {githubOrg} --ado-org {adoOrg} --all", _tokens);
 
             await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject1}-{teamProject1}");
             await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject2}-{teamProject2}");

--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -40,8 +40,8 @@ namespace OctoshiftCLI.IntegrationTests
         [Fact]
         public async Task Basic()
         {
-            var adoOrg = $"gei-e2e-testing-{_helper.GetOsName()}";
-            var githubOrg = $"e2e-testing-{_helper.GetOsName()}";
+            var adoOrg = $"gei-e2e-testing-{TestHelper.GetOsName()}";
+            var githubOrg = $"e2e-testing-{TestHelper.GetOsName()}";
             var teamProject1 = "gei-e2e-1";
             var teamProject2 = "gei-e2e-2";
             var adoRepo1 = teamProject1;

--- a/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OctoshiftCLI.IntegrationTests;
+
+[Collection("Integration Tests")]
+public sealed class GhesToGithub : IDisposable
+{
+    private const string GHES_API_URL = "https://octoshift-ghe.westus2.cloudapp.azure.com/api/v3";
+
+    private readonly ITestOutputHelper _output;
+    private readonly TestHelper _targetHelper;
+    private readonly TestHelper _sourceHelper;
+    private readonly HttpClient _versionClient;
+    private readonly HttpClient _targetGithubHttpClient;
+    private readonly GithubClient _targetGithubClient;
+    private readonly GithubApi _targetGithubApi;
+    private readonly HttpClient _sourceGithubHttpClient;
+    private readonly GithubClient _sourceGithubClient;
+    private readonly GithubApi _sourceGithubApi;
+    private readonly BlobServiceClient _blobServiceClient;
+
+    public GhesToGithub(ITestOutputHelper output)
+    {
+        _output = output;
+
+        var logger = new OctoLogger(_ => { }, x => _output.WriteLine(x), _ => { }, _ => { });
+        var sourceGithubToken = Environment.GetEnvironmentVariable("GH_SOURCE_PAT");
+        var targetGithubToken = Environment.GetEnvironmentVariable("GH_PAT");
+        var azureStorageConnectionString = Environment.GetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING");
+
+        _versionClient = new HttpClient();
+
+        _sourceGithubHttpClient = new HttpClient();
+        _sourceGithubClient = new GithubClient(logger, _sourceGithubHttpClient, new VersionChecker(_versionClient, logger), sourceGithubToken);
+        _sourceGithubApi = new GithubApi(_sourceGithubClient, GHES_API_URL, new RetryPolicy(logger));
+
+        _targetGithubHttpClient = new HttpClient();
+        _targetGithubClient = new GithubClient(logger, _targetGithubHttpClient, new VersionChecker(_versionClient, logger), targetGithubToken);
+        _targetGithubApi = new GithubApi(_targetGithubClient, "https://api.github.com", new RetryPolicy(logger));
+
+        _blobServiceClient = new BlobServiceClient(azureStorageConnectionString);
+
+        _sourceHelper = new TestHelper(_output, _sourceGithubApi, _sourceGithubClient) { GithubApiBaseUrl = GHES_API_URL };
+        _targetHelper = new TestHelper(_output, _targetGithubApi, _targetGithubClient, _blobServiceClient);
+    }
+
+    [Fact]
+    public async Task Basic()
+    {
+        var githubSourceOrg = $"e2e-testing-{_targetHelper.GetOsName()}";
+        var githubTargetOrg = $"e2e-testing-{_targetHelper.GetOsName()}";
+        const string repo1 = "repo-1";
+        const string repo2 = "repo-2";
+
+        await _targetHelper.ResetBlobContainers();
+
+        await _sourceHelper.ResetGithubTestEnvironment(githubSourceOrg);
+        await _targetHelper.ResetGithubTestEnvironment(githubTargetOrg);
+
+        await _sourceHelper.CreateGithubRepo(githubSourceOrg, repo1);
+        await _sourceHelper.CreateGithubRepo(githubSourceOrg, repo2);
+
+        await _targetHelper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --ghes-api-url {GHES_API_URL} --download-migration-logs");
+
+        await _targetHelper.AssertGithubRepoExists(githubTargetOrg, repo1);
+        await _targetHelper.AssertGithubRepoExists(githubTargetOrg, repo2);
+        await _targetHelper.AssertGithubRepoInitialized(githubTargetOrg, repo1);
+        await _targetHelper.AssertGithubRepoInitialized(githubTargetOrg, repo2);
+
+        _targetHelper.AssertMigrationLogFileExists(githubTargetOrg, repo1);
+        _targetHelper.AssertMigrationLogFileExists(githubTargetOrg, repo2);
+    }
+
+    public void Dispose()
+    {
+        _sourceGithubHttpClient?.Dispose();
+        _targetGithubHttpClient?.Dispose();
+        _versionClient?.Dispose();
+    }
+}

--- a/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
@@ -23,6 +23,7 @@ public sealed class GhesToGithub : IDisposable
     private readonly GithubClient _sourceGithubClient;
     private readonly GithubApi _sourceGithubApi;
     private readonly BlobServiceClient _blobServiceClient;
+    private readonly string _azureStorageConnectionString;
 
     public GhesToGithub(ITestOutputHelper output)
     {
@@ -31,7 +32,7 @@ public sealed class GhesToGithub : IDisposable
         var logger = new OctoLogger(_ => { }, x => _output.WriteLine(x), _ => { }, _ => { });
         var sourceGithubToken = Environment.GetEnvironmentVariable("GH_SOURCE_PAT");
         var targetGithubToken = Environment.GetEnvironmentVariable("GH_PAT");
-        var azureStorageConnectionString = Environment.GetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING");
+        _azureStorageConnectionString = Environment.GetEnvironmentVariable($"AZURE_STORAGE_CONNECTION_STRING_{TestHelper.GetOsName().ToUpper()}");
 
         _versionClient = new HttpClient();
 
@@ -43,7 +44,7 @@ public sealed class GhesToGithub : IDisposable
         _targetGithubClient = new GithubClient(logger, _targetGithubHttpClient, new VersionChecker(_versionClient, logger), targetGithubToken);
         _targetGithubApi = new GithubApi(_targetGithubClient, "https://api.github.com", new RetryPolicy(logger));
 
-        _blobServiceClient = new BlobServiceClient(azureStorageConnectionString);
+        _blobServiceClient = new BlobServiceClient(_azureStorageConnectionString);
 
         _sourceHelper = new TestHelper(_output, _sourceGithubApi, _sourceGithubClient) { GithubApiBaseUrl = GHES_API_URL };
         _targetHelper = new TestHelper(_output, _targetGithubApi, _targetGithubClient, _blobServiceClient);
@@ -52,8 +53,8 @@ public sealed class GhesToGithub : IDisposable
     [Fact]
     public async Task Basic()
     {
-        var githubSourceOrg = $"e2e-testing-{_targetHelper.GetOsName()}";
-        var githubTargetOrg = $"e2e-testing-{_targetHelper.GetOsName()}";
+        var githubSourceOrg = $"e2e-testing-{TestHelper.GetOsName()}";
+        var githubTargetOrg = $"e2e-testing-{TestHelper.GetOsName()}";
         const string repo1 = "repo-1";
         const string repo2 = "repo-2";
 
@@ -65,7 +66,7 @@ public sealed class GhesToGithub : IDisposable
         await _sourceHelper.CreateGithubRepo(githubSourceOrg, repo1);
         await _sourceHelper.CreateGithubRepo(githubSourceOrg, repo2);
 
-        await _targetHelper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --ghes-api-url {GHES_API_URL} --download-migration-logs");
+        await _targetHelper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --ghes-api-url {GHES_API_URL} --azure-storage-connection-string {_azureStorageConnectionString} --download-migration-logs");
 
         await _targetHelper.AssertGithubRepoExists(githubTargetOrg, repo1);
         await _targetHelper.AssertGithubRepoExists(githubTargetOrg, repo2);

--- a/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
@@ -36,8 +36,8 @@ namespace OctoshiftCLI.IntegrationTests
         [Fact]
         public async Task Basic()
         {
-            var githubSourceOrg = $"e2e-testing-source-{_helper.GetOsName()}";
-            var githubTargetOrg = $"e2e-testing-{_helper.GetOsName()}";
+            var githubSourceOrg = $"e2e-testing-source-{TestHelper.GetOsName()}";
+            var githubTargetOrg = $"e2e-testing-{TestHelper.GetOsName()}";
             var repo1 = "repo-1";
             var repo2 = "repo-2";
 

--- a/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
@@ -17,13 +18,16 @@ namespace OctoshiftCLI.IntegrationTests
         private readonly HttpClient _versionClient;
         private readonly GithubClient _githubClient;
         private bool disposedValue;
+        private readonly Dictionary<string, string> _tokens;
 
         public GithubToGithub(ITestOutputHelper output)
         {
             _output = output;
 
             var logger = new OctoLogger(x => { }, x => _output.WriteLine(x), x => { }, x => { });
-            var githubToken = Environment.GetEnvironmentVariable("GH_PAT");
+
+            var githubToken = Environment.GetEnvironmentVariable("GHEC_PAT");
+            _tokens = new Dictionary<string, string> { ["GH_PAT"] = githubToken };
 
             _githubHttpClient = new HttpClient();
             _versionClient = new HttpClient();
@@ -47,7 +51,7 @@ namespace OctoshiftCLI.IntegrationTests
             await _helper.CreateGithubRepo(githubSourceOrg, repo1);
             await _helper.CreateGithubRepo(githubSourceOrg, repo2);
 
-            await _helper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --download-migration-logs");
+            await _helper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --download-migration-logs", _tokens);
 
             await _helper.AssertGithubRepoExists(githubTargetOrg, repo1);
             await _helper.AssertGithubRepoExists(githubTargetOrg, repo2);

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -410,7 +410,7 @@ steps:
             return (string)response.Single(x => (string)x["name"] == repo)["role_name"];
         }
 
-        public string GetOsName()
+        public static string GetOsName()
         {
             return RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
                 ? "linux"

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -440,7 +440,7 @@ steps:
                     }
                     else
                     {
-                        startInfo.EnvironmentVariables.Add("ADO_PAT", token.Value);
+                        startInfo.EnvironmentVariables.Add(token.Key, token.Value);
                     }
                 }
             }
@@ -462,22 +462,11 @@ steps:
             p.ExitCode.Should().Be(0, "migrate.ps1 should return an exit code of 0");
         }
 
-        public async Task RunAdoToGithubCliMigration(string generateScriptCommand)
-        {
-            var adoToken = Environment.GetEnvironmentVariable("ADO_PAT");
-            var githubToken = Environment.GetEnvironmentVariable("GH_PAT");
-            var tokens = new Dictionary<string, string>() { { "ADO_PAT", adoToken }, { "GH_PAT", githubToken } };
-
+        public async Task RunAdoToGithubCliMigration(string generateScriptCommand, IDictionary<string, string> tokens) =>
             await RunCliMigration(generateScriptCommand, Path.Join(GetOsDistPath(), "ado2gh"), tokens);
-        }
 
-        public async Task RunGeiCliMigration(string generateScriptCommand)
-        {
-            var githubToken = Environment.GetEnvironmentVariable("GH_PAT");
-            var tokens = new Dictionary<string, string>() { { "GH_PAT", githubToken } };
-
+        public async Task RunGeiCliMigration(string generateScriptCommand, IDictionary<string, string> tokens) =>
             await RunCliMigration($"gei {generateScriptCommand}", "gh", tokens);
-        }
 
         private string GetOsDistPath()
         {


### PR DESCRIPTION
Closes #353 

This PR adds an integration test to cover GHES to GHEC migration path. For the GHES migration path to work we needed to store GHES' PAT in GitHub but in order to not interfere with GHEC to GHEC migration path, we renamed the `GH_SOURCE_PAT` secret key to `GHES_PAT` and consequently did the same for `GH_PAT` and renamed it to `GHEC_PAT`. Then in the test code we do the mapping and properly map the PATs and create a dictionary of env variables to be used by the process that eventually runs the migration.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
