### PR TITLE
GHAE support (on-hold)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Add `--target-api-url` to all `gh gei` commands for GitHub to GitHub migration paths.

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -20,7 +20,7 @@ namespace OctoshiftCLI
         public GithubApi(GithubClient client, string apiUrl, RetryPolicy retryPolicy)
         {
             _client = client;
-            _apiUrl = apiUrl;
+            _apiUrl = apiUrl?.TrimEnd('/');
             _retryPolicy = retryPolicy;
         }
 

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -115,6 +115,11 @@ namespace OctoshiftCLI
         {
             url = url?.Replace(" ", "%20");
 
+            if (httpMethod == HttpMethod.Post && url is not null && url.Trim().EndsWith("/v3/graphql", StringComparison.OrdinalIgnoreCase))
+            {
+                url = url.Replace("/v3/graphql", "/graphql", StringComparison.OrdinalIgnoreCase);
+            }
+
             _log.LogVerbose($"HTTP {httpMethod}: {url}");
 
             if (body != null)

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -155,6 +155,27 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task GetAsync_Does_Not_Remove_V3_From_Url()
+        {
+            // Arrange
+            var handlerMock = MockHttpHandlerForGet();
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            const string url = "https://example.com/v3";
+
+            // Act
+            await githubClient.GetAsync(url);
+
+            // Assert
+            handlerMock.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == url),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
         public async Task PostAsync_Returns_String_Response()
         {
             // Arrange
@@ -290,6 +311,49 @@ namespace OctoshiftCLI.Tests
                 })
                 .Should()
                 .ThrowExactlyAsync<HttpRequestException>();
+        }
+
+        [Fact]
+        public async Task PostAsync_Removes_V3_From_GraphQL_Url_For_GraphQL_Requests()
+        {
+            // Arrange
+            var handlerMock = MockHttpHandlerForPost();
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            const string actualUrl = "https://example.com/V3/GraphQL";
+            const string expectedUrl = "https://example.com/graphql";
+
+            // Act
+            await githubClient.PostAsync(actualUrl, _rawRequestBody);
+
+            // Assert
+            handlerMock.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == expectedUrl),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task PostAsync_Does_Not_Remove_V3_From_Url_For_Non_GraphQL_Requests()
+        {
+            // Arrange
+            var handlerMock = MockHttpHandlerForPost();
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            const string url = "https://example.com/v3/";
+
+            // Act
+            await githubClient.PostAsync(url, _rawRequestBody);
+
+            // Assert
+            handlerMock.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == url),
+                ItExpr.IsAny<CancellationToken>());
         }
 
         [Fact]
@@ -431,6 +495,27 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task PutAsync_Does_Not_Remove_V3_From_Url()
+        {
+            // Arrange
+            var handlerMock = MockHttpHandlerForPut();
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            const string url = "https://example.com/v3";
+
+            // Act
+            await githubClient.PutAsync(url, _rawRequestBody);
+
+            // Assert
+            handlerMock.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == url),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
         public async Task PatchAsync_Returns_String_Response()
         {
             // Arrange
@@ -569,6 +654,27 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task PatchAsync_Does_Not_Remove_V3_From_Url()
+        {
+            // Arrange
+            var handlerMock = MockHttpHandlerForPatch();
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            const string url = "https://example.com/v3";
+
+            // Act
+            await githubClient.PatchAsync(url, _rawRequestBody);
+
+            // Assert
+            handlerMock.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == url),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
         public async Task DeleteAsync_Returns_String_Response()
         {
             // Arrange
@@ -643,6 +749,27 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task DeleteAsync_Does_Not_Remove_V3_From_Url()
+        {
+            // Arrange
+            var handlerMock = MockHttpHandlerForDelete();
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            const string url = "https://example.com/v3";
+
+            // Act
+            await githubClient.DeleteAsync(url);
+
+            // Assert
+            handlerMock.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == url),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
         public async Task GetNonSuccessAsync_Is_Unsuccessful()
         {
             // Arrange
@@ -705,6 +832,27 @@ namespace OctoshiftCLI.Tests
 
             // Assert
             _mockOctoLogger.Verify(m => m.LogVerbose($"GITHUB REQUEST ID: {githubRequestId}"));
+        }
+
+        [Fact]
+        public async Task GetNonSuccessAsync_Does_Not_Remove_V3_From_Url()
+        {
+            // Arrange
+            var handlerMock = MockHttpHandlerForGet();
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            const string url = "https://example.com/v3";
+
+            // Act
+            await githubClient.GetNonSuccessAsync(url, HttpStatusCode.OK);
+
+            // Assert
+            handlerMock.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == url),
+                ItExpr.IsAny<CancellationToken>());
         }
 
         [Fact]
