### PR TITLE
Add repo size to repos.csv

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,4 @@
 - `generate-script` command in `ado2gh` and `gh gei` will no longer generate an empty script if no migratable repos were found.
 - `--ado-pipeline` arg in the `ado2gh rewire-pipeline` command will now accept a pipeline name without the full pipeline path, so long as there is only one pipeline found that matches that name. If there are multiple pipelines with the same name (in different pipeline folders), you will need to provide the full pipeline path.
 - Fixed a bug where the `migrate-repo` command would return an error when migrating to a recently renamed GitHub repo which the old/original name was used as the target repo.
-- `repos.csv` now also reports the compressed repo size of each repo.
+- `repos.csv` now also reports the compressed size of each repo.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,4 @@
 - `generate-script` command in `ado2gh` and `gh gei` will no longer generate an empty script if no migratable repos were found.
 - `--ado-pipeline` arg in the `ado2gh rewire-pipeline` command will now accept a pipeline name without the full pipeline path, so long as there is only one pipeline found that matches that name. If there are multiple pipelines with the same name (in different pipeline folders), you will need to provide the full pipeline path.
 - Resolved a bug where the `migrate-repo` command wouldn't queue a migration if the target repo had recently been renamed.
-- `repos.csv` now also reports the compressed size of each repo.
+- `ado2gh inventory-report` command now also reports the compressed size of each repo in `repos.csv`.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
 - `generate-script` command in `ado2gh` and `gh gei` will no longer generate an empty script if no migratable repos were found.
 - `--ado-pipeline` arg in the `ado2gh rewire-pipeline` command will now accept a pipeline name without the full pipeline path, so long as there is only one pipeline found that matches that name. If there are multiple pipelines with the same name (in different pipeline folders), you will need to provide the full pipeline path.
 - Fixed a bug where the `migrate-repo` command would return an error when migrating to a recently renamed GitHub repo which the old/original name was used as the target repo.
+- `repos.csv` now also reports the compressed repo size of each repo.

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -145,13 +145,14 @@ namespace OctoshiftCLI
         {
             var url = $"{_adoBaseUrl}/{org}/{teamProject}/_apis/git/repositories?api-version=6.1-preview.1";
             var data = await _client.GetWithPagingAsync(url);
-            return data.Select(x => new AdoRepository
-            {
-                Id = (string)x["id"],
-                Name = (string)x["name"],
-                Size = (uint)x["size"],
-                IsDisabled = ((string)x["isDisabled"]).ToBool()
-            })
+            return data
+                .Select(x => new AdoRepository
+                {
+                    Id = (string)x["id"],
+                    Name = (string)x["name"],
+                    Size = ((string)x["size"]).ToULongOrNull(),
+                    IsDisabled = ((string)x["isDisabled"]).ToBool()
+                })
                 .ToList();
         }
 

--- a/src/Octoshift/AdoApi.cs
+++ b/src/Octoshift/AdoApi.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using Octoshift.Models;
 using OctoshiftCLI.Extensions;
 
 namespace OctoshiftCLI
@@ -138,14 +139,20 @@ namespace OctoshiftCLI
             return data.Select(x => (string)x["name"]).ToList();
         }
 
-        public virtual async Task<IEnumerable<string>> GetEnabledRepos(string org, string teamProject) => (await GetRepos(org, teamProject)).Where(x => !x.IsDisabled).Select(x => x.Name).ToList();
+        public virtual async Task<IEnumerable<AdoRepository>> GetEnabledRepos(string org, string teamProject) => (await GetRepos(org, teamProject)).Where(x => !x.IsDisabled).ToList();
 
-        public virtual async Task<IEnumerable<(string Id, string Name, bool IsDisabled)>> GetRepos(string org, string teamProject)
+        public virtual async Task<IEnumerable<AdoRepository>> GetRepos(string org, string teamProject)
         {
             var url = $"{_adoBaseUrl}/{org}/{teamProject}/_apis/git/repositories?api-version=6.1-preview.1";
             var data = await _client.GetWithPagingAsync(url);
-            return data.Select(x => ((string)x["id"], (string)x["name"], ((string)x["isDisabled"]).ToBool()))
-                       .ToList();
+            return data.Select(x => new AdoRepository
+            {
+                Id = (string)x["id"],
+                Name = (string)x["name"],
+                Size = (uint)x["size"],
+                IsDisabled = ((string)x["isDisabled"]).ToBool()
+            })
+                .ToList();
         }
 
         public virtual async Task<string> GetGithubAppId(string org, string githubOrg, IEnumerable<string> teamProjects)

--- a/src/Octoshift/Extensions/StringExtensions.cs
+++ b/src/Octoshift/Extensions/StringExtensions.cs
@@ -14,7 +14,8 @@ namespace OctoshiftCLI.Extensions
 
         public static bool ToBool(this string s) => bool.TryParse(s, out var result) && result;
 
-        public static string ReplaceInvalidCharactersWithDash(this string s) => s.HasValue() ? Regex.Replace(s, @"[^\w.-]+", "-", RegexOptions.Compiled | RegexOptions.CultureInvariant) : string.Empty;
+        public static ulong? ToULongOrNull(this string s) => ulong.TryParse(s, out var result) ? result : null;
 
+        public static string ReplaceInvalidCharactersWithDash(this string s) => s.HasValue() ? Regex.Replace(s, @"[^\w.-]+", "-", RegexOptions.Compiled | RegexOptions.CultureInvariant) : string.Empty;
     }
 }

--- a/src/Octoshift/Models/AdoRepository.cs
+++ b/src/Octoshift/Models/AdoRepository.cs
@@ -4,6 +4,6 @@ public record AdoRepository
 {
     public string Id { get; init; }
     public string Name { get; init; }
-    public uint Size { get; init; }
+    public ulong? Size { get; init; }
     public bool IsDisabled { get; init; }
 }

