### PR TITLE
Error out when no migratable repos

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- `generate-script` command in `ado2gh` and `gh gei` will no longer generate an empty script if no migratable repos were found.

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -794,7 +794,7 @@ if ($Failed -ne 0) {
         }
 
         [Fact]
-        public async Task PatallelScript_Skips_Team_Project_With_No_Repos()
+        public async Task ParallelScript_Skips_Team_Project_With_No_Repos()
         {
             // Arrange
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -34,8 +34,9 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
         private readonly Mock<AdoInspectorService> _mockAdoInspector = TestHelpers.CreateMock<AdoInspectorService>();
         private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
+        private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
 
-        private string _scriptOutput = "";
+        private string _scriptOutput;
         private readonly GenerateScriptCommand _command;
 
         public GenerateScriptCommandTests()
@@ -44,7 +45,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
             _mockAdoInspectorServiceFactory.Setup(m => m.Create(_mockAdoApi.Object)).Returns(_mockAdoInspector.Object);
 
-            _command = new GenerateScriptCommand(TestHelpers.CreateMock<OctoLogger>().Object, _mockAdoApiFactory.Object, mockVersionProvider.Object, _mockAdoInspectorServiceFactory.Object)
+            _command = new GenerateScriptCommand(_mockOctoLogger.Object, _mockAdoApiFactory.Object, mockVersionProvider.Object, _mockAdoInspectorServiceFactory.Object)
             {
                 WriteToFile = (_, contents) =>
                 {
@@ -78,28 +79,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             TestHelpers.VerifyCommandOption(command.Options, "integrate-boards", false);
             TestHelpers.VerifyCommandOption(command.Options, "rewire-pipelines", false);
             TestHelpers.VerifyCommandOption(command.Options, "all", false);
-        }
-
-        [Fact]
-        public async Task SequentialScript_No_Data()
-        {
-            // Arrange
-            var orgs = new List<string>();
-
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-            _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(orgs);
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                Sequential = true,
-                Output = new FileInfo("unit-test-output")
-            };
-            await _command.Invoke(args);
-
-            // Assert
-            _scriptOutput.Should().BeNullOrWhiteSpace();
         }
 
         [Fact]
@@ -288,10 +267,9 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             };
             await _command.Invoke(args);
 
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput);
-
             // Assert
-            _scriptOutput.Should().BeEmpty();
+            _scriptOutput.Should().BeNull();
+            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled and TFVC repos."));
         }
 
         [Fact]
@@ -594,26 +572,6 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         }
 
         [Fact]
-        public async Task ParallelScript_No_Data()
-        {
-            // Arrange
-            _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
-
-            _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(0);
-
-            // Act
-            var args = new GenerateScriptCommandArgs
-            {
-                GithubOrg = GITHUB_ORG,
-                Output = new FileInfo("unit-test-output")
-            };
-            await _command.Invoke(args);
-
-            // Assert
-            _scriptOutput.Should().BeEmpty();
-        }
-
-        [Fact]
         public async Task ParallelScript_StartsWith_Shebang()
         {
             // Arrange
@@ -852,10 +810,9 @@ if ($Failed -ne 0) {
             };
             await _command.Invoke(args);
 
-            _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
-
             // Assert
-            _scriptOutput.Should().BeEmpty();
+            _scriptOutput.Should().BeNull();
+            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled and TFVC repos."));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -269,7 +269,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             // Assert
             _scriptOutput.Should().BeNull();
-            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled and TFVC repos."));
+            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled or TFVC repos."));
         }
 
         [Fact]
@@ -812,7 +812,7 @@ if ($Failed -ne 0) {
 
             // Assert
             _scriptOutput.Should().BeNull();
-            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled and TFVC repos."));
+            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled or TFVC repos."));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -269,7 +269,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             // Assert
             _scriptOutput.Should().BeNull();
-            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled or TFVC repos."));
+            _mockOctoLogger.Verify(m => m.LogError(It.IsAny<string>()));
         }
 
         [Fact]
@@ -812,7 +812,7 @@ if ($Failed -ne 0) {
 
             // Assert
             _scriptOutput.Should().BeNull();
-            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled or TFVC repos."));
+            _mockOctoLogger.Verify(m => m.LogError(It.IsAny<string>()));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -105,7 +105,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Assert
             _script.Should().BeNull();
-            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found."));
+            _mockOctoLogger.Verify(m => m.LogError(It.IsAny<string>()));
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Assert
             _script.Should().BeNull();
-            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found."));
+            _mockOctoLogger.Verify(m => m.LogError(It.IsAny<string>()));
         }
 
         [Fact]
