### PR TITLE
Refactor generate-mannequin-csv command

### DIFF
--- a/src/Octoshift/Commands/GenerateMannequinCsvCommandBase.cs
+++ b/src/Octoshift/Commands/GenerateMannequinCsvCommandBase.cs
@@ -1,0 +1,107 @@
+using System;
+using System.CommandLine;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Octoshift;
+using OctoshiftCLI.Contracts;
+using OctoshiftCLI.Extensions;
+
+namespace OctoshiftCLI.Commands;
+
+public class GenerateMannequinCsvCommandBase : Command
+{
+    internal Func<string, string, Task> WriteToFile = async (path, contents) => await File.WriteAllTextAsync(path, contents);
+
+    private readonly OctoLogger _log;
+    private readonly ITargetGithubApiFactory _targetGithubApiFactory;
+
+    public GenerateMannequinCsvCommandBase(OctoLogger log, ITargetGithubApiFactory targetGithubApiFactory) : base("generate-mannequin-csv")
+    {
+        _log = log;
+        _targetGithubApiFactory = targetGithubApiFactory;
+
+        Description = "Generates a CSV with unreclaimed mannequins to reclaim them in bulk.";
+    }
+
+    protected virtual Option<string> GithubOrg { get; } = new("--github-org")
+    {
+        IsRequired = true,
+        Description = "Uses GH_PAT env variable."
+    };
+
+    protected virtual Option<FileInfo> Output { get; } = new("--output", () => new FileInfo("./mannequins.csv"))
+    {
+        IsRequired = false,
+        Description = "Output filename. Default value mannequins.csv"
+    };
+
+    protected virtual Option<bool> IncludeReclaimed { get; } = new("--include-reclaimed")
+    {
+        IsRequired = false,
+        Description = "Include mannequins that have already been reclaimed"
+    };
+
+    protected virtual Option<bool> Verbose { get; } = new("--verbose")
+    {
+        IsRequired = false
+    };
+
+    protected virtual Option<string> GithubPat { get; } = new("--github-pat")
+    {
+        IsRequired = false
+    };
+
+    protected void AddOptions()
+    {
+        AddOption(GithubOrg);
+        AddOption(Output);
+        AddOption(IncludeReclaimed);
+        AddOption(GithubPat);
+        AddOption(Verbose);
+    }
+
+    public async Task Handle(
+        string githubOrg,
+        FileInfo output,
+        bool includeReclaimed = false,
+        string githubPat = null,
+        bool verbose = false)
+    {
+        _log.Verbose = verbose;
+
+        _log.LogInformation("Generating CSV...");
+
+        _log.LogInformation($"{GithubOrg.GetLogFriendlyName()}: {githubOrg}");
+        if (githubPat is not null)
+        {
+            _log.LogInformation($"{GithubPat.GetLogFriendlyName()}: ***");
+        }
+
+        _log.LogInformation($"{Output.GetLogFriendlyName()}: {output}");
+        if (includeReclaimed)
+        {
+            _log.LogInformation($"{IncludeReclaimed.GetLogFriendlyName()}: true");
+        }
+
+        var githubApi = _targetGithubApiFactory.Create(targetPersonalAccessToken: githubPat);
+
+        var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
+        var mannequins = await githubApi.GetMannequins(githubOrgId);
+
+        _log.LogInformation($"    # Mannequins Found: {mannequins.Count()}");
+        _log.LogInformation($"    # Mannequins Previously Reclaimed: {mannequins.Count(x => x.MappedUser is not null)}");
+
+        var contents = new StringBuilder().AppendLine(ReclaimService.CSVHEADER);
+        foreach (var mannequin in mannequins.Where(m => includeReclaimed || m.MappedUser is null))
+        {
+            contents.AppendLine($"{mannequin.Login},{mannequin.Id},{mannequin.MappedUser?.Login}");
+        }
+
+        if (output?.FullName is not null)
+        {
+            await WriteToFile(output.FullName, contents.ToString());
+        }
+    }
+}

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/GenerateMannequinCsvCommandBaseTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/GenerateMannequinCsvCommandBaseTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using OctoshiftCLI.Commands;
+using OctoshiftCLI.Contracts;
+using OctoshiftCLI.Models;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.Octoshift.Commands;
+
+public class GenerateMannequinCsvCommandBaseTests
+{
+    private readonly Mock<GithubApi> _mockGithubApi = TestHelpers.CreateMock<GithubApi>();
+    private readonly Mock<ITargetGithubApiFactory> _mockGithubApiFactory = new();
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+    private readonly GenerateMannequinCsvCommandBase _command;
+
+    private const string CSV_HEADER = "mannequin-user,mannequin-id,target-user";
+    private const string GITHUB_ORG = "FooOrg";
+    private readonly string GITHUB_ORG_ID = Guid.NewGuid().ToString();
+    private string _csvContent = string.Empty;
+
+    public GenerateMannequinCsvCommandBaseTests()
+    {
+        _command = new GenerateMannequinCsvCommandBase(_mockOctoLogger.Object, _mockGithubApiFactory.Object)
+        {
+            WriteToFile = (_, contents) =>
+            {
+                _csvContent = contents;
+                return Task.CompletedTask;
+            }
+        };
+    }
+
+    [Fact]
+    public async Task NoMannequins_GenerateEmptyCSV_WithOnlyHeaders()
+    {
+        _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
+
+        _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
+        _mockGithubApi.Setup(x => x.GetMannequins(GITHUB_ORG_ID).Result).Returns(Array.Empty<Mannequin>());
+
+        var expected = CSV_HEADER + Environment.NewLine;
+
+        // Act
+        await _command.Handle("octocat", new FileInfo("unit-test-output"), false);
+
+        // Assert
+        _csvContent.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task Mannequins_GenerateCSV_UnreclaimedOnly()
+    {
+        var mannequinsResponse = new[]
+        {
+            new Mannequin { Id = "monaid", Login = "mona" },
+            new Mannequin { Id = "monalisaid", Login = "monalisa", MappedUser = new Claimant { Id = "monalisamapped-id", Login = "monalisa_gh" } }
+        };
+
+        _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
+
+        _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
+        _mockGithubApi.Setup(x => x.GetMannequins(GITHUB_ORG_ID).Result).Returns(mannequinsResponse);
+
+        var expected = CSV_HEADER + Environment.NewLine
+                                  + "mona,monaid," + Environment.NewLine;
+
+        // Act
+        await _command.Handle(GITHUB_ORG, new FileInfo("unit-test-output"), false);
+
+        // Assert
+        _csvContent.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task Mannequins_GenerateCSV_IncludeAlreadyReclaimed()
+    {
+        var mannequinsResponse = new[]
+        {
+            new Mannequin { Id = "monaid", Login = "mona" },
+            new Mannequin { Id = "monalisaid", Login = "monalisa", MappedUser = new Claimant { Id = "monalisamapped-id", Login = "monalisa_gh" } }
+        };
+
+        _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
+
+        _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
+        _mockGithubApi.Setup(x => x.GetMannequins(GITHUB_ORG_ID).Result).Returns(mannequinsResponse);
+
+        var expected = CSV_HEADER + Environment.NewLine
+                                  + "mona,monaid," + Environment.NewLine
+                                  + "monalisa,monalisaid,monalisa_gh" + Environment.NewLine;
+
+        // Act
+        await _command.Handle(GITHUB_ORG, new FileInfo("unit-test-output"), true);
+
+        // Assert
+        _csvContent.Should().Be(expected);
+    }
+}

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateMannequinCsvCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateMannequinCsvCommandTests.cs
@@ -1,144 +1,32 @@
-using System;
-using System.IO;
-using System.Threading.Tasks;
-using FluentAssertions;
 using Moq;
 using OctoshiftCLI.AdoToGithub;
 using OctoshiftCLI.AdoToGithub.Commands;
-using OctoshiftCLI.Models;
 using Xunit;
 
-namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+namespace OctoshiftCLI.Tests.AdoToGithub.Commands;
+
+public class GenerateMannequinCsvCommandTests
 {
-    public class GenerateMannequinCsvCommandTests
+    private readonly Mock<GithubApiFactory> _mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+    private readonly GenerateMannequinCsvCommand _command;
+
+    public GenerateMannequinCsvCommandTests()
     {
-        private readonly Mock<GithubApi> _mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-        private readonly Mock<GithubApiFactory> _mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
-        private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+        _command = new GenerateMannequinCsvCommand(_mockOctoLogger.Object, _mockGithubApiFactory.Object);
+    }
 
-        private readonly GenerateMannequinCsvCommand _command;
+    [Fact]
+    public void Should_Have_Options()
+    {
+        Assert.NotNull(_command);
+        Assert.Equal("generate-mannequin-csv", _command.Name);
+        Assert.Equal(5, _command.Options.Count);
 
-        private const string CSV_HEADER = "mannequin-user,mannequin-id,target-user";
-        private const string GITHUB_ORG = "FooOrg";
-        private readonly string GITHUB_ORG_ID = Guid.NewGuid().ToString();
-        private string _csvContent = string.Empty;
-
-        public GenerateMannequinCsvCommandTests()
-        {
-            _command = new GenerateMannequinCsvCommand(_mockOctoLogger.Object, _mockGithubApiFactory.Object)
-            {
-                WriteToFile = (_, contents) =>
-                {
-                    _csvContent = contents;
-                    return Task.CompletedTask;
-                }
-            };
-        }
-
-        [Fact]
-        public void Should_Have_Options()
-        {
-            Assert.NotNull(_command);
-            Assert.Equal("generate-mannequin-csv", _command.Name);
-            Assert.Equal(5, _command.Options.Count);
-
-            TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
-            TestHelpers.VerifyCommandOption(_command.Options, "output", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "include-reclaimed", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "github-pat", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
-        }
-
-        [Fact]
-        public async Task NoMannequins_GenerateEmptyCSV_WithOnlyHeaders()
-        {
-            _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
-
-            _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
-            _mockGithubApi.Setup(x => x.GetMannequins(GITHUB_ORG_ID).Result).Returns(Array.Empty<Mannequin>());
-
-            var expected = CSV_HEADER + Environment.NewLine;
-
-            // Act
-            await _command.Invoke("octocat", new FileInfo("unit-test-output"), false);
-
-            // Assert
-            _csvContent.Should().Be(expected);
-        }
-
-        [Fact]
-        public async Task Mannequins_GenerateCSV_UnreclaimedOnly()
-        {
-            var mannequinsResponse = new[]
-            {
-                new Mannequin
-                {
-                    Id = "monaid",
-                    Login = "mona"
-                },
-                new Mannequin
-                {
-                    Id = "monalisaid",
-                    Login = "monalisa",
-                    MappedUser = new Claimant
-                    {
-                        Id = "monalisamapped-id",
-                        Login = "monalisa_gh"
-                    }
-                }
-            };
-
-            _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
-
-            _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
-            _mockGithubApi.Setup(x => x.GetMannequins(GITHUB_ORG_ID).Result).Returns(mannequinsResponse);
-
-            var expected = CSV_HEADER + Environment.NewLine
-                + "mona,monaid," + Environment.NewLine;
-
-            // Act
-            await _command.Invoke(GITHUB_ORG, new FileInfo("unit-test-output"), false);
-
-            // Assert
-            _csvContent.Should().Be(expected);
-        }
-
-        [Fact]
-        public async Task Mannequins_GenerateCSV_IncludeAlreadyReclaimed()
-        {
-            var mannequinsResponse = new[]
-            {
-                new Mannequin
-                {
-                    Id = "monaid",
-                    Login = "mona"
-                },
-                new Mannequin
-                {
-                    Id = "monalisaid",
-                    Login = "monalisa",
-                    MappedUser = new Claimant
-                    {
-                        Id = "monalisamapped-id",
-                        Login = "monalisa_gh"
-                    }
-                }
-            };
-
-            _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
-
-            _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
-            _mockGithubApi.Setup(x => x.GetMannequins(GITHUB_ORG_ID).Result).Returns(mannequinsResponse);
-
-            var expected = CSV_HEADER + Environment.NewLine
-                + "mona,monaid," + Environment.NewLine
-                + "monalisa,monalisaid,monalisa_gh" + Environment.NewLine;
-
-            // Act
-            await _command.Invoke(GITHUB_ORG, new FileInfo("unit-test-output"), true);
-
-            // Assert
-            _csvContent.Should().Be(expected);
-        }
+        TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "output", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "include-reclaimed", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "github-pat", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateMannequinCsvCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateMannequinCsvCommandTests.cs
@@ -1,145 +1,32 @@
-using System;
-using System.IO;
-using System.Threading.Tasks;
-using FluentAssertions;
 using Moq;
 using OctoshiftCLI.Contracts;
 using OctoshiftCLI.GithubEnterpriseImporter.Commands;
-using OctoshiftCLI.Models;
 using Xunit;
 
-namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
+namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands;
+
+public class GenerateMannequinCsvCommandTests
 {
-    public class GenerateMannequinCsvCommandTests
+    private readonly Mock<ITargetGithubApiFactory> _mockTargetGithubApiFactory = new();
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+    private readonly GenerateMannequinCsvCommand _command;
+
+    public GenerateMannequinCsvCommandTests()
     {
-        private readonly Mock<GithubApi> _mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-        private readonly Mock<ITargetGithubApiFactory> _mockTargetGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-        private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+        _command = new GenerateMannequinCsvCommand(_mockOctoLogger.Object, _mockTargetGithubApiFactory.Object);
+    }
 
-        private readonly GenerateMannequinCsvCommand _command;
+    [Fact]
+    public void Should_Have_Options()
+    {
+        Assert.NotNull(_command);
+        Assert.Equal("generate-mannequin-csv", _command.Name);
+        Assert.Equal(5, _command.Options.Count);
 
-        private const string CSV_HEADER = "mannequin-user,mannequin-id,target-user";
-        private const string GITHUB_ORG = "FooOrg";
-        private readonly string GITHUB_ORG_ID = Guid.NewGuid().ToString();
-        private string _csvContent = string.Empty;
-
-        public GenerateMannequinCsvCommandTests()
-        {
-            _command = new GenerateMannequinCsvCommand(_mockOctoLogger.Object, _mockTargetGithubApiFactory.Object)
-            {
-                WriteToFile = (_, contents) =>
-                {
-                    _csvContent = contents;
-                    return Task.CompletedTask;
-                }
-            };
-        }
-
-        [Fact]
-        public void Should_Have_Options()
-        {
-            Assert.NotNull(_command);
-            Assert.Equal("generate-mannequin-csv", _command.Name);
-            Assert.Equal(5, _command.Options.Count);
-
-            TestHelpers.VerifyCommandOption(_command.Options, "github-target-org", true);
-            TestHelpers.VerifyCommandOption(_command.Options, "output", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "include-reclaimed", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "github-target-pat", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
-        }
-
-        [Fact]
-        public async Task NoMannequins_GenerateEmptyCSV_WithOnlyHeaders()
-        {
-            _mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
-
-            _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
-            _mockGithubApi.Setup(x => x.GetMannequins(GITHUB_ORG_ID).Result).Returns(Array.Empty<Mannequin>());
-
-            var expected = CSV_HEADER + Environment.NewLine;
-
-            // Act
-            await _command.Invoke("octocat", new FileInfo("unit-test-output"), false);
-
-            // Assert
-            _csvContent.Should().Be(expected);
-        }
-
-        [Fact]
-        public async Task Mannequins_GenerateCSV_UnreclaimedOnly()
-        {
-            var mannequinsResponse = new[]
-            {
-                new Mannequin
-                {
-                    Id = "monaid",
-                    Login = "mona"
-                },
-                new Mannequin
-                {
-                    Id = "monalisaid",
-                    Login = "monalisa",
-                    MappedUser = new Claimant
-                    {
-                        Id = "monalisamapped-id",
-                        Login = "monalisa_gh"
-                    }
-                }
-            };
-
-            _mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
-            _mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
-
-            _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
-            _mockGithubApi.Setup(x => x.GetMannequins(GITHUB_ORG_ID).Result).Returns(mannequinsResponse);
-
-            var expected = CSV_HEADER + Environment.NewLine
-                + "mona,monaid," + Environment.NewLine;
-
-            // Act
-            await _command.Invoke(GITHUB_ORG, new FileInfo("unit-test-output"), false);
-
-            // Assert
-            _csvContent.Should().Be(expected);
-        }
-
-        [Fact]
-        public async Task Mannequins_GenerateCSV_IncludeAlreadyReclaimed()
-        {
-            var mannequinsResponse = new[]
-            {
-                new Mannequin
-                {
-                    Id = "monaid",
-                    Login = "mona"
-                },
-                new Mannequin
-                {
-                    Id = "monalisaid",
-                    Login = "monalisa",
-                    MappedUser = new Claimant
-                    {
-                        Id = "monalisamapped-id",
-                        Login = "monalisa_gh"
-                    }
-                }
-            };
-
-            _mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
-
-            _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
-            _mockGithubApi.Setup(x => x.GetMannequins(GITHUB_ORG_ID).Result).Returns(mannequinsResponse);
-
-            var expected = CSV_HEADER + Environment.NewLine
-                + "mona,monaid," + Environment.NewLine
-                + "monalisa,monalisaid,monalisa_gh" + Environment.NewLine;
-
-            // Act
-            await _command.Invoke(GITHUB_ORG, new FileInfo("unit-test-output"), true);
-
-            // Assert
-            _csvContent.Should().Be(expected);
-        }
+        TestHelpers.VerifyCommandOption(_command.Options, "github-target-org", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "output", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "include-reclaimed", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "github-target-pat", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
     }
 }

--- a/src/ado2gh/Commands/GenerateMannequinCsvCommand.cs
+++ b/src/ado2gh/Commands/GenerateMannequinCsvCommand.cs
@@ -1,105 +1,15 @@
-﻿using System;
-using System.CommandLine;
-using System.CommandLine.Invocation;
+﻿using System.CommandLine.Invocation;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Octoshift;
+using OctoshiftCLI.Commands;
+using OctoshiftCLI.Contracts;
 
-namespace OctoshiftCLI.AdoToGithub.Commands
+namespace OctoshiftCLI.AdoToGithub.Commands;
+
+public sealed class GenerateMannequinCsvCommand : GenerateMannequinCsvCommandBase
 {
-    public class GenerateMannequinCsvCommand : Command
+    public GenerateMannequinCsvCommand(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base(log, githubApiFactory)
     {
-        internal Func<string, string, Task> WriteToFile = async (path, contents) => await File.WriteAllTextAsync(path, contents);
-
-        private readonly OctoLogger _log;
-        private readonly GithubApiFactory _githubApiFactory;
-
-        public GenerateMannequinCsvCommand(OctoLogger log, GithubApiFactory githubApiFactory) : base("generate-mannequin-csv")
-        {
-            _log = log;
-            _githubApiFactory = githubApiFactory;
-
-            Description = "Generates a CSV with unreclaimed mannequins to reclaim them in bulk.";
-
-            var githubOrgOption = new Option<string>("--github-org")
-            {
-                IsRequired = true,
-                Description = "Uses GH_PAT env variable."
-            };
-
-            var outputOption = new Option<FileInfo>("--output", () => new FileInfo("./mannequins.csv"))
-            {
-                IsRequired = false,
-                Description = "Output filename. Default value mannequins.csv"
-            };
-
-            var includeReclaimedOption = new Option("--include-reclaimed")
-            {
-                IsRequired = false,
-                Description = "Include mannequins that have already been reclaimed"
-            };
-
-            var verbose = new Option("--verbose")
-            {
-                IsRequired = false
-            };
-
-            var githubPat = new Option<string>("--github-pat")
-            {
-                IsRequired = false
-            };
-
-            AddOption(githubOrgOption);
-            AddOption(outputOption);
-            AddOption(includeReclaimedOption);
-            AddOption(githubPat);
-            AddOption(verbose);
-
-            Handler = CommandHandler.Create<string, FileInfo, bool, string, bool>(Invoke);
-        }
-
-        public async Task Invoke(
-          string githubOrg,
-          FileInfo output,
-          bool includeReclaimed = false,
-          string githubPat = null,
-          bool verbose = false)
-        {
-            _log.Verbose = verbose;
-
-            _log.LogInformation("Generating CSV...");
-
-            _log.LogInformation($"GITHUB ORG: {githubOrg}");
-            if (githubPat is not null)
-            {
-                _log.LogInformation("GITHUB PAT: ***");
-            }
-            _log.LogInformation($"FILE: {output}");
-            if (includeReclaimed)
-            {
-                _log.LogInformation("INCLUDING RECLAIMED");
-            }
-
-            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubPat);
-
-            var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
-            var mannequins = await githubApi.GetMannequins(githubOrgId);
-
-            _log.LogInformation($"    # Mannequins Found: {mannequins.Count()}");
-            _log.LogInformation($"    # Mannequins Previously Reclaimed: {mannequins.Count(x => x.MappedUser is not null)}");
-
-            var contents = new StringBuilder().AppendLine(ReclaimService.CSVHEADER);
-            foreach (var mannequin in mannequins.Where(m => includeReclaimed || m.MappedUser is null))
-            {
-                contents.AppendLine($"{mannequin.Login},{mannequin.Id},{mannequin.MappedUser?.Login}");
-            }
-
-            if (output?.FullName is not null)
-            {
-                await WriteToFile(output.FullName, contents.ToString());
-            }
-        }
+        AddOptions();
+        Handler = CommandHandler.Create<string, FileInfo, bool, string, bool>(Handle);
     }
 }

--- a/src/gei/Commands/GenerateMannequinCsvCommand.cs
+++ b/src/gei/Commands/GenerateMannequinCsvCommand.cs
@@ -1,106 +1,28 @@
-﻿using System;
-using System.CommandLine;
+﻿using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Octoshift;
+using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;
 
-namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
+namespace OctoshiftCLI.GithubEnterpriseImporter.Commands;
+
+public sealed class GenerateMannequinCsvCommand : GenerateMannequinCsvCommandBase
 {
-    public class GenerateMannequinCsvCommand : Command
+    public GenerateMannequinCsvCommand(OctoLogger log, ITargetGithubApiFactory targetGithubApiFactory) : base(log, targetGithubApiFactory)
     {
-        internal Func<string, string, Task> WriteToFile = async (path, contents) => await File.WriteAllTextAsync(path, contents);
-
-        private readonly OctoLogger _log;
-        private readonly ITargetGithubApiFactory _targetGithubApiFactory;
-
-        public GenerateMannequinCsvCommand(OctoLogger log, ITargetGithubApiFactory targetGithubApiFactory) : base("generate-mannequin-csv")
-        {
-            _log = log;
-            _targetGithubApiFactory = targetGithubApiFactory;
-
-            Description = "Generates a CSV with unreclaimed mannequins to reclaim them in bulk.";
-
-            var githubTargetOrgOption = new Option<string>("--github-target-org")
-            {
-                IsRequired = true,
-                Description = "Uses GH_PAT env variable."
-            };
-
-            var outputOption = new Option<FileInfo>("--output", () => new FileInfo("./mannequins.csv"))
-            {
-                IsRequired = false,
-                Description = "Output filename. Default value mannequins.csv"
-            };
-
-            var includeReclaimedOption = new Option("--include-reclaimed")
-            {
-                IsRequired = false,
-                Description = "Include mannequins that have already been reclaimed"
-            };
-
-            var verbose = new Option("--verbose")
-            {
-                IsRequired = false
-            };
-
-            var githubTargetPat = new Option<string>("--github-target-pat")
-            {
-                IsRequired = false
-            };
-
-            AddOption(githubTargetOrgOption);
-            AddOption(outputOption);
-            AddOption(includeReclaimedOption);
-            AddOption(githubTargetPat);
-            AddOption(verbose);
-
-            Handler = CommandHandler.Create<string, FileInfo, bool, string, bool>(Invoke);
-        }
-
-        public async Task Invoke(
-          string githubTargetOrg,
-          FileInfo output,
-          bool includeReclaimed = false,
-          string githubTargetPat = null,
-          bool verbose = false)
-        {
-            _log.Verbose = verbose;
-
-            _log.LogInformation("Generating CSV...");
-
-            _log.LogInformation($"GITHUB TARGET ORG: {githubTargetOrg}");
-            if (githubTargetPat is not null)
-            {
-                _log.LogInformation("GITHUB TARGET PAT: ***");
-            }
-            _log.LogInformation($"FILE: {output}");
-            if (includeReclaimed)
-            {
-                _log.LogInformation("INCLUDING RECLAIMED");
-            }
-
-            var githubApi = _targetGithubApiFactory.Create(targetPersonalAccessToken: githubTargetPat);
-
-            var githubOrgId = await githubApi.GetOrganizationId(githubTargetOrg);
-            var mannequins = await githubApi.GetMannequins(githubOrgId);
-
-            _log.LogInformation($"    # Mannequins Found: {mannequins.Count()}");
-            _log.LogInformation($"    # Mannequins Previously Reclaimed: {mannequins.Count(x => x.MappedUser is not null)}");
-
-            var contents = new StringBuilder().AppendLine(ReclaimService.CSVHEADER);
-            foreach (var mannequin in mannequins.Where(m => includeReclaimed || m.MappedUser is null))
-            {
-                contents.AppendLine($"{mannequin.Login},{mannequin.Id},{mannequin.MappedUser?.Login}");
-            }
-
-            if (output?.FullName is not null)
-            {
-                await WriteToFile(output.FullName, contents.ToString());
-            }
-        }
+        AddOptions();
+        Handler = CommandHandler.Create<string, FileInfo, bool, string, bool>(Invoke);
     }
+
+    protected override Option<string> GithubOrg { get; } = new("--github-target-org")
+    {
+        IsRequired = true,
+        Description = "Uses GH_PAT env variable."
+    };
+
+    protected override Option<string> GithubPat { get; } = new("--github-target-pat") { IsRequired = false };
+
+    public async Task Invoke(string githubTargetOrg, FileInfo output, bool includeReclaimed = false, string githubTargetPat = null, bool verbose = false) =>
+        await Handle(githubTargetOrg, output, includeReclaimed, githubTargetPat, verbose);
 }


### PR DESCRIPTION
Closes #499 

Same as other refactors, this PR refactors `generate-mannequin-csv` command to be able to share it between CLI projects. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
