### PR TITLE
Delete migration logs before kicking off a new migration

### DIFF
--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -18,9 +18,11 @@ namespace OctoshiftCLI.IntegrationTests
         private readonly HttpClient _versionClient;
         private bool disposedValue;
         private readonly Dictionary<string, string> _tokens;
+        private readonly DateTime _startTime;
 
         public AdoToGithub(ITestOutputHelper output)
         {
+            _startTime = DateTime.Now;
             _output = output;
 
             var logger = new OctoLogger(x => { }, x => _output.WriteLine(x), x => { }, x => { });
@@ -70,6 +72,8 @@ namespace OctoshiftCLI.IntegrationTests
             await _helper.CreatePipeline(adoOrg, teamProject2, adoRepo2, pipeline2, commitId);
 
             await _helper.RunAdoToGithubCliMigration($"generate-script --github-org {githubOrg} --ado-org {adoOrg} --all", _tokens);
+
+            _helper.AssertNoErrorInLogs(_startTime);
 
             await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject1}-{teamProject1}");
             await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject2}-{teamProject2}");

--- a/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
@@ -25,9 +25,11 @@ public sealed class GhesToGithub : IDisposable
     private readonly GithubApi _sourceGithubApi;
     private readonly BlobServiceClient _blobServiceClient;
     private readonly Dictionary<string, string> _tokens;
+    private readonly DateTime _startTime;
 
     public GhesToGithub(ITestOutputHelper output)
     {
+        _startTime = DateTime.Now;
         _output = output;
 
         var logger = new OctoLogger(_ => { }, x => _output.WriteLine(x), _ => { }, _ => { });
@@ -76,6 +78,8 @@ public sealed class GhesToGithub : IDisposable
 
         await _targetHelper.RunGeiCliMigration(
             $"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --ghes-api-url {GHES_API_URL} --download-migration-logs", _tokens);
+
+        _targetHelper.AssertNoErrorInLogs(_startTime);
 
         await _targetHelper.AssertGithubRepoExists(githubTargetOrg, repo1);
         await _targetHelper.AssertGithubRepoExists(githubTargetOrg, repo2);

--- a/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
@@ -19,9 +19,11 @@ namespace OctoshiftCLI.IntegrationTests
         private readonly GithubClient _githubClient;
         private bool disposedValue;
         private readonly Dictionary<string, string> _tokens;
+        private readonly DateTime _startTime;
 
         public GithubToGithub(ITestOutputHelper output)
         {
+            _startTime = DateTime.Now;
             _output = output;
 
             var logger = new OctoLogger(x => { }, x => _output.WriteLine(x), x => { }, x => { });
@@ -52,6 +54,8 @@ namespace OctoshiftCLI.IntegrationTests
             await _helper.CreateGithubRepo(githubSourceOrg, repo2);
 
             await _helper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --download-migration-logs", _tokens);
+
+            _helper.AssertNoErrorInLogs(_startTime);
 
             await _helper.AssertGithubRepoExists(githubTargetOrg, repo1);
             await _helper.AssertGithubRepoExists(githubTargetOrg, repo2);

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -624,10 +624,10 @@ steps:
 
         private static void DeleteMigrationLog(string githubOrg, string githubRepo)
         {
-            var migrationLogFileName = $"migration-log-{githubOrg}-{githubRepo}.log";
-            if (File.Exists(migrationLogFileName))
+            var migrationLogFileFullName = Path.Join(GetOsDistPath(), $"migration-log-{githubOrg}-{githubRepo}.log");
+            if (File.Exists(migrationLogFileFullName))
             {
-                File.Delete(migrationLogFileName);
+                File.Delete(migrationLogFileFullName);
             }
         }
     }

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -595,7 +595,7 @@ steps:
         public void AssertNoErrorInLogs(DateTime after)
         {
             _output.WriteLine("Checking that CLI logs have no errors...");
-            
+
             var directoryInfo = new DirectoryInfo(GetOsDistPath());
 
             var firstLogFileWithError = directoryInfo.GetFiles("*.octoshift.log")
@@ -607,7 +607,7 @@ steps:
 
             var firstError = firstLogFileWithError is not null
                 ? File.ReadAllLines(firstLogFileWithError.FullName).First(line => line.Contains("[ERROR]"))
-                : null; 
+                : null;
 
             firstError.Should().BeNull();
         }

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -86,6 +86,9 @@ namespace OctoshiftCLI.IntegrationTests
 
             foreach (var repo in githubRepos)
             {
+                _output.WriteLine($"Deleting migration log for repo: {githubOrg}\\{repo}");
+                DeleteMigrationLog(githubOrg, repo);
+
                 _output.WriteLine($"Deleting GitHub repo: {githubOrg}\\{repo}...");
                 await _githubApi.DeleteRepo(githubOrg, repo);
             }
@@ -596,6 +599,15 @@ steps:
             {
                 _output.WriteLine($"Deleting blob container: {blobContainer.Name}");
                 await _blobServiceClient.DeleteBlobContainerAsync(blobContainer.Name);
+            }
+        }
+
+        private static void DeleteMigrationLog(string githubOrg, string githubRepo)
+        {
+            var migrationLogFileName = $"migration-log-{githubOrg}-{githubRepo}.log";
+            if (File.Exists(migrationLogFileName))
+            {
+                File.Delete(migrationLogFileName);
             }
         }
     }

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -594,21 +594,22 @@ steps:
 
         public void AssertNoErrorInLogs(DateTime after)
         {
+            _output.WriteLine("Checking that CLI logs have no errors...");
+            
             var directoryInfo = new DirectoryInfo(GetOsDistPath());
 
-            var firstLogFileWithErrors = directoryInfo.GetFiles("*.octoshift.log")
+            var firstLogFileWithError = directoryInfo.GetFiles("*.octoshift.log")
                 .Select(fi => (Timestamp: DateTime.ParseExact(fi.Name.Split('.').First(), "yyyyMMddHHmmss", null), FileInfo: fi))
                 .Where(x => x.Timestamp >= after)
                 .OrderBy(x => x.Timestamp)
                 .Select(x => x.FileInfo)
                 .FirstOrDefault(fi => File.ReadAllLines(fi.FullName).Any(line => line.Contains("[ERROR]")));
 
-            if (firstLogFileWithErrors is not null)
-            {
-                _output.WriteLine($"Log file {firstLogFileWithErrors.Name} contains error(s).");
-            }
+            var firstError = firstLogFileWithError is not null
+                ? File.ReadAllLines(firstLogFileWithError.FullName).First(line => line.Contains("[ERROR]"))
+                : null; 
 
-            firstLogFileWithErrors.Should().BeNull();
+            firstError.Should().BeNull();
         }
 
         public async Task ResetBlobContainers()


### PR DESCRIPTION
For our INT tests we need to delete the migration logs before kicking off a new migration. Additionally it fails the INT test if there is any error in CLI logs. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