@@ -446,7 +446,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Assert
             _script.Should().BeNull();
-            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled or TFVC repos."));
+            _mockOctoLogger.Verify(m => m.LogError(It.IsAny<string>()));
         }
 
         [Fact]
@@ -468,7 +468,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Assert
             _script.Should().BeNull();
-            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled or TFVC repos."));
+            _mockOctoLogger.Verify(m => m.LogError(It.IsAny<string>()));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -27,7 +27,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         private const string SOURCE_ORG = "FOO-SOURCE-ORG";
         private const string TARGET_ORG = "FOO-TARGET-ORG";
         private const string REPO = "REPO";
-        private string _script = "";
+        private string _script;
 
         public GenerateScriptCommandTests()
         {
@@ -104,7 +104,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await _command.Invoke(args);
 
             // Assert
-            _script.Should().BeNullOrWhiteSpace();
+            _script.Should().BeNull();
+            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found."));
         }
 
         [Fact]
@@ -126,7 +127,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await _command.Invoke(args);
 
             // Assert
-            _script.Should().BeNullOrWhiteSpace();
+            _script.Should().BeNull();
+            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found."));
         }
 
         [Fact]
@@ -345,7 +347,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await _command.Invoke(args);
 
             // Assert
-            TrimNonExecutableLines(_script).Should().BeEmpty();
+            _script.Should().BeNull();
             _mockAdoApi.Verify(m => m.GetTeamProjects(org), Times.Once);
             _mockAdoApi.VerifyNoOtherCalls();
         }
@@ -443,7 +445,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await _command.Invoke(args);
 
             // Assert
-            _script.Should().BeNullOrWhiteSpace();
+            _script.Should().BeNull();
+            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled and TFVC repos."));
         }
 
         [Fact]
@@ -464,7 +467,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await _command.Invoke(args);
 
             // Assert
-            _script.Should().BeNullOrWhiteSpace();
+            _script.Should().BeNull();
+            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled and TFVC repos."));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -446,7 +446,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Assert
             _script.Should().BeNull();
-            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled and TFVC repos."));
+            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled or TFVC repos."));
         }
 
         [Fact]
@@ -468,7 +468,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Assert
             _script.Should().BeNull();
-            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled and TFVC repos."));
+            _mockOctoLogger.Verify(m => m.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled or TFVC repos."));
         }
 
         [Fact]

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -160,7 +160,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
             if (await _adoInspectorService.GetRepoCount() == 0)
             {
-                _log.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled and TFVC repos.");
+                _log.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled or TFVC repos.");
                 return;
             }
 

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -158,6 +158,12 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _adoInspectorService.OrgFilter = args.AdoOrg;
             _adoInspectorService.TeamProjectFilter = args.AdoTeamProject;
 
+            if (await _adoInspectorService.GetRepoCount() == 0)
+            {
+                _log.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled and TFVC repos.");
+                return;
+            }
+
             var appIds = _generateScriptOptions.RewirePipelines ? await GetAppIds(ado, args.GithubOrg) : new Dictionary<string, string>();
 
             var script = args.Sequential
@@ -221,11 +227,6 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
         private async Task<string> GenerateSequentialScript(IDictionary<string, string> appIds, string githubOrg)
         {
-            if ((await _adoInspectorService.GetRepoCount()) == 0)
-            {
-                return string.Empty;
-            }
-
             var content = new StringBuilder();
 
             AppendLine(content, PWSH_SHEBANG);
@@ -289,11 +290,6 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
         private async Task<string> GenerateParallelScript(IDictionary<string, string> appIds, string githubOrg)
         {
-            if ((await _adoInspectorService.GetRepoCount()) == 0)
-            {
-                return string.Empty;
-            }
-
             var content = new StringBuilder();
             AppendLine(content, PWSH_SHEBANG);
             AppendLine(content);

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -261,7 +261,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var repos = await GetAdoRepos(_sourceAdoApiFactory.Create(adoServerUrl, adoPat), adoSourceOrg, adoTeamProject);
             if (!repos.Any())
             {
-                _log.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled and TFVC repos.");
+                _log.LogError("A migration script could not be generated because no migratable repos were found. Please note that the GEI does not migrate disabled or TFVC repos.");
                 return string.Empty;
             }
 


### PR DESCRIPTION
Fixes #448 

With this PR the `generate-script` command in both `ado2gh` and `gei` will no longer create an empty script if no migratable repos were found. In that case it will spit out an error log and gracefully exits. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)