@@ -1041,6 +1189,35 @@ namespace OctoshiftCLI.Tests
                 })
                 .Should()
                 .ThrowExactlyAsync<HttpRequestException>();
+        }
+
+        [Fact]
+        public async Task GetAllAsync_Does_Not_Remove_V3_From_Url()
+        {
+            // Arrange
+            using var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("[\"firs\"]") };
+            var handlerMock = new Mock<HttpMessageHandler>();
+            handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(response);
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            const string url = "https://example.com/v3";
+
+            // Act
+            await githubClient.GetAllAsync(url).ToListAsync();
+
+            // Assert
+            handlerMock.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == url),
+                ItExpr.IsAny<CancellationToken>());
         }
 
         [Fact]
@@ -1688,6 +1865,54 @@ query($id: ID!, $first: Int, $after: String) {
             // Assert
             _mockOctoLogger.Verify(m => m.LogVerbose($"GITHUB REQUEST ID: {firstGithubRequestId}"));
             _mockOctoLogger.Verify(m => m.LogVerbose($"GITHUB REQUEST ID: {secondGithubRequestId}"));
+        }
+
+        [Fact]
+        public async Task PostGraphQLWithPaginationAsync_Removes_V3_From_GraphQL_Url_For_GraphQL_Requests()
+        {
+            // Arrange
+            const string actualUrl = "https://example.com/V3/GraphQL";
+            const string expectedUrl = "https://example.com/graphql";
+            const string query = "QUERY";
+
+            var requestBody = new { query };
+            var responseContent = new
+            {
+                data = new
+                {
+                    node = new
+                    {
+                        repositoryMigrations = new
+                        {
+                            nodes = new[] { 1 }
+                        }
+                    }
+                }
+            };
+            using var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseContent.ToJson())
+            };
+
+            var handlerMock = MockHttpHandler(req => req.Method == HttpMethod.Post, response);
+
+            using var httpClient = new HttpClient(handlerMock.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+
+            // Act
+            await githubClient.PostGraphQLWithPaginationAsync(
+                    actualUrl,
+                    requestBody,
+                    obj => (JArray)obj["data"]["node"]["repositoryMigrations"]["nodes"],
+                    obj => (JObject)obj["data"]["node"]["repositoryMigrations"]["pageInfo"], 2)
+                .ToListAsync();
+
+            // Assert
+            handlerMock.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == expectedUrl),
+                ItExpr.IsAny<CancellationToken>());
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateMannequinCsvCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateMannequinCsvCommandTests.cs
@@ -40,12 +40,13 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         {
             Assert.NotNull(_command);
             Assert.Equal("generate-mannequin-csv", _command.Name);
-            Assert.Equal(5, _command.Options.Count);
+            Assert.Equal(6, _command.Options.Count);
 
             TestHelpers.VerifyCommandOption(_command.Options, "github-target-org", true);
             TestHelpers.VerifyCommandOption(_command.Options, "output", false);
             TestHelpers.VerifyCommandOption(_command.Options, "include-reclaimed", false);
             TestHelpers.VerifyCommandOption(_command.Options, "github-target-pat", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "target-api-url", false);
             TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
         }
 
@@ -140,6 +141,22 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             // Assert
             _csvContent.Should().Be(expected);
