### PR TITLE
GithubApi#RepoExists returns false on 301

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,3 @@
 - `generate-script` command in `ado2gh` and `gh gei` will no longer generate an empty script if no migratable repos were found.
 - `--ado-pipeline` arg in the `ado2gh rewire-pipeline` command will now accept a pipeline name without the full pipeline path, so long as there is only one pipeline found that matches that name. If there are multiple pipelines with the same name (in different pipeline folders), you will need to provide the full pipeline path.
-- Fixed a bug where the `migrate-repo` command would return `301` for a recently renamed repo. 
+- Fixed a bug where the `migrate-repo` command would return an error when migrating to a recently renamed GitHub repo which the old/original name was used as the target repo.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - `generate-script` command in `ado2gh` and `gh gei` will no longer generate an empty script if no migratable repos were found.
 - `--ado-pipeline` arg in the `ado2gh rewire-pipeline` command will now accept a pipeline name without the full pipeline path, so long as there is only one pipeline found that matches that name. If there are multiple pipelines with the same name (in different pipeline folders), you will need to provide the full pipeline path.
+- Fixed a bug where the `migrate-repo` command would return `301` for a recently renamed repo. 

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -106,7 +106,7 @@ namespace OctoshiftCLI
                 await _client.GetAsync(url);
                 return true;
             }
-            catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.NotFound)
+            catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Moved)
             {
                 return false;
             }

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -1511,7 +1511,7 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task RepoExists_Should_Return_False_If_Repo_Does_Not_Exist()
+        public async Task RepoExists_Should_Return_False_If_Repo_Does_Not_Exist_404()
         {
             // Arrange
             const string url = $"https://api.github.com/repos/{GITHUB_ORG}/{GITHUB_REPO}";
@@ -1528,7 +1528,7 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task RepoExists_Throws_When_Underlying_HtttRepsponseException_Status_Is_Not_NotFound()
+        public async Task RepoExists_Should_Return_False_If_Repo_Does_Not_Exist_301()
         {
             // Arrange
             const string url = $"https://api.github.com/repos/{GITHUB_ORG}/{GITHUB_REPO}";
@@ -1536,6 +1536,23 @@ namespace OctoshiftCLI.Tests
             _githubClientMock
                 .Setup(m => m.GetAsync(url))
                 .Throws(new HttpRequestException(null, null, HttpStatusCode.Moved));
+
+            // Act
+            var result = await _githubApi.RepoExists(GITHUB_ORG, GITHUB_REPO);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task RepoExists_Throws_When_Underlying_HtttRepsponseException_Status_Is_Not_NotFound_Or_Moved()
+        {
+            // Arrange
+            const string url = $"https://api.github.com/repos/{GITHUB_ORG}/{GITHUB_REPO}";
+
+            _githubClientMock
+                .Setup(m => m.GetAsync(url))
+                .Throws(new HttpRequestException(null, null, HttpStatusCode.MultipleChoices));
 
             // Act, Assert
             await _githubApi


### PR DESCRIPTION
Fixes #469 

When a repo gets renamed, the GitHub API returns `301 (Moved)` instead of `404 (Not Found)`. This PR fixed it so on both `404` and `301` responses the `GithubApi#RepoExists()` returns `false`. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
