### PR TITLE
Update integration-tests.yml to use `gh ado2gh`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -68,22 +68,42 @@ jobs:
 
     - name: Copy binary to root (linux)
       if: matrix.runner-os == 'ubuntu-latest'
-      run: Copy-Item ./dist/linux-x64/gei-linux-amd64 ./gh-gei
+      run: |
+        New-Item -Path "./" -Name "gh-gei" -ItemType "directory"
+        New-Item -Path "./" -Name "gh-ado2gh" -ItemType "directory"
+        Copy-Item ./dist/linux-x64/gei-linux-amd64 ./gh-gei/gh-gei
+        Copy-Item ./dist/linux-x64/ado2gh-linux-amd64 ./gh-ado2gh/gh-ado2gh
       shell: pwsh
 
     - name: Copy binary to root (windows)
       if: matrix.runner-os == 'windows-latest'
-      run: Copy-Item ./dist/win-x64/gei-windows-amd64.exe ./gh-gei.exe
+      run: |
+        New-Item -Path "./" -Name "gh-gei" -ItemType "directory"
+        New-Item -Path "./" -Name "gh-ado2gh" -ItemType "directory"
+        Copy-Item ./dist/win-x64/gei-windows-amd64.exe ./gh-gei/gh-gei.exe
+        Copy-Item ./dist/win-x64/ado2gh-windows-amd64.exe ./gh-ado2gh/gh-ado2gh.exe
       shell: pwsh
 
     - name: Copy binary to root (macos)
       if: matrix.runner-os == 'macos-latest'
-      run: Copy-Item ./dist/osx-x64/gei-darwin-amd64 ./gh-gei
+      run: |
+        New-Item -Path "./" -Name "gh-gei" -ItemType "directory"
+        New-Item -Path "./" -Name "gh-ado2gh" -ItemType "directory"
+        Copy-Item ./dist/osx-x64/gei-darwin-amd64 ./gh-gei/gh-gei
+        Copy-Item ./dist/osx-x64/ado2gh-darwin-amd64 ./gh-ado2gh/gh-ado2gh
       shell: pwsh
 
-    - name: Install GH extension
+    - name: Install gh-gei extension
       run: gh extension install .
       shell: pwsh
+      working-directory: ./gh-gei
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Install gh-ado2gh extension
+      run: gh extension install .
+      shell: pwsh
+      working-directory: ./gh-ado2gh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

In the PR to add `gh ado2gh` I forgot to update the separate YML we have for `integration-tests.yml`

Related to #497 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->