--- a/src/Octoshift/Models/AdoRepository.cs
+++ b/src/Octoshift/Models/AdoRepository.cs
@@ -1,0 +1,9 @@
+namespace Octoshift.Models;
+
+public record AdoRepository
+{
+    public string Id { get; init; }
+    public string Name { get; init; }
+    public uint Size { get; init; }
+    public bool IsDisabled { get; init; }
+}

--- a/src/OctoshiftCLI.Tests/AdoApiTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoApiTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using Newtonsoft.Json.Linq;
+using Octoshift.Models;
 using OctoshiftCLI.Extensions;
 using Xunit;
 
@@ -158,10 +159,11 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task GetRepos_Should_Not_Return_Disabled_Repos()
+        public async Task GetEnabledRepos_Should_Not_Return_Disabled_Repos()
         {
-            var repo2 = "foo-repo2";
             var endpoint = $"https://dev.azure.com/{ADO_ORG}/{ADO_TEAM_PROJECT}/_apis/git/repositories?api-version=6.1-preview.1";
+            var repo1 = new AdoRepository { Id = "1", Name = ADO_REPO, Size = 123, IsDisabled = false };
+            var repo2 = new AdoRepository { Id = "2", Name = "foo-repo2", Size = 5678, IsDisabled = false };
             var json = new object[]
             {
                 new
@@ -172,15 +174,17 @@ namespace OctoshiftCLI.Tests
                 },
                 new
                 {
-                    isDisabled = false,
-                    name = ADO_REPO,
-                    size = 123
+                    id = repo1.Id,
+                    isDisabled = repo1.IsDisabled,
+                    name = repo1.Name,
+                    size = repo1.Size
                 },
                 new
                 {
+                    id = repo2.Id,
                     isDisabled = "FALSE",
-                    name = repo2,
-                    size = 5678
+                    name = repo2.Name,
+                    size = repo2.Size
                 }
             };
             var response = JArray.Parse(json.ToJson());
@@ -190,7 +194,7 @@ namespace OctoshiftCLI.Tests
             var result = await sut.GetEnabledRepos(ADO_ORG, ADO_TEAM_PROJECT);
 
             result.Count().Should().Be(2);
-            result.Select(r => r.Name).Should().Contain(new[] { ADO_REPO, repo2 });
+            result.Should().BeEquivalentTo(new[] { repo1, repo2 });
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/AdoApiTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoApiTests.cs
@@ -167,17 +167,20 @@ namespace OctoshiftCLI.Tests
                 new
                 {
                     isDisabled = true,
-                    name = "testing"
+                    name = "testing",
+                    size = 1234
                 },
                 new
                 {
                     isDisabled = false,
-                    name = ADO_REPO
+                    name = ADO_REPO,
+                    size = 123
                 },
                 new
                 {
                     isDisabled = "FALSE",
-                    name = repo2
+                    name = repo2,
+                    size = 5678
                 }
             };
             var response = JArray.Parse(json.ToJson());
@@ -187,7 +190,7 @@ namespace OctoshiftCLI.Tests
             var result = await sut.GetEnabledRepos(ADO_ORG, ADO_TEAM_PROJECT);
 
             result.Count().Should().Be(2);
-            result.Should().Contain(new[] { ADO_REPO, repo2 });
+            result.Select(r => r.Name).Should().Contain(new[] { ADO_REPO, repo2 });
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/DisableRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/DisableRepoCommandTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Moq;
+using Octoshift.Models;
 using OctoshiftCLI.AdoToGithub;
 using OctoshiftCLI.AdoToGithub.Commands;
 using Xunit;
