### PR TITLE
added cache to version checker

### DIFF
--- a/src/Octoshift/VersionChecker.cs
+++ b/src/Octoshift/VersionChecker.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -23,7 +24,24 @@ namespace OctoshiftCLI
         public async Task<bool> IsLatest()
         {
             var curVersion = GetCurrentVersion();
-            var latestVersion = await GetLatestVersion();
+            var latestVersion = string.Empty;
+
+            var cacheCheck = Environment.GetEnvironmentVariable("OCTOSHIFT_VERSION_CHECK_DATE");
+
+            if (DateTime.TryParse(cacheCheck, out var cacheDate))
+            {
+                if (cacheDate.AddDays(1) > DateTime.Now)
+                {
+                    _log.LogVerbose("Version check cache is valid");
+                    latestVersion = Environment.GetEnvironmentVariable("OCTOSHIFT_VERSION_CHECK_RESULT");
+                }
+            }
+            else
+            {
+                latestVersion = await GetLatestVersion();
+                Environment.SetEnvironmentVariable("OCTOSHIFT_VERSION_CHECK_DATE", DateTime.Now.ToString());
+                Environment.SetEnvironmentVariable("OCTOSHIFT_VERSION_CHECK_RESULT", latestVersion);
+            }
 
             curVersion = curVersion[..latestVersion.Length];
 


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Using environment variables to cache the results of the version check. Will store the latest version found, and the last time the check was made against github.com. When the CLI runs it will use the env vars to see if a check has been made in the past 24 hours, and if so use the cached latest version number for the check. If no env vars are found, of if the cached date is older than 24 hours it will make the version check API call and update the env vars.

Closes #555 

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->