### PR TITLE
fix test explorer settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "dotnet-test-explorer.testProjectPath": "src/OctoshiftCLI.Tests"
+    "dotnet-test-explorer.testProjectPath": "**/OctoshiftCLI.Tests.csproj"
 }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Changed the path/glob it uses to find test project. Didn't seem to work with the old setting. Now it properly finds all our unit tests and shows them in the extension GUI.

Related #119 

![image](https://user-images.githubusercontent.com/1508559/184293774-cb30ba66-427b-46f3-9559-4ead37a89ac7.png)


- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->