### PR TITLE
Update documentation with updated flags for org names

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Refer to the [official documentation](https://docs.github.com/en/early-access/gi
 2. Set the ADO_PAT and GH_PAT environment variables.
 
 3. Run the `generate-script` command to generate a migration script.
->`ado2gh generate-script --ado-org ORGNAME --github-org ORGNAME --all`
+>`ado2gh generate-script --ado-source-org ORGNAME --github-target-org ORGNAME --all`
 
 4. The previous command will have created a migrate.ps1 script. Review the steps in the generated script and tweak if necessary.
 


### PR DESCRIPTION
In both ado as gh

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->