@@ -43,7 +44,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         [Fact]
         public async Task Happy_Path()
         {
-            var repos = new List<(string Id, string Name, bool IsDisabled)> { (REPO_ID, ADO_REPO, false) };
+            var repos = new List<AdoRepository> { new() { Id = REPO_ID, Name = ADO_REPO, IsDisabled = false } };
 
             _mockAdoApi.Setup(x => x.GetRepos(ADO_ORG, ADO_TEAM_PROJECT).Result).Returns(repos);
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
@@ -56,7 +57,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         [Fact]
         public async Task Idempotency_Repo_Disabled()
         {
-            var repos = new List<(string Id, string Name, bool IsDisabled)> { (REPO_ID, ADO_REPO, true) };
+            var repos = new List<AdoRepository> { new() { Id = REPO_ID, Name = ADO_REPO, IsDisabled = true } };
 
             _mockAdoApi.Setup(x => x.GetRepos(ADO_ORG, ADO_TEAM_PROJECT).Result).Returns(repos);
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
@@ -71,11 +72,11 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         {
             const string adoPat = "ado-pat";
 
-            var repos = new[] { ("repoId", "adoRepo", true) };
+            var repos = new List<AdoRepository> { new() { Id = REPO_ID, Name = ADO_REPO, Size = 1234, IsDisabled = true } };
             _mockAdoApi.Setup(x => x.GetRepos(It.IsAny<string>(), It.IsAny<string>()).Result).Returns(repos);
             _mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke("adoOrg", "adoTeamProject", "adoRepo", adoPat);
+            await _command.Invoke("adoOrg", "adoTeamProject", ADO_REPO, adoPat);
 
             _mockAdoApiFactory.Verify(m => m.Create(adoPat));
         }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScriptCommandTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
+using Octoshift.Models;
 using OctoshiftCLI.AdoToGithub;
 using OctoshiftCLI.AdoToGithub.Commands;
 using OctoshiftCLI.Extensions;
@@ -26,7 +27,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
         private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
         private readonly IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
-        private IEnumerable<string> ADO_REPOS = new List<string>() { FOO_REPO };
+        private IEnumerable<AdoRepository> ADO_REPOS = new List<AdoRepository> { new() { Name = FOO_REPO } };
         private IEnumerable<string> ADO_PIPELINES = new List<string>() { FOO_PIPELINE };
         private readonly IEnumerable<string> EMPTY_PIPELINES = new List<string>();
 
@@ -179,7 +180,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var cleanedAdoTeamProject = "Parts-Unlimited";
             var adoTeamProjects = new List<string>() { adoTeamProject };
             var adoRepo = "Some Repo";
-            var adoRepos = new List<string>() { adoRepo };
+            var adoRepos = new List<AdoRepository> { new() { Name = adoRepo } };
             var expectedGithubRepoName = "Parts-Unlimited-Some-Repo";
 
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
@@ -819,7 +820,7 @@ if ($Failed -ne 0) {
         public async Task ParallelScript_Two_Repos_Two_Pipelines_All_Options()
         {
             // Arrange
-            ADO_REPOS = new List<string> { FOO_REPO, BAR_REPO };
+            ADO_REPOS = new List<AdoRepository> { new() { Name = FOO_REPO }, new() { Name = BAR_REPO } };
 
             _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
             _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, ADO_TEAM_PROJECTS)).ReturnsAsync(APP_ID);

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/AdoInspectorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/AdoInspectorServiceTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
+using Octoshift.Models;
 using OctoshiftCLI.AdoToGithub;
 using Xunit;
 
@@ -90,7 +91,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             // Arrange
             var repo1 = "foo";
             var repo2 = "bar";
-            var repos = new List<string>() { repo1, repo2 };
+            var repos = new List<AdoRepository> { new() { Name = repo1 }, new() { Name = repo2 } };
 
             _mockAdoApi.Setup(m => m.GetEnabledRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(repos);
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/OrgsCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/OrgsCsvGeneratorServiceTests.cs
@@ -17,7 +17,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
         private const string ADO_ORG = "foo-org";
-        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
+        private readonly IEnumerable<string> _adoOrgs = new List<string>() { ADO_ORG };
 
         private readonly OrgsCsvGeneratorService _service;
 
@@ -39,7 +39,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            _mockAdoInspectorService.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+            _mockAdoInspectorService.Setup(m => m.GetOrgs()).ReturnsAsync(_adoOrgs);
             _mockAdoInspectorService.Setup(m => m.GetTeamProjectCount(ADO_ORG)).ReturnsAsync(projectCount);
             _mockAdoInspectorService.Setup(m => m.GetRepoCount(ADO_ORG)).ReturnsAsync(repoCount);
             _mockAdoInspectorService.Setup(m => m.GetPipelineCount(ADO_ORG)).ReturnsAsync(pipelineCount);

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
@@ -18,13 +18,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
         private const string ADO_ORG = "foo-org";
-        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
+        private readonly IEnumerable<string> _adoOrgs = new List<string>() { ADO_ORG };
         private const string ADO_TEAM_PROJECT = "foo-tp";
-        private readonly IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
+        private readonly IEnumerable<string> _adoTeamProjects = new List<string>() { ADO_TEAM_PROJECT };
         private const string ADO_REPO = "foo-repo";
-        private readonly IEnumerable<AdoRepository> ADO_REPOS = new List<AdoRepository> { new() { Name = ADO_REPO } };
+        private readonly IEnumerable<AdoRepository> _adoRepos = new List<AdoRepository> { new() { Name = ADO_REPO } };
         private const string ADO_PIPELINE = "foo-pipeline";
-        private readonly IEnumerable<string> ADO_PIPELINES = new List<string>() { ADO_PIPELINE };
+        private readonly IEnumerable<string> _adoPipelines = new List<string>() { ADO_PIPELINE };
 
         private readonly PipelinesCsvGeneratorService _service;
 
@@ -43,10 +43,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockAdoApi.Setup(m => m.GetPipelineId(ADO_ORG, ADO_TEAM_PROJECT, ADO_PIPELINE)).ReturnsAsync(pipelineId);
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            _mockAdoInspectorService.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspectorService.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspectorService.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
-            _mockAdoInspectorService.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO)).ReturnsAsync(ADO_PIPELINES);
+            _mockAdoInspectorService.Setup(m => m.GetOrgs()).ReturnsAsync(_adoOrgs);
+            _mockAdoInspectorService.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(_adoTeamProjects);
+            _mockAdoInspectorService.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(_adoRepos);
+            _mockAdoInspectorService.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO)).ReturnsAsync(_adoPipelines);
 
             // Act
             var result = await _service.Generate(null);

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
+using Octoshift.Models;
 using OctoshiftCLI.AdoToGithub;
 using Xunit;
 
@@ -21,7 +22,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private const string ADO_TEAM_PROJECT = "foo-tp";
         private readonly IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
         private const string ADO_REPO = "foo-repo";
