### PR TITLE
updated CI to publish bbs2gh

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -274,6 +274,17 @@ jobs:
           ./dist/linux-x64/ado2gh-linux-amd64
           ./dist/osx-x64/ado2gh-darwin-amd64
 
+    - name: Create gh-bbs2gh Release
+      uses: softprops/action-gh-release@v1
+      with:
+        body_path: ./RELEASENOTES.md
+        repository: github/gh-bbs2gh
+        token: ${{ secrets.PUBLISH_BBS2GH_TOKEN }}
+        files: |
+          ./dist/win-x64/bbs2gh-windows-amd64.exe
+          ./dist/linux-x64/bbs2gh-linux-amd64
+          ./dist/osx-x64/bbs2gh-darwin-amd64
+
     - name: Archive Release Notes
       shell: pwsh
       run: |

--- a/publish.ps1
+++ b/publish.ps1
@@ -118,3 +118,55 @@ else {
 
     Rename-Item ./dist/osx-x64/gei gei-darwin-amd64
 }
+
+### bbs2gh ###
+if ((Test-Path env:SKIP_WINDOWS) -And $env:SKIP_WINDOWS.ToUpper() -eq "TRUE") {
+    Write-Output "Skipping bbs2gh Windows build because SKIP_WINDOWS is set"
+}
+else {
+    dotnet publish src/bbs2gh/bbs2gh.csproj -c Release -o dist/win-x64/ -r win-x64 -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    if (Test-Path -Path ./dist/win-x64/bbs2gh-windows-amd64.exe) {
+        Remove-Item ./dist/win-x64/bbs2gh-windows-amd64.exe
+    }
+
+    Rename-Item ./dist/win-x64/bbs2gh.exe bbs2gh-windows-amd64.exe
+}
+
+if ((Test-Path env:SKIP_LINUX) -And $env:SKIP_LINUX.ToUpper() -eq "TRUE") {
+    Write-Output "Skipping bbs2gh Linux build because SKIP_LINUX is set"
+}
+else {
+    dotnet publish src/bbs2gh/bbs2gh.csproj -c Release -o dist/linux-x64/ -r linux-x64 -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    if (Test-Path -Path ./dist/linux-x64/bbs2gh-linux-amd64) {
+        Remove-Item ./dist/linux-x64/bbs2gh-linux-amd64
+    }
+
+    Rename-Item ./dist/linux-x64/bbs2gh bbs2gh-linux-amd64
+}
+
+if ((Test-Path env:SKIP_MACOS) -And $env:SKIP_MACOS.ToUpper() -eq "TRUE") {
+    Write-Output "Skipping bbs2gh MacOS build because SKIP_MACOS is set"
+}
+else {
+    dotnet publish src/bbs2gh/bbs2gh.csproj -c Release -o dist/osx-x64/ -r osx-x64 -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    if (Test-Path -Path ./dist/osx-x64/bbs2gh-darwin-amd64) {
+        Remove-Item ./dist/osx-x64/bbs2gh-darwin-amd64
+    }
+
+    Rename-Item ./dist/osx-x64/bbs2gh bbs2gh-darwin-amd64
+}


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Updating our build to publish the bbs2gh binaries to the github/gh-bbs2gh repo when we release.

This is still dark releasing. We're not talking about it yet, and customers can't use it because the backend is behind a feature flag.

Related to #515 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created) [no docs for BBS migrations yet - future epic]

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->