### PR TITLE
Ghes no ssl verify

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,2 @@
 - `ado2gh inventory-report` command now also reports the compressed size of each repo in `repos.csv`.
-- fixed bug in gh gei generate-script so that it properly respects the --no-ssl-verify argument
+- fixed bug in `gh gei generate-script` so that it properly respects the `--no-ssl-verify` argument

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 - `ado2gh inventory-report` command now also reports the compressed size of each repo in `repos.csv`.
+- fixed bug in gh gei generate-script so that it properly respects the --no-ssl-verify argument

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -319,7 +319,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Assert
             _script.Should().NotBeEmpty();
-            _mockSourceGithubApiFactory.Verify(m => CreateClientNoSsl(ghesApiUrl, It.IsAny<string>()), Times.Once);
+            _mockSourceGithubApiFactory.Verify(m => m.CreateClientNoSsl(ghesApiUrl, It.IsAny<string>()), Times.Once);
             _mockGithubApi.Verify(m => m.GetRepos(args.GithubSourceOrg), Times.Once);
         }
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -287,7 +287,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         }
 
         [Fact]
-        public async Task Invoke_Returns_For_Ghas_NoSsl_Client_When_NoSsl_Parameter_is_Provided()
+        public async Task Invoke_Returns_For_Ghas_NoSsl_Client_When_NoSsl_Parameter_Is_Provided()
         {
 
             // Arrange
@@ -314,8 +314,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 NoSslVerify = true,
                 Sequential = true
             };
-
-          
             await _command.Invoke(args);
 
             // Assert

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -287,7 +287,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         }
 
         [Fact]
-        public async Task Invoke_Returns_For_Ghas_NoSsl_Client_When_NoSsl_Parameter_Is_Provided()
+        public async Task Invoke_Returns_For_Ghes_NoSsl_Client_When_NoSsl_Parameter_Is_Provided()
         {
 
             // Arrange

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -318,7 +318,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Assert
             _script.Should().NotBeEmpty();
-            _mockGithubApi.Verify(m=> m.GetRepos(args.GithubSourceOrg), Times.Once);
+            _mockGithubApi.Verify(m => m.GetRepos(args.GithubSourceOrg), Times.Once);
         }
 
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -318,6 +318,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Assert
             _script.Should().NotBeEmpty();
+            _mockSourceGithubApiFactory.Verify(m => CreateClientNoSsl(ghesApiUrl, It.IsAny<string>()), Times.Once);
             _mockGithubApi.Verify(m => m.GetRepos(args.GithubSourceOrg), Times.Once);
         }
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -437,7 +437,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .ReturnsAsync(new[] { REPO });
 
             _mockSourceGithubApiFactory
-                .Setup(m => m.Create(ghesApiUrl, It.IsAny<string>()))
+                .Setup(m => m.CreateClientNoSsl(ghesApiUrl, It.IsAny<string>()))
                 .Returns(_mockGithubApi.Object);
 
             var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{REPO}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{REPO}\" --ghes-api-url \"{ghesApiUrl}\" --azure-storage-connection-string \"{azureStorageConnectionString}\" --no-ssl-verify --wait }}";
@@ -1307,7 +1307,7 @@ if ($Failed -ne 0) {
                 .ReturnsAsync(new[] { REPO });
 
             _mockSourceGithubApiFactory
-                .Setup(m => m.Create(ghesApiUrl, It.IsAny<string>()))
+                .Setup(m => m.CreateClientNoSsl(ghesApiUrl, It.IsAny<string>()))
                 .Returns(_mockGithubApi.Object);
 
             _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -287,6 +287,44 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         }
 
         [Fact]
+        public async Task Invoke_Returns_For_Ghas_NoSsl_Client_When_NoSsl_Parameter_is_Provided()
+        {
+
+            // Arrange
+            const string ghesApiUrl = "https://foo.com/api/v3";
+            const string azureStorageConnectionString = "FOO-STORAGE-CONNECTION-STRING";
+
+            _mockGithubApi
+                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .ReturnsAsync(new[] { REPO });
+
+            _mockSourceGithubApiFactory
+                .Setup(m => m.CreateClientNoSsl(ghesApiUrl, It.IsAny<string>()))
+                .Returns(_mockGithubApi.Object);
+
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                GithubTargetOrg = TARGET_ORG,
+                Output = new FileInfo("unit-test-output"),
+                GhesApiUrl = ghesApiUrl,
+                AzureStorageConnectionString = azureStorageConnectionString,
+                NoSslVerify = true,
+                Sequential = true
+            };
+
+          
+            await _command.Invoke(args);
+
+            // Assert
+            _script.Should().NotBeEmpty();
+            _mockGithubApi.Verify(m=> m.GetRepos(args.GithubSourceOrg), Times.Once);
+        }
+
+
+        [Fact]
         public async Task Invoke_Gets_All_Ado_Repos_For_Provided_Team_Project()
         {
             // Arrnage

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -244,7 +244,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
         private async Task<string> InvokeGithub(string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool sequential, string githubSourcePat, bool skipReleases, bool downloadMigrationLogs)
         {
-            var repos = await GetGithubRepos(_sourceGithubApiFactory.Create(ghesApiUrl, githubSourcePat), githubSourceOrg);
+            var client = (!ghesApiUrl.IsNullOrWhiteSpace() && noSslVerify) ? _sourceGithubApiFactory.CreateClientNoSsl(ghesApiUrl, githubSourcePat) : _sourceGithubApiFactory.Create(ghesApiUrl, githubSourcePat);
             if (!repos.Any())
             {
                 _log.LogError("A migration script could not be generated because no migratable repos were found.");

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -244,7 +244,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
         private async Task<string> InvokeGithub(string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool sequential, string githubSourcePat, bool skipReleases, bool downloadMigrationLogs)
         {
-            var client = (!ghesApiUrl.IsNullOrWhiteSpace() && noSslVerify) ? _sourceGithubApiFactory.CreateClientNoSsl(ghesApiUrl, githubSourcePat) : _sourceGithubApiFactory.Create(ghesApiUrl, githubSourcePat);
+            var client = (ghesApiUrl.HasValue() && noSslVerify) ? _sourceGithubApiFactory.CreateClientNoSsl(ghesApiUrl, githubSourcePat) : _sourceGithubApiFactory.Create(ghesApiUrl, githubSourcePat);
 
             var repos = await GetGithubRepos(client, githubSourceOrg);
             if (!repos.Any())

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -245,6 +245,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         private async Task<string> InvokeGithub(string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool sequential, string githubSourcePat, bool skipReleases, bool downloadMigrationLogs)
         {
             var client = (!ghesApiUrl.IsNullOrWhiteSpace() && noSslVerify) ? _sourceGithubApiFactory.CreateClientNoSsl(ghesApiUrl, githubSourcePat) : _sourceGithubApiFactory.Create(ghesApiUrl, githubSourcePat);
+
+            var repos = await GetGithubRepos(client, githubSourceOrg);
             if (!repos.Any())
             {
                 _log.LogError("A migration script could not be generated because no migratable repos were found.");


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->

Issue was  that when nossl was true it was not applied when querying repo data from GHES and that failed to validated SSL connection if self-signed certificate was used