+        }
+
+        [Fact]
+        public async Task It_Uses_Target_Api_Url_When_Provided()
+        {
+            // Arrange
+            const string targetApiUrl = "https://api.contoso.com";
+
+            _mockTargetGithubApiFactory.Setup(m => m.Create(targetApiUrl, It.IsAny<string>())).Returns(_mockGithubApi.Object);
+
+            // Act
+            await _command.Invoke(GITHUB_ORG, new FileInfo("unit-test-output"), targetApiUrl: targetApiUrl);
+
+            // Assert
+            _mockOctoLogger.Verify(m => m.LogInformation($"TARGET API URL: {targetApiUrl}"));
+            _mockTargetGithubApiFactory.Verify(m => m.Create(targetApiUrl, null));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
@@ -27,12 +27,13 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         {
             Assert.NotNull(_command);
             Assert.Equal("grant-migrator-role", _command.Name);
-            Assert.Equal(5, _command.Options.Count);
+            Assert.Equal(6, _command.Options.Count);
 
             TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(_command.Options, "actor", true);
             TestHelpers.VerifyCommandOption(_command.Options, "actor-type", true);
             TestHelpers.VerifyCommandOption(_command.Options, "github-target-pat", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "target-api-url", false);
             TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
         }
 
@@ -75,6 +76,25 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             // Assert
             actualLogOutput.Should().Contain("GITHUB TARGET PAT: ***");
             _mockTargetGithubApiFactory.Verify(m => m.Create(null, githubTargetPat));
+        }
+
+        [Fact]
+        public async Task It_Uses_Target_Api_Url_When_Provided()
+        {
+            // Arrange
+            const string targetApiUrl = "https://api.contoso.com";
+
+            _mockTargetGithubApiFactory.Setup(m => m.Create(targetApiUrl, null)).Returns(_mockGithubApi.Object);
+
+            var actualLogOutput = new List<string>();
+            _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
+
+            // Act
+            await _command.Invoke("githubOrg", "actor", "TEAM", targetApiUrl: targetApiUrl);
+
+            // Assert
+            actualLogOutput.Should().Contain($"TARGET API URL: {targetApiUrl}");
+            _mockTargetGithubApiFactory.Verify(m => m.Create(targetApiUrl, null));
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/ReclaimMannequinCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/ReclaimMannequinCommandTests.cs
@@ -36,7 +36,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         {
             Assert.NotNull(_command);
             Assert.Equal("reclaim-mannequin", _command.Name);
-            Assert.Equal(8, _command.Options.Count);
+            Assert.Equal(9, _command.Options.Count);
 
             TestHelpers.VerifyCommandOption(_command.Options, "github-target-org", true);
             TestHelpers.VerifyCommandOption(_command.Options, "csv", false);
@@ -45,6 +45,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(_command.Options, "target-user", false);
             TestHelpers.VerifyCommandOption(_command.Options, "force", false);
             TestHelpers.VerifyCommandOption(_command.Options, "github-target-pat", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "target-api-url", false);
             TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
         }
 
@@ -68,6 +69,22 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await _command.Invoke(GITHUB_ORG, MANNEQUIN_USER, null, TARGET_USER, mannequinUserId, false, githubTargetPat);
 
             _mockTargetGithubApiFactory.Verify(m => m.Create(null, githubTargetPat));
+        }
+
+        [Fact]
+        public async Task It_Uses_Target_Api_Url_When_Provided()
+        {
+            // Arrange
+            const string targetApiUrl = "https://api.contoso.com";
+
+            _mockReclaimService.Setup(x => x.ReclaimMannequin(MANNEQUIN_USER, null, TARGET_USER, GITHUB_ORG, false)).Returns(Task.FromResult(default(object)));
+            _mockTargetGithubApiFactory.Setup(m => m.Create(targetApiUrl, null)).Returns(_mockGithubApi.Object);
+
+            // Act
+            await _command.Invoke(GITHUB_ORG, MANNEQUIN_USER, null, TARGET_USER, null, targetApiUrl: targetApiUrl);
+
+            // Assert
+            _mockTargetGithubApiFactory.Verify(m => m.Create(targetApiUrl, null));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
@@ -27,12 +27,13 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         {
             Assert.NotNull(_command);
             Assert.Equal("revoke-migrator-role", _command.Name);
-            Assert.Equal(5, _command.Options.Count);
+            Assert.Equal(6, _command.Options.Count);
 
             TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(_command.Options, "actor", true);
             TestHelpers.VerifyCommandOption(_command.Options, "actor-type", true);
             TestHelpers.VerifyCommandOption(_command.Options, "github-target-pat", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "target-api-url", false);
             TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
         }
 
@@ -76,6 +77,25 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             // Assert
             actualLogOutput.Should().Contain("GITHUB TARGET PAT: ***");
             _mockTargetGithubApiFactory.Verify(m => m.Create(null, githubTargetPat));
+        }
+
+        [Fact]
+        public async Task It_Uses_Target_Api_Url_When_Provided()
+        {
+            // Arrange
+            const string targetApiUrl = "github-target-pat";
+
+            _mockTargetGithubApiFactory.Setup(m => m.Create(targetApiUrl, null)).Returns(_mockGithubApi.Object);
+
+            var actualLogOutput = new List<string>();
+            _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
+
+            // Act
+            await _command.Invoke("githubOrg", "actor", "TEAM", targetApiUrl: targetApiUrl);
+
+            // Assert
+            actualLogOutput.Should().Contain($"TARGET API URL: {targetApiUrl}");
+            _mockTargetGithubApiFactory.Verify(m => m.Create(targetApiUrl, null));
         }
     }
 }

