### PR TITLE
Simplify PR number sanitisation

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           eventjson=`cat 'artifacts/Event File/event.json'`
           prnumber=`echo $(jq -r '.pull_request.number' <<< "$eventjson")`
-          echo "PR_NUMBER=$(echo $prnumber | sed 's/[^0-9]*//g' | tr -d '\n')" >> $GITHUB_ENV
+          echo "PR_NUMBER=$(echo $prnumber | tr -cd '[0-9]')" >> $GITHUB_ENV
       
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1


### PR DESCRIPTION
Continuing from #495 as `tr` is being used to strip the new lines `\n` anyway ( recommended by @anticomputer ), we can use it to remove all non-numeric and save ourselves the separate `fork()`, `exec()` and execution of the `sed` command.

Here, we use `tr` to delete (`-d`) the characters we match, `[0-9]` to match only numeric, and `-c` to make the match complimentary, thereby deleting any non-number.

**NOTE:** This has NOT changed the functionality in that if your input were:

```
123abc

Lorem ipsum dolor sit amet consectetur
abc123
```

Your output would still be:

```
123123
```

Which may or may not actually be desired

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)