### PR TITLE
remove echo of pr number

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -37,7 +37,6 @@ jobs:
         run: |
           eventjson=`cat 'artifacts/Event File/event.json'`
           prnumber=`echo $(jq -r '.pull_request.number' <<< "$eventjson")`
-          echo $prnumber
           echo "PR_NUMBER=$(echo $prnumber | sed 's/[^0-9]*//g' | tr -d '\n')" >> $GITHUB_ENV
       
       - name: Publish Unit Test Results


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Removing the `echo $prnumber` line from our publish-test-results.yml workflow. $prnumber is (potentially) a user-provided value and there are security concerns with echoing user-provided values in a workflow (https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#stopping-and-starting-workflow-commands). 

There are ways to make it secure, as suggested in this PR from @JarLob #508 . But in this case the echo is unnecessary so we're going to just remove it.

Closes #511 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->