--- a/src/gei/Commands/DownloadLogsCommand.cs
+++ b/src/gei/Commands/DownloadLogsCommand.cs
@@ -48,7 +48,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var targetApiUrl = new Option<string>("--target-api-url")
             {
                 IsRequired = false,
-                Description = "The URL of the target API, if not migrating to github.com (default: to https://api.github.com)."
+                Description = "The URL of the target API, if not migrating to github.com (default: https://api.github.com)."
             };
 
             var githubTargetPat = new Option<string>("--github-target-pat")

--- a/src/gei/Commands/DownloadLogsCommand.cs
+++ b/src/gei/Commands/DownloadLogsCommand.cs
@@ -48,13 +48,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var targetApiUrl = new Option<string>("--target-api-url")
             {
                 IsRequired = false,
-                Description = "Target GitHub API URL if not targeting github.com (default: https://api.github.com)."
+                Description = "The URL of the target API, if not migrating to github.com (default: to https://api.github.com)."
             };
 
             var githubTargetPat = new Option<string>("--github-target-pat")
             {
                 IsRequired = false,
-                Description = "Personal access token of the GitHub target.  Overrides GH_PAT environment variable."
+                Description = "Personal access token of the GitHub target. Overrides GH_PAT environment variable."
             };
 
             var migrationLogFile = new Option<string>("--migration-log-file")

--- a/src/gei/Commands/GenerateMannequinCsvCommand.cs
+++ b/src/gei/Commands/GenerateMannequinCsvCommand.cs
@@ -51,13 +51,20 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 IsRequired = false
             };
 
+            var targetApiUrl = new Option<string>("--target-api-url")
+            {
+                IsRequired = false,
+                Description = "The URL of the target API, if not migrating to github.com (default: https://api.github.com)."
+            };
+
             AddOption(githubTargetOrgOption);
             AddOption(outputOption);
             AddOption(includeReclaimedOption);
             AddOption(githubTargetPat);
+            AddOption(targetApiUrl);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, FileInfo, bool, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, FileInfo, bool, string, string, bool>(Invoke);
         }
 
         public async Task Invoke(
@@ -65,6 +72,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
           FileInfo output,
           bool includeReclaimed = false,
           string githubTargetPat = null,
+          string targetApiUrl = null,
           bool verbose = false)
         {
             _log.Verbose = verbose;
@@ -81,8 +89,12 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 _log.LogInformation("INCLUDING RECLAIMED");
             }
+            if (targetApiUrl is not null)
+            {
+                _log.LogInformation($"TARGET API URL: {targetApiUrl}");
+            }
 
-            var githubApi = _targetGithubApiFactory.Create(targetPersonalAccessToken: githubTargetPat);
+            var githubApi = _targetGithubApiFactory.Create(targetApiUrl, githubTargetPat);
 
             var githubOrgId = await githubApi.GetOrganizationId(githubTargetOrg);
             var mannequins = await githubApi.GetMannequins(githubOrgId);

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -115,7 +115,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var targetApiUrl = new Option<string>("--target-api-url")
             {
                 IsRequired = false,
-                Description = "The URL of the target API, if not migrating to github.com (default: https://api.github.com). It will be ignored for ADO to GitHub migration path."
+                Description = "The URL of the target API, if not migrating to github.com (default: https://api.github.com). It is useful when migrating to GHAE."
             };
             var verbose = new Option("--verbose")
             {

--- a/src/gei/Commands/GrantMigratorRoleCommand.cs
+++ b/src/gei/Commands/GrantMigratorRoleCommand.cs
@@ -35,6 +35,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 IsRequired = false
             };
