### PR TITLE
Fix dotnet format warnings

### DIFF
--- a/src/ado2gh/AdoInspectorServiceFactory.cs
+++ b/src/ado2gh/AdoInspectorServiceFactory.cs
@@ -9,10 +9,7 @@ namespace OctoshiftCLI.AdoToGithub
 
         public virtual AdoInspectorService Create(AdoApi adoApi)
         {
-            if (_instance is null)
-            {
-                _instance = new(_octoLogger, adoApi);
-            }
+            _instance ??= new(_octoLogger, adoApi);
 
             return _instance;
         }

--- a/src/ado2gh/Commands/ReclaimMannequinCommand.cs
+++ b/src/ado2gh/Commands/ReclaimMannequinCommand.cs
@@ -105,10 +105,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             }
 
             var githubApi = _githubApiFactory.Create(personalAccessToken: githubPat);
-            if (_reclaimService == null)
-            {
-                _reclaimService = new ReclaimService(githubApi, _log);
-            }
+            _reclaimService ??= new ReclaimService(githubApi, _log);
 
             if (!string.IsNullOrEmpty(csv))
             {

--- a/src/gei/Commands/ReclaimMannequinCommand.cs
+++ b/src/gei/Commands/ReclaimMannequinCommand.cs
@@ -104,10 +104,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             }
 
             var githubApi = _targetGithubApiFactory.Create(targetPersonalAccessToken: githubPat);
-            if (_reclaimService == null)
-            {
-                _reclaimService = new ReclaimService(githubApi, _log);
-            }
+            _reclaimService ??= new ReclaimService(githubApi, _log);
 
             if (!string.IsNullOrEmpty(csv))
             {


### PR DESCRIPTION
This is a quick PR to fix `dotnet format` warnings that appeared after updating .NET version to `6.0.400`

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