-        private readonly IEnumerable<string> ADO_REPOS = new List<string>() { ADO_REPO };
+        private readonly IEnumerable<AdoRepository> ADO_REPOS = new List<AdoRepository> { new() { Name = ADO_REPO } };
         private const string ADO_PIPELINE = "foo-pipeline";
         private readonly IEnumerable<string> ADO_PIPELINES = new List<string>() { ADO_PIPELINE };
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
@@ -11,7 +11,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 {
     public class ReposCsvGeneratorServiceTests
     {
-        private const string CSV_HEADER = "org,teamproject,repo,url,pipeline-count,pr-count,last-push-date,commits-past-year,most-active-contributor";
+        private const string CSV_HEADER = "org,teamproject,repo,url,pipeline-count,pr-count,last-push-date,commits-past-year,most-active-contributor,compressed-repo-size-in-bytes";
 
         private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
         private readonly Mock<AdoApiFactory> _mockAdoApiFactory = TestHelpers.CreateMock<AdoApiFactory>();
@@ -23,7 +23,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private const string ADO_TEAM_PROJECT = "foo-tp";
         private readonly IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
         private const string ADO_REPO = "foo-repo";
-        private readonly IEnumerable<AdoRepository> ADO_REPOS = new List<AdoRepository> { new() { Name = ADO_REPO } };
+        private readonly IEnumerable<AdoRepository> ADO_REPOS = new List<AdoRepository> { new() { Name = ADO_REPO, Size = 12345 } };
 
         private readonly ReposCsvGeneratorService _service;
 
@@ -60,7 +60,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             // Assert
             var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            expected += $"\"{ADO_ORG}\",\"{ADO_TEAM_PROJECT}\",\"{ADO_REPO}\",\"https://dev.azure.com/{ADO_ORG}/{ADO_TEAM_PROJECT}/_git/{ADO_REPO}\",{pipelineCount},{prCount},\"{lastPushDate:dd-MMM-yyyy hh:mm tt}\",{commitCount},\"Arin\"{Environment.NewLine}";
+            expected += $"\"{ADO_ORG}\",\"{ADO_TEAM_PROJECT}\",\"{ADO_REPO}\",\"https://dev.azure.com/{ADO_ORG}/{ADO_TEAM_PROJECT}/_git/{ADO_REPO}\",{pipelineCount},{prCount},\"{lastPushDate:dd-MMM-yyyy hh:mm tt}\",{commitCount},\"Arin\",\"12,345\"{Environment.NewLine}";
 
             result.Should().Be(expected);
         }
@@ -92,7 +92,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             // Assert
             var expected = $"{CSV_HEADER}{Environment.NewLine}";
-            expected += $"\"{ADO_ORG}\",\"{ADO_TEAM_PROJECT}\",\"{ADO_REPO}\",\"https://dev.azure.com/{ADO_ORG}/{ADO_TEAM_PROJECT}/_git/{ADO_REPO}\",{pipelineCount},{prCount},\"{lastPushDate:dd-MMM-yyyy hh:mm tt}\",{commitCount},\"Max\"{Environment.NewLine}";
+            expected += $"\"{ADO_ORG}\",\"{ADO_TEAM_PROJECT}\",\"{ADO_REPO}\",\"https://dev.azure.com/{ADO_ORG}/{ADO_TEAM_PROJECT}/_git/{ADO_REPO}\",{pipelineCount},{prCount},\"{lastPushDate:dd-MMM-yyyy hh:mm tt}\",{commitCount},\"Max\",\"12,345\"{Environment.NewLine}";
 
             result.Should().Be(expected);
         }

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
@@ -19,11 +19,11 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
         private const string ADO_ORG = "foo-org";
-        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
+        private readonly IEnumerable<string> _adoOrgs = new List<string>() { ADO_ORG };
         private const string ADO_TEAM_PROJECT = "foo-tp";
-        private readonly IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
+        private readonly IEnumerable<string> _adoTeamProjects = new List<string>() { ADO_TEAM_PROJECT };
         private const string ADO_REPO = "foo-repo";
-        private readonly IEnumerable<AdoRepository> ADO_REPOS = new List<AdoRepository> { new() { Name = ADO_REPO, Size = 12345 } };
+        private readonly IEnumerable<AdoRepository> _adoRepos = new List<AdoRepository> { new() { Name = ADO_REPO, Size = 12345 } };
 
         private readonly ReposCsvGeneratorService _service;
 
@@ -45,9 +45,9 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            _mockAdoInspectorService.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspectorService.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspectorService.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+            _mockAdoInspectorService.Setup(m => m.GetOrgs()).ReturnsAsync(_adoOrgs);
+            _mockAdoInspectorService.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(_adoTeamProjects);
+            _mockAdoInspectorService.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(_adoRepos);
             _mockAdoInspectorService.Setup(m => m.GetPipelineCount(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO)).ReturnsAsync(pipelineCount);
             _mockAdoInspectorService.Setup(m => m.GetPullRequestCount(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO)).ReturnsAsync(prCount);
             _mockAdoApi.Setup(m => m.GetPushersSince(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO, It.IsAny<DateTime>())).ReturnsAsync(pushers);
@@ -77,9 +77,9 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            _mockAdoInspectorService.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspectorService.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
-            _mockAdoInspectorService.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+            _mockAdoInspectorService.Setup(m => m.GetOrgs()).ReturnsAsync(_adoOrgs);
+            _mockAdoInspectorService.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(_adoTeamProjects);
+            _mockAdoInspectorService.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(_adoRepos);
             _mockAdoInspectorService.Setup(m => m.GetPipelineCount(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO)).ReturnsAsync(pipelineCount);
             _mockAdoInspectorService.Setup(m => m.GetPullRequestCount(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO)).ReturnsAsync(prCount);
             _mockAdoApi.Setup(m => m.GetPushersSince(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO, It.IsAny<DateTime>())).ReturnsAsync(pushers);

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
+using Octoshift.Models;
 using OctoshiftCLI.AdoToGithub;
 using Xunit;
 
@@ -22,7 +23,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private const string ADO_TEAM_PROJECT = "foo-tp";
         private readonly IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
         private const string ADO_REPO = "foo-repo";
-        private readonly IEnumerable<string> ADO_REPOS = new List<string>() { ADO_REPO };
+        private readonly IEnumerable<AdoRepository> ADO_REPOS = new List<AdoRepository> { new() { Name = ADO_REPO } };
 
         private readonly ReposCsvGeneratorService _service;
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/TeamProjectsCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/TeamProjectsCsvGeneratorServiceTests.cs
@@ -17,9 +17,9 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
         private const string ADO_ORG = "foo-org";
