### PR TITLE
fix datetime format bug

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,2 @@
 - fixed a bug where `generate-script` would not properly handle Team Projects with spaces (or other invalid for github chars) in the name
-- fixed bug where `inventory-report` would fail if your computers datetime format settings were dd/mm/yyyy
+- fixed bug where `inventory-report` would fail if your computer's datetime format settings were dd/mm/yyyy

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 - fixed a bug where `generate-script` would not properly handle Team Projects with spaces (or other invalid for github chars) in the name
+- fixed bug where `inventory-report` would fail if your computers datetime format settings were dd/mm/yyyy

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -63,20 +64,20 @@ namespace OctoshiftCLI
             var response = await _client.GetAsync(url);
 
             var data = JObject.Parse(response);
-            var pushDate = data.TryGetValue("value", out var dataValue) && dataValue.Any() ? (string)dataValue.First()["date"] : DateTime.MinValue.ToString();
+            var pushDate = data.TryGetValue("value", out var dataValue) && dataValue.Any() ? (DateTime)dataValue.First()["date"] : DateTime.MinValue;
 
-            return DateTime.Parse(pushDate);
+            return pushDate.Date;
         }
 
         public virtual async Task<int> GetCommitCountSince(string org, string teamProject, string repo, DateTime fromDate)
         {
-            var url = $"{_adoBaseUrl}/{org}/{teamProject}/_apis/git/repositories/{repo}/commits?searchCriteria.fromDate={fromDate.ToShortDateString()}&api-version=7.1-preview.1";
+            var url = $"{_adoBaseUrl}/{org}/{teamProject}/_apis/git/repositories/{repo}/commits?searchCriteria.fromDate={fromDate.ToString("d", CultureInfo.InvariantCulture)}&api-version=7.1-preview.1";
             return await _client.GetCountUsingSkip(url);
         }
 
         public virtual async Task<IEnumerable<string>> GetPushersSince(string org, string teamProject, string repo, DateTime fromDate)
         {
-            var url = $"{_adoBaseUrl}/{org}/{teamProject}/_apis/git/repositories/{repo}/pushes?searchCriteria.fromDate={fromDate.ToShortDateString()}&api-version=7.1-preview.1";
+            var url = $"{_adoBaseUrl}/{org}/{teamProject}/_apis/git/repositories/{repo}/pushes?searchCriteria.fromDate={fromDate.ToString("d", CultureInfo.InvariantCulture)}&api-version=7.1-preview.1";
             var response = await _client.GetWithPagingTopSkipAsync(url, x => $"{x["pushedBy"]["displayName"]} ({x["pushedBy"]["uniqueName"]})");
 
             return response;


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Fixes #455 

GetLastPushDate was converting a DateTime to a string then back unnecessarily and not using the InvariantCulture which would cause it to crash on a system with non-US datetime format settings (still not entirely sure why, I would have thought it would use the local datetime format settings for both stringifying and parsing the date). But getting rid of the unnecessary date->string->date conversion fixed it.

GetCommitCountSince and GetPushersSince both need to pass a string representation of a date to the API, and previously they were using the local datetime format to do this, but the API expects a datetime in InvariantCulture format.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->