+            var targetApiUrl = new Option<string>("--target-api-url")
+            {
+                IsRequired = false,
+                Description = "The URL of the target API, if not migrating to github.com (default: https://api.github.com)."
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -44,12 +49,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(actor);
             AddOption(actorType);
             AddOption(githubTargetPat);
+            AddOption(targetApiUrl);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubOrg, string actor, string actorType, string githubTargetPat = null, bool verbose = false)
+        public async Task Invoke(string githubOrg, string actor, string actorType, string githubTargetPat = null, string targetApiUrl = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -59,6 +65,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             if (githubTargetPat is not null)
             {
                 _log.LogInformation("GITHUB TARGET PAT: ***");
+            }
+            if (targetApiUrl is not null)
+            {
+                _log.LogInformation($"TARGET API URL: {targetApiUrl}");
             }
 
             actorType = actorType?.ToUpper();
@@ -74,7 +84,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 return;
             }
 
-            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubTargetPat);
+            var githubApi = _githubApiFactory.Create(targetApiUrl, githubTargetPat);
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
             var success = await githubApi.GrantMigratorRole(githubOrgId, actor, actorType);
 

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -67,7 +67,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var targetApiUrl = new Option<string>("--target-api-url")
             {
                 IsRequired = false,
-                Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com"
+                Description = "The URL of the target API, if not migrating to github.com (default: https://api.github.com)."
             };
 
             // GHES migration path

--- a/src/gei/Commands/ReclaimMannequinCommand.cs
+++ b/src/gei/Commands/ReclaimMannequinCommand.cs
@@ -69,6 +69,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 IsRequired = false
             };
+            var targetApiUrlOption = new Option<string>("--target-api-url")
+            {
+                IsRequired = false,
+                Description = "The URL of the target API, if not migrating to github.com (default: https://api.github.com)."
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -81,9 +86,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(targetUsernameOption);
             AddOption(forceOption);
             AddOption(githubTargetPatOption);
+            AddOption(targetApiUrlOption);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, string, bool, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, string, bool, string, string, bool>(Invoke);
         }
 
         public async Task Invoke(
@@ -94,6 +100,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
           string csv,
           bool force = false,
           string githubPat = null,
+          string targetApiUrl = null,
           bool verbose = false)
         {
             _log.Verbose = verbose;
@@ -103,7 +110,12 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 throw new OctoshiftCliException("Either --csv or --mannequin-user and --target-user must be specified");
             }
 
-            var githubApi = _targetGithubApiFactory.Create(targetPersonalAccessToken: githubPat);
+            if (targetApiUrl is not null)
+            {
+                _log.LogInformation($"TARGET API URL: {targetApiUrl}");
+            }
+
+            var githubApi = _targetGithubApiFactory.Create(targetApiUrl, githubPat);
             if (_reclaimService == null)
             {
                 _reclaimService = new ReclaimService(githubApi, _log);

--- a/src/gei/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/gei/Commands/RevokeMigratorRoleCommand.cs
@@ -34,6 +34,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 IsRequired = false
             };
+            var targetApiUrl = new Option<string>("--target-api-url")
+            {
+                IsRequired = false,
+                Description = "The URL of the target API, if not migrating to github.com (default: https://api.github.com)."
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -43,12 +48,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(actor);
             AddOption(actorType);
             AddOption(githubTargetPat);
+            AddOption(targetApiUrl);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<string, string, string, string, string, bool>(Invoke);
         }
 
-        public async Task Invoke(string githubOrg, string actor, string actorType, string githubTargetPat = null, bool verbose = false)
+        public async Task Invoke(string githubOrg, string actor, string actorType, string githubTargetPat = null, string targetApiUrl = null, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -58,6 +64,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             if (githubTargetPat is not null)
             {
                 _log.LogInformation("GITHUB TARGET PAT: ***");
+            }
+            if (targetApiUrl is not null)
+            {
+                _log.LogInformation($"TARGET API URL: {targetApiUrl}");
             }
 
             actorType = actorType?.ToUpper();
@@ -75,7 +85,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 return;
             }
 
-            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubTargetPat);
+            var githubApi = _githubApiFactory.Create(targetApiUrl, githubTargetPat);
             var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
             var success = await githubApi.RevokeMigratorRole(githubOrgId, actor, actorType);
 


### PR DESCRIPTION
Closes #375 

This PR adds the `--target-api-url` to all `gh gei` commands for GitHub to GitHub migration paths.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