-        private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
+        private readonly IEnumerable<string> _adoOrgs = new List<string>() { ADO_ORG };
         private const string ADO_TEAM_PROJECT = "foo-tp";
-        private readonly IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
+        private readonly IEnumerable<string> _adoTeamProjects = new List<string>() { ADO_TEAM_PROJECT };
 
         private readonly TeamProjectsCsvGeneratorService _service;
 
@@ -39,8 +39,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            _mockAdoInspectorService.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
-            _mockAdoInspectorService.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+            _mockAdoInspectorService.Setup(m => m.GetOrgs()).ReturnsAsync(_adoOrgs);
+            _mockAdoInspectorService.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(_adoTeamProjects);
             _mockAdoInspectorService.Setup(m => m.GetRepoCount(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(repoCount);
             _mockAdoInspectorService.Setup(m => m.GetPipelineCount(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(pipelineCount);
             _mockAdoInspectorService.Setup(m => m.GetPullRequestCount(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(prCount);

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
+using Octoshift.Models;
 using OctoshiftCLI.Extensions;
 using OctoshiftCLI.GithubEnterpriseImporter;
 using OctoshiftCLI.GithubEnterpriseImporter.Commands;
@@ -261,8 +262,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             const string repo2 = "foo-repo2";
 
             _mockAdoApi.Setup(x => x.GetTeamProjects(org)).ReturnsAsync(new[] { teamProject1, teamProject2 });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(org, teamProject1)).ReturnsAsync(new[] { repo1 });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(org, teamProject2)).ReturnsAsync(new[] { repo2 });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(org, teamProject1)).ReturnsAsync(new[] { new AdoRepository { Name = repo1 } });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(org, teamProject2)).ReturnsAsync(new[] { new AdoRepository { Name = repo2 } });
 
             _mockAdoApiFactory
                 .Setup(m => m.Create(null, null))
@@ -297,7 +298,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             const string repo2 = "FOO-REPO2";
 
             _mockAdoApi.Setup(x => x.GetTeamProjects(org)).ReturnsAsync(new[] { adoTeamProject, anotherTeamProject });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(org, adoTeamProject)).ReturnsAsync(new[] { repo1, repo2 });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(org, adoTeamProject)).ReturnsAsync(new[] { new AdoRepository { Name = repo1 }, new AdoRepository { Name = repo2 } });
 
             _mockAdoApiFactory
                 .Setup(m => m.Create(null, null))
@@ -478,7 +479,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             const string adoTeamProject = "ADO-TEAM-PROJECT";
 
             _mockAdoApi.Setup(x => x.GetTeamProjects(SOURCE_ORG)).ReturnsAsync(new[] { adoTeamProject });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { REPO });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { new AdoRepository { Name = REPO } });
 
             _mockAdoApiFactory
                 .Setup(m => m.Create(null, null))
@@ -511,7 +512,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             const string adoRepo = "SOME REPO";
 
             _mockAdoApi.Setup(x => x.GetTeamProjects(SOURCE_ORG)).ReturnsAsync(new[] { adoTeamProject });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { adoRepo });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { new AdoRepository { Name = adoRepo } });
 
             _mockAdoApiFactory
                 .Setup(m => m.Create(null, null))
@@ -544,7 +545,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             const string adoServerUrl = "https://ado.contoso.com";
 
             _mockAdoApi.Setup(x => x.GetTeamProjects(SOURCE_ORG)).ReturnsAsync(new[] { adoTeamProject });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { REPO });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { new AdoRepository { Name = REPO } });
 
             _mockAdoApiFactory
                 .Setup(m => m.Create(adoServerUrl, null))
@@ -580,7 +581,12 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             const string repo3 = "FOO-REPO-3";
 
             _mockAdoApi.Setup(x => x.GetTeamProjects(SOURCE_ORG)).ReturnsAsync(new[] { adoTeamProject });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { repo1, repo2, repo3 });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[]
+            {
+                new AdoRepository { Name = repo1 },
+                new AdoRepository { Name = repo2 },
+                new AdoRepository { Name = repo3 }
+            });
 
             _mockAdoApiFactory
                 .Setup(m => m.Create(null, null))
@@ -617,7 +623,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             const string repo2 = "FOO-REPO-2";
 
             _mockAdoApi.Setup(x => x.GetTeamProjects(SOURCE_ORG)).ReturnsAsync(new[] { adoTeamProject });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { repo1, repo2 });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { new AdoRepository { Name = repo1 }, new AdoRepository { Name = repo2 } });
 
             _mockAdoApiFactory
                 .Setup(m => m.Create(null, null))
@@ -879,7 +885,7 @@ if ($Failed -ne 0) {
             const string adoTeamProject = "ADO-TEAM-PROJECT";
 
             _mockAdoApi.Setup(x => x.GetTeamProjects(SOURCE_ORG)).ReturnsAsync(new[] { adoTeamProject });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, It.IsAny<string>())).ReturnsAsync(new[] { REPO });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, It.IsAny<string>())).ReturnsAsync(new[] { new AdoRepository { Name = REPO } });
 
             _mockAdoApiFactory
                 .Setup(m => m.Create(null, null))
@@ -915,7 +921,7 @@ if ($Failed -ne 0) {
             const string adoServerUrl = "https://ado.contoso.com";
 
             _mockAdoApi.Setup(x => x.GetTeamProjects(SOURCE_ORG)).ReturnsAsync(new[] { adoTeamProject });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { REPO });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { new AdoRepository { Name = REPO } });
 
             _mockAdoApiFactory
                 .Setup(m => m.Create(adoServerUrl, null))
