### PR TITLE
Add powershell vscode extension to devcontainer.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,8 @@
 			"extensions": [
 				"ms-dotnettools.csharp",
 				"formulahendry.dotnet-test-explorer",
-				"github.copilot"
+				"github.copilot",
+				"ms-vscode.powershell"
 			]
 		}
 	},


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->
This change adds the [vscode powershell extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell) to the devcontainer.

Related #119 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->