### PR TITLE
rewire-pipeline option to change default branch

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
 - `--github-pat` arg in the `gei reclaim-mannequin` command was renamed to `--github-target-pat` to follow the same naming convention for other commands like ` gei migrate-repo` or `gei generate-mannequin-csv` 
 - `ado2gh inventory-report` command now also reports the compressed size of each repo in `repos.csv`.
 - fixed bug in `gh gei generate-script` so that it properly respects the `--no-ssl-verify` argument
+- `rewire-pipeline` now has a `--default-branch` option to target a different default branch

--- a/src/ado2gh/Commands/RewirePipelineCommand.cs
+++ b/src/ado2gh/Commands/RewirePipelineCommand.cs
@@ -71,7 +71,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             Handler = CommandHandler.Create<string, string, string, string, string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string adoOrg, string adoTeamProject, string adoPipeline, string githubOrg, string githubRepo, string serviceConnectionId, string defaultBranch = null, string adoPat = null, bool verbose = false)
+        public async Task Invoke(string adoOrg, string adoTeamProject, string adoPipeline, string githubOrg, string githubRepo, string serviceConnectionId, string adoPat = null, string defaultBranch = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 


### PR DESCRIPTION
This PR adds `--default-branch` option to `rewire-pipeline` allowing me to target a different branch. In my case I'm migrating from a repo with `master` to one with `main`.

See issue: #484 

Added unit tests to confirm behaviour with and without the option.

![image](https://user-images.githubusercontent.com/4551792/177730885-3d8cf7e5-a176-4e74-a6cf-6018c60f7c52.png)

Example usage:
```
rewire-pipeline --ado-org "<snip>" --ado-team-project "Fredproj" --ado-pipeline "\Fredproj (1)" --github-org "<gh-org>" - github-repo "TestMerger" --service-connection-id  <sc-id> --ado-pat <my-pat> --default-branch main
```