@@ -954,7 +960,12 @@ if ($Failed -ne 0) {
             const string repo3 = "FOO-REPO-3";
 
             _mockAdoApi.Setup(x => x.GetTeamProjects(SOURCE_ORG)).ReturnsAsync(new[] { adoTeamProject });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { repo1, repo2, repo3 });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[]
+            {
+                new AdoRepository { Name = repo1},
+                new AdoRepository { Name = repo2},
+                new AdoRepository { Name = repo3}
+            });
 
             _mockAdoApiFactory
                 .Setup(m => m.Create(null, null))
@@ -995,7 +1006,7 @@ if ($Failed -ne 0) {
             const string repo2 = "FOO-REPO-2";
 
             _mockAdoApi.Setup(x => x.GetTeamProjects(SOURCE_ORG)).ReturnsAsync(new[] { adoTeamProject });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, It.IsAny<string>())).ReturnsAsync(new[] { repo1, repo2 });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, It.IsAny<string>())).ReturnsAsync(new[] { new AdoRepository { Name = repo1 }, new AdoRepository { Name = repo2 } });
 
             _mockAdoApiFactory
                 .Setup(m => m.Create(null, null))
@@ -1523,7 +1534,7 @@ if ($Failed -ne 0) {
             const string adoTeamProject = "ADO-TEAM-PROJECT";
 
             _mockAdoApi.Setup(x => x.GetTeamProjects(SOURCE_ORG)).ReturnsAsync(new[] { adoTeamProject });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { REPO });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, adoTeamProject)).ReturnsAsync(new[] { new AdoRepository { Name = REPO } });
 
             _mockAdoApiFactory
                 .Setup(m => m.Create(null, null))
@@ -1555,7 +1566,7 @@ if ($Failed -ne 0) {
 
             // Arrange
             _mockAdoApi.Setup(x => x.GetTeamProjects(SOURCE_ORG)).ReturnsAsync(new[] { adoTeamProject });
-            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, It.IsAny<string>())).ReturnsAsync(new[] { REPO });
+            _mockAdoApi.Setup(x => x.GetEnabledRepos(SOURCE_ORG, It.IsAny<string>())).ReturnsAsync(new[] { new AdoRepository { Name = REPO } });
 
             _mockAdoApiFactory
                 .Setup(m => m.Create(null, null))

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -212,9 +212,9 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                 {
                     foreach (var repo in await _adoInspectorService.GetRepos(org, teamProject))
                     {
-                        if (!seen.Add(GetGithubRepoName(teamProject, repo)))
+                        if (!seen.Add(GetGithubRepoName(teamProject, repo.Name)))
                         {
-                            _log.LogWarning($"DUPLICATE REPO NAME: {GetGithubRepoName(teamProject, repo)}");
+                            _log.LogWarning($"DUPLICATE REPO NAME: {GetGithubRepoName(teamProject, repo.Name)}");
                         }
                     }
                 }
@@ -262,19 +262,19 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
                     foreach (var adoRepo in await _adoInspectorService.GetRepos(adoOrg, adoTeamProject))
                     {
-                        var githubRepo = GetGithubRepoName(adoTeamProject, adoRepo);
+                        var githubRepo = GetGithubRepoName(adoTeamProject, adoRepo.Name);
 
                         AppendLine(content);
-                        AppendLine(content, Exec(LockAdoRepoScript(adoOrg, adoTeamProject, adoRepo)));
-                        AppendLine(content, Exec(MigrateRepoScript(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, true)));
-                        AppendLine(content, Exec(DisableAdoRepoScript(adoOrg, adoTeamProject, adoRepo)));
+                        AppendLine(content, Exec(LockAdoRepoScript(adoOrg, adoTeamProject, adoRepo.Name)));
+                        AppendLine(content, Exec(MigrateRepoScript(adoOrg, adoTeamProject, adoRepo.Name, githubOrg, githubRepo, true)));
+                        AppendLine(content, Exec(DisableAdoRepoScript(adoOrg, adoTeamProject, adoRepo.Name)));
                         AppendLine(content, Exec(ConfigureAutolinkScript(githubOrg, githubRepo, adoOrg, adoTeamProject)));
                         AppendLine(content, Exec(AddMaintainersToGithubRepoScript(adoTeamProject, githubOrg, githubRepo)));
                         AppendLine(content, Exec(AddAdminsToGithubRepoScript(adoTeamProject, githubOrg, githubRepo)));
                         AppendLine(content, Exec(BoardsIntegrationScript(adoOrg, adoTeamProject, githubOrg, githubRepo)));
                         AppendLine(content, Exec(DownloadMigrationLogScript(githubOrg, githubRepo)));
 
-                        foreach (var adoPipeline in await _adoInspectorService.GetPipelines(adoOrg, adoTeamProject, adoRepo))
+                        foreach (var adoPipeline in await _adoInspectorService.GetPipelines(adoOrg, adoTeamProject, adoRepo.Name))
                         {
                             AppendLine(content, Exec(RewireAzurePipelineScript(adoOrg, adoTeamProject, adoPipeline, githubOrg, githubRepo, appId)));
                         }
@@ -336,11 +336,11 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                     foreach (var adoRepo in await _adoInspectorService.GetRepos(adoOrg, adoTeamProject))
                     {
 
-                        var githubRepo = GetGithubRepoName(adoTeamProject, adoRepo);
+                        var githubRepo = GetGithubRepoName(adoTeamProject, adoRepo.Name);
 
                         AppendLine(content);
-                        AppendLine(content, Exec(LockAdoRepoScript(adoOrg, adoTeamProject, adoRepo)));
-                        AppendLine(content, QueueMigrateRepoScript(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo));
+                        AppendLine(content, Exec(LockAdoRepoScript(adoOrg, adoTeamProject, adoRepo.Name)));
+                        AppendLine(content, QueueMigrateRepoScript(adoOrg, adoTeamProject, adoRepo.Name, githubOrg, githubRepo));
                         AppendLine(content, $"$RepoMigrations[\"{GetRepoMigrationKey(adoOrg, githubRepo)}\"] = $MigrationID");
                     }
                 }
