### PR TITLE
sanitize pr number

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -38,7 +38,7 @@ jobs:
           eventjson=`cat 'artifacts/Event File/event.json'`
           prnumber=`echo $(jq -r '.pull_request.number' <<< "$eventjson")`
           echo $prnumber
-          echo "PR_NUMBER=$(echo $prnumber | sed 's/[*0-9]*//g')" >> $GITHUB_ENV
+          echo "PR_NUMBER=$(echo $prnumber | sed 's/[^0-9]*//g')" >> $GITHUB_ENV
       
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -38,7 +38,7 @@ jobs:
           eventjson=`cat 'artifacts/Event File/event.json'`
           prnumber=`echo $(jq -r '.pull_request.number' <<< "$eventjson")`
           echo $prnumber
-          echo "PR_NUMBER=$(echo $prnumber | sed 's/[^0-9]*//g')" >> $GITHUB_ENV
+          echo "PR_NUMBER=$(echo $prnumber | sed 's/[^0-9]*//g' | tr -d '\n')" >> $GITHUB_ENV
       
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -37,10 +37,8 @@ jobs:
         run: |
           eventjson=`cat 'artifacts/Event File/event.json'`
           prnumber=`echo $(jq -r '.pull_request.number' <<< "$eventjson")`
-          prorg=`echo $(jq -r '.pull_request.head.repo.owner.login' <<< "$eventjson")`
           echo $prnumber
-          echo "PR_NUMBER=$(echo $prnumber)" >> $GITHUB_ENV
-          echo "PR_ORG=$(echo $prnumber)" >> $GITHUB_ENV
+          echo "PR_NUMBER=$(echo $prnumber | sed 's/[*0-9]*//g')" >> $GITHUB_ENV
       
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
@@ -57,13 +55,3 @@ jobs:
           recreate: true
           path: artifacts/Code Coverage Report/code-coverage-results.md
           number: ${{ env.PR_NUMBER }}
-
-      - name: Publish Integration Test Results
-        if: ${{ env.PR_ORG == 'github' }}
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        with:
-          commit: ${{ github.event.workflow_run.head_sha }}
-          event_file: artifacts/Event File/event.json
-          event_name: ${{ github.event.workflow_run.event }}
-          files: 'artifacts/Integration Test Results/*.xml'
-          check_name: "Integration Test Results"


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Sanitizes the PR Number in publish-test-results.yml workflow. Uses `sed` to strip any non numeric characters from the string.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->