@@ -357,9 +357,9 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                     foreach (var adoRepo in await _adoInspectorService.GetRepos(adoOrg, adoTeamProject))
                     {
                         AppendLine(content);
-                        AppendLine(content, $"# === Waiting for repo migration to finish for Team Project: {adoTeamProject} and Repo: {adoRepo}. Will then complete the below post migration steps. ===");
+                        AppendLine(content, $"# === Waiting for repo migration to finish for Team Project: {adoTeamProject} and Repo: {adoRepo.Name}. Will then complete the below post migration steps. ===");
 
-                        var githubRepo = GetGithubRepoName(adoTeamProject, adoRepo);
+                        var githubRepo = GetGithubRepoName(adoTeamProject, adoRepo.Name);
                         var repoMigrationKey = GetRepoMigrationKey(adoOrg, githubRepo);
 
                         AppendLine(content, "$CanExecuteBatch = $true");
@@ -378,7 +378,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                         )
                         {
                             AppendLine(content, "    ExecBatch @(");
-                            AppendLine(content, "        " + Wrap(DisableAdoRepoScript(adoOrg, adoTeamProject, adoRepo)));
+                            AppendLine(content, "        " + Wrap(DisableAdoRepoScript(adoOrg, adoTeamProject, adoRepo.Name)));
                             AppendLine(content, "        " + Wrap(ConfigureAutolinkScript(githubOrg, githubRepo, adoOrg, adoTeamProject)));
                             AppendLine(content, "        " + Wrap(AddMaintainersToGithubRepoScript(adoTeamProject, githubOrg, githubRepo)));
                             AppendLine(content, "        " + Wrap(AddAdminsToGithubRepoScript(adoTeamProject, githubOrg, githubRepo)));
@@ -386,7 +386,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                             AppendLine(content, "        " + Wrap(DownloadMigrationLogScript(githubOrg, githubRepo)));
 
                             appIds.TryGetValue(adoOrg, out var appId);
-                            foreach (var adoPipeline in await _adoInspectorService.GetPipelines(adoOrg, adoTeamProject, adoRepo))
+                            foreach (var adoPipeline in await _adoInspectorService.GetPipelines(adoOrg, adoTeamProject, adoRepo.Name))
                             {
                                 AppendLine(content, "        " + Wrap(RewireAzurePipelineScript(adoOrg, adoTeamProject, adoPipeline, githubOrg, githubRepo, appId)));
                             }

--- a/src/ado2gh/Services/AdoInspectorService.cs
+++ b/src/ado2gh/Services/AdoInspectorService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Octoshift.Models;
 using OctoshiftCLI.Extensions;
 
 namespace OctoshiftCLI.AdoToGithub
@@ -12,7 +13,7 @@ namespace OctoshiftCLI.AdoToGithub
 
         private IEnumerable<string> _orgs;
         private readonly IDictionary<string, IEnumerable<string>> _teamProjects = new Dictionary<string, IEnumerable<string>>();
-        private readonly IDictionary<string, IDictionary<string, IEnumerable<string>>> _repos = new Dictionary<string, IDictionary<string, IEnumerable<string>>>();
+        private readonly IDictionary<string, IDictionary<string, IEnumerable<AdoRepository>>> _repos = new Dictionary<string, IDictionary<string, IEnumerable<AdoRepository>>>();
         private readonly IDictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>> _pipelines = new Dictionary<string, IDictionary<string, IDictionary<string, IEnumerable<string>>>>();
         private readonly IDictionary<string, IDictionary<string, IDictionary<string, int>>> _prCounts = new Dictionary<string, IDictionary<string, IDictionary<string, int>>>();
 
@@ -88,7 +89,7 @@ namespace OctoshiftCLI.AdoToGithub
         public virtual async Task<int> GetPipelineCount(string org, string teamProject)
         {
             var repos = await GetRepos(org, teamProject);
-            return await repos.Sum(async r => await GetPipelineCount(org, teamProject, r));
+            return await repos.Sum(async r => await GetPipelineCount(org, teamProject, r.Name));
         }
 
         public virtual async Task<int> GetPipelineCount(string org, string teamProject, string repo)
@@ -99,7 +100,7 @@ namespace OctoshiftCLI.AdoToGithub
         public virtual async Task<int> GetPullRequestCount(string org, string teamProject)
         {
             var repos = await GetRepos(org, teamProject);
-            return await repos.Sum(async r => await GetPullRequestCount(org, teamProject, r));
+            return await repos.Sum(async r => await GetPullRequestCount(org, teamProject, r.Name));
         }
 
         public virtual async Task<int> GetPullRequestCount(string org)
@@ -119,11 +120,11 @@ namespace OctoshiftCLI.AdoToGithub
             return teamProjects;
         }
 
-        public virtual async Task<IEnumerable<string>> GetRepos(string org, string teamProject)
+        public virtual async Task<IEnumerable<AdoRepository>> GetRepos(string org, string teamProject)
         {
             if (!_repos.ContainsKey(org))
             {
-                _repos.Add(org, new Dictionary<string, IEnumerable<string>>());
+                _repos.Add(org, new Dictionary<string, IEnumerable<AdoRepository>>());
             }
 
             if (!_repos[org].TryGetValue(teamProject, out var repos))

--- a/src/ado2gh/Services/PipelinesCsvGeneratorService.cs
+++ b/src/ado2gh/Services/PipelinesCsvGeneratorService.cs
@@ -29,11 +29,11 @@ namespace OctoshiftCLI.AdoToGithub
                 {
                     foreach (var repo in await inspector.GetRepos(org, teamProject))
                     {
-                        foreach (var pipeline in await inspector.GetPipelines(org, teamProject, repo))
+                        foreach (var pipeline in await inspector.GetPipelines(org, teamProject, repo.Name))
                         {
                             var pipelineId = await adoApi.GetPipelineId(org, teamProject, pipeline);
                             var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}/_build?definitionId={pipelineId}";
-                            result.AppendLine($"\"{org}\",\"{teamProject}\",\"{repo}\",\"{pipeline}\",\"{url}\"");
+                            result.AppendLine($"\"{org}\",\"{teamProject}\",\"{repo.Name}\",\"{pipeline}\",\"{url}\"");
                         }
                     }
                 }

--- a/src/ado2gh/Services/ReposCsvGeneratorService.cs
+++ b/src/ado2gh/Services/ReposCsvGeneratorService.cs
@@ -22,7 +22,7 @@ namespace OctoshiftCLI.AdoToGithub
             var inspector = _adoInspectorServiceFactory.Create(adoApi);
             var result = new StringBuilder();
 
-            result.AppendLine("org,teamproject,repo,url,pipeline-count,pr-count,last-push-date,commits-past-year,most-active-contributor");
+            result.AppendLine("org,teamproject,repo,url,pipeline-count,pr-count,last-push-date,commits-past-year,most-active-contributor,compressed-repo-size-in-bytes");
 
             foreach (var org in await inspector.GetOrgs())
             {
@@ -37,7 +37,7 @@ namespace OctoshiftCLI.AdoToGithub
                         var commitsPastYear = await adoApi.GetCommitCountSince(org, teamProject, repo.Name, DateTime.Today.AddYears(-1));
                         var mostActiveContributor = await GetMostActiveContributor(org, teamProject, repo.Name, adoApi);
 
-                        result.AppendLine($"\"{org}\",\"{teamProject}\",\"{repo.Name}\",\"{url}\",{pipelineCount},{prCount},\"{lastPushDate:dd-MMM-yyyy hh:mm tt}\",{commitsPastYear},\"{mostActiveContributor}\"");
+                        result.AppendLine($"\"{org}\",\"{teamProject}\",\"{repo.Name}\",\"{url}\",{pipelineCount},{prCount},\"{lastPushDate:dd-MMM-yyyy hh:mm tt}\",{commitsPastYear},\"{mostActiveContributor}\",\"{repo.Size:N0}\"");
                     }
                 }
             }

--- a/src/ado2gh/Services/ReposCsvGeneratorService.cs
+++ b/src/ado2gh/Services/ReposCsvGeneratorService.cs
@@ -30,14 +30,14 @@ namespace OctoshiftCLI.AdoToGithub
                 {
                     foreach (var repo in await inspector.GetRepos(org, teamProject))
                     {
-                        var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}/_git/{Uri.EscapeDataString(repo)}";
-                        var pipelineCount = await inspector.GetPipelineCount(org, teamProject, repo);
-                        var prCount = await inspector.GetPullRequestCount(org, teamProject, repo);
-                        var lastPushDate = await adoApi.GetLastPushDate(org, teamProject, repo);
-                        var commitsPastYear = await adoApi.GetCommitCountSince(org, teamProject, repo, DateTime.Today.AddYears(-1));
-                        var mostActiveContributor = await GetMostActiveContributor(org, teamProject, repo, adoApi);
+                        var url = $"https://dev.azure.com/{Uri.EscapeDataString(org)}/{Uri.EscapeDataString(teamProject)}/_git/{Uri.EscapeDataString(repo.Name)}";
+                        var pipelineCount = await inspector.GetPipelineCount(org, teamProject, repo.Name);
+                        var prCount = await inspector.GetPullRequestCount(org, teamProject, repo.Name);
+                        var lastPushDate = await adoApi.GetLastPushDate(org, teamProject, repo.Name);
+                        var commitsPastYear = await adoApi.GetCommitCountSince(org, teamProject, repo.Name, DateTime.Today.AddYears(-1));
+                        var mostActiveContributor = await GetMostActiveContributor(org, teamProject, repo.Name, adoApi);
 
-                        result.AppendLine($"\"{org}\",\"{teamProject}\",\"{repo}\",\"{url}\",{pipelineCount},{prCount},\"{lastPushDate:dd-MMM-yyyy hh:mm tt}\",{commitsPastYear},\"{mostActiveContributor}\"");
+                        result.AppendLine($"\"{org}\",\"{teamProject}\",\"{repo.Name}\",\"{url}\",{pipelineCount},{prCount},\"{lastPushDate:dd-MMM-yyyy hh:mm tt}\",{commitsPastYear},\"{mostActiveContributor}\"");
                     }
                 }
             }

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -528,7 +528,7 @@ if ($Failed -ne 0) {
         private async Task<IEnumerable<string>> GetTeamProjectRepos(AdoApi adoApi, string adoOrg, string teamProject)
         {
             _log.LogInformation($"Team Project: {teamProject}");
-            var projectRepos = await adoApi.GetEnabledRepos(adoOrg, teamProject);
+            var projectRepos = (await adoApi.GetEnabledRepos(adoOrg, teamProject)).Select(repo => repo.Name);
 
             foreach (var repo in projectRepos)
             {


### PR DESCRIPTION
Closes #461 

This PR adds an additional field to `repos.csv` that reports the compressed size of each ADO repository.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
