### PR TITLE
Refactor revoke-migrator-role command

### DIFF
--- a/src/Octoshift/Commands/RevokeMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/RevokeMigratorRoleCommandBase.cs
@@ -1,0 +1,81 @@
+using System.CommandLine;
+using System.Threading.Tasks;
+using OctoshiftCLI.Contracts;
+using OctoshiftCLI.Extensions;
+
+namespace OctoshiftCLI.Commands;
+
+public class RevokeMigratorRoleCommandBase : Command
+{
+    private readonly OctoLogger _log;
+    private readonly ITargetGithubApiFactory _githubApiFactory;
+
+    public RevokeMigratorRoleCommandBase(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base("revoke-migrator-role")
+    {
+        _log = log;
+        _githubApiFactory = githubApiFactory;
+
+        Description = "Allows an organization admin to revoke the migrator role for a USER or TEAM for a single GitHub organization. This will remove their ability to run a migration into the target organization.";
+    }
+
+    protected virtual Option<string> GithubOrg { get; } = new("--github-org") { IsRequired = true };
+
+    protected virtual Option<string> Actor { get; } = new("--actor") { IsRequired = true };
+
+    protected virtual Option<string> ActorType { get; } = new("--actor-type") { IsRequired = true };
+
+    protected virtual Option<string> GithubPat { get; } = new("--github-pat") { IsRequired = false };
+
+    protected virtual Option<bool> Verbose { get; } = new("--verbose") { IsRequired = false };
+
+    protected void AddOptions()
+    {
+        AddOption(GithubOrg);
+        AddOption(Actor);
+        AddOption(ActorType);
+        AddOption(GithubPat);
+        AddOption(Verbose);
+    }
+
+    public async Task Handle(string githubOrg, string actor, string actorType, string githubPat = null, bool verbose = false)
+    {
+        _log.Verbose = verbose;
+
+        _log.LogInformation("Granting migrator role ...");
+        _log.LogInformation($"{GithubOrg.GetLogFriendlyName()}: {githubOrg}");
+        _log.LogInformation($"{Actor.GetLogFriendlyName()}: {actor}");
+
+        if (githubPat is not null)
+        {
+            _log.LogInformation($"{GithubPat.GetLogFriendlyName()}: ***");
+        }
+
+        actorType = actorType?.ToUpper();
+        _log.LogInformation($"{ActorType.GetLogFriendlyName()}: {actorType}");
+
+        actorType = actorType.ToUpper();
+
+        if (actorType is "TEAM" or "USER")
+        {
+            _log.LogInformation("Actor type is valid...");
+        }
+        else
+        {
+            _log.LogError("Actor type must be either TEAM or USER.");
+            return;
+        }
+
+        var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubPat);
+        var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
+        var success = await githubApi.RevokeMigratorRole(githubOrgId, actor, actorType);
+
+        if (success)
+        {
+            _log.LogSuccess($"Migrator role successfully revoked for the {actorType} \"{actor}\"");
+        }
+        else
+        {
+            _log.LogError($"Migrator role couldn't be revoked for the {actorType} \"{actor}\"");
+        }
+    }
+}

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/RevokeMigratorRoleCommandBaseTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/RevokeMigratorRoleCommandBaseTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading.Tasks;
+using Moq;
+using OctoshiftCLI.Commands;
+using OctoshiftCLI.Contracts;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.Octoshift.Commands;
+
+public class RevokeMigratorRoleCommandBaseTests
+{
+    private readonly Mock<GithubApi> _mockGithubApi = TestHelpers.CreateMock<GithubApi>();
+    private readonly Mock<ITargetGithubApiFactory> _mockGithubApiFactory = new();
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+
+    private readonly RevokeMigratorRoleCommandBase _command;
+
+    public RevokeMigratorRoleCommandBaseTests()
+    {
+        _command = new RevokeMigratorRoleCommandBase(_mockOctoLogger.Object, _mockGithubApiFactory.Object);
+    }
+
+    [Fact]
+    public async Task Happy_Path()
+    {
+        var githubOrg = "FooOrg";
+        var actor = "foo-actor";
+        var actorType = "TEAM";
+        var githubOrgId = Guid.NewGuid().ToString();
+
+        _mockGithubApi.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
+        _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
+
+        await _command.Handle(githubOrg, actor, actorType);
+
+        _mockGithubApi.Verify(x => x.RevokeMigratorRole(githubOrgId, actor, actorType));
+    }
+
+    [Fact]
+    public async Task It_Uses_The_Github_Pat_When_Provided()
+    {
+        const string githubPat = "github-pat";
+
+        _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(_mockGithubApi.Object);
+
+        await _command.Handle("githubOrg", "actor", "TEAM", githubPat);
+
+        _mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
+    }
+
+    [Fact]
+    public async Task Invalid_Actor_Type()
+    {
+        await _command.Handle("foo", "foo", "foo");
+    }
+}

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
@@ -1,71 +1,33 @@
-using System;
-using System.Threading.Tasks;
 using Moq;
 using OctoshiftCLI.AdoToGithub;
 using OctoshiftCLI.AdoToGithub.Commands;
 using Xunit;
 
-namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+namespace OctoshiftCLI.Tests.AdoToGithub.Commands;
+
+public class RevokeMigratorRoleCommandTests
 {
-    public class RevokeMigratorRoleCommandTests
+    private readonly Mock<GithubApiFactory> _mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+
+    private readonly RevokeMigratorRoleCommand _command;
+
+    public RevokeMigratorRoleCommandTests()
     {
-        private readonly Mock<GithubApi> _mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-        private readonly Mock<GithubApiFactory> _mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
-        private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+        _command = new RevokeMigratorRoleCommand(_mockOctoLogger.Object, _mockGithubApiFactory.Object);
+    }
 
-        private readonly RevokeMigratorRoleCommand _command;
+    [Fact]
+    public void Should_Have_Options()
+    {
+        Assert.NotNull(_command);
+        Assert.Equal("revoke-migrator-role", _command.Name);
+        Assert.Equal(5, _command.Options.Count);
 
-        public RevokeMigratorRoleCommandTests()
-        {
-            _command = new RevokeMigratorRoleCommand(_mockOctoLogger.Object, _mockGithubApiFactory.Object);
-        }
-
-        [Fact]
-        public void Should_Have_Options()
-        {
-            Assert.NotNull(_command);
-            Assert.Equal("revoke-migrator-role", _command.Name);
-            Assert.Equal(5, _command.Options.Count);
-
-            TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
-            TestHelpers.VerifyCommandOption(_command.Options, "actor", true);
-            TestHelpers.VerifyCommandOption(_command.Options, "actor-type", true);
-            TestHelpers.VerifyCommandOption(_command.Options, "github-pat", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
-        }
-
-        [Fact]
-        public async Task Happy_Path()
-        {
-            var githubOrg = "FooOrg";
-            var actor = "foo-actor";
-            var actorType = "TEAM";
-            var githubOrgId = Guid.NewGuid().ToString();
-
-            _mockGithubApi.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-            _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
-
-            await _command.Invoke(githubOrg, actor, actorType);
-
-            _mockGithubApi.Verify(x => x.RevokeMigratorRole(githubOrgId, actor, actorType));
-        }
-
-        [Fact]
-        public async Task It_Uses_The_Github_Pat_When_Provided()
-        {
-            const string githubPat = "github-pat";
-
-            _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(_mockGithubApi.Object);
-
-            await _command.Invoke("githubOrg", "actor", "TEAM", githubPat);
-
-            _mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
-        }
-
-        [Fact]
-        public async Task Invalid_Actor_Type()
-        {
-            await _command.Invoke("foo", "foo", "foo");
-        }
+        TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "actor", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "actor-type", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "github-pat", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
@@ -1,81 +1,33 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using FluentAssertions;
 using Moq;
 using OctoshiftCLI.Contracts;
 using OctoshiftCLI.GithubEnterpriseImporter.Commands;
 using Xunit;
 
-namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
+namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands;
+
+public class RevokeMigratorRoleCommandTests
 {
-    public class RevokeMigratorRoleCommandTests
+    private readonly Mock<ITargetGithubApiFactory> _mockTargetGithubApiFactory = new();
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+
+    private readonly RevokeMigratorRoleCommand _command;
+
+    public RevokeMigratorRoleCommandTests()
     {
-        private readonly Mock<GithubApi> _mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-        private readonly Mock<ITargetGithubApiFactory> _mockTargetGithubApiFactory = new Mock<ITargetGithubApiFactory>();
-        private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+        _command = new RevokeMigratorRoleCommand(_mockOctoLogger.Object, _mockTargetGithubApiFactory.Object);
+    }
 
-        private readonly RevokeMigratorRoleCommand _command;
+    [Fact]
+    public void Should_Have_Options()
+    {
+        Assert.NotNull(_command);
+        Assert.Equal("revoke-migrator-role", _command.Name);
+        Assert.Equal(5, _command.Options.Count);
 
-        public RevokeMigratorRoleCommandTests()
-        {
-            _command = new RevokeMigratorRoleCommand(_mockOctoLogger.Object, _mockTargetGithubApiFactory.Object);
-        }
-
-        [Fact]
-        public void Should_Have_Options()
-        {
-            Assert.NotNull(_command);
-            Assert.Equal("revoke-migrator-role", _command.Name);
-            Assert.Equal(5, _command.Options.Count);
-
-            TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
-            TestHelpers.VerifyCommandOption(_command.Options, "actor", true);
-            TestHelpers.VerifyCommandOption(_command.Options, "actor-type", true);
-            TestHelpers.VerifyCommandOption(_command.Options, "github-target-pat", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
-        }
-
-        [Fact]
-        public async Task Happy_Path()
-        {
-            var githubOrg = "FooOrg";
-            var actor = "foo-actor";
-            var actorType = "TEAM";
-            var githubOrgId = Guid.NewGuid().ToString();
-
-            _mockGithubApi.Setup(x => x.GetOrganizationId(githubOrg).Result).Returns(githubOrgId);
-
-            _mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
-
-            await _command.Invoke(githubOrg, actor, actorType);
-
-            _mockGithubApi.Verify(x => x.RevokeMigratorRole(githubOrgId, actor, actorType));
-        }
-
-        [Fact]
-        public async Task Invalid_Actor_Type()
-        {
-            await _command.Invoke("foo", "foo", "foo");
-        }
-
-        [Fact]
-        public async Task It_Uses_Github_Target_Pat_When_Provided()
-        {
-            // Arrange
-            const string githubTargetPat = "github-target-pat";
-
-            _mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubTargetPat)).Returns(_mockGithubApi.Object);
-
-            var actualLogOutput = new List<string>();
-            _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
-
-            // Act
-            await _command.Invoke("githubOrg", "actor", "TEAM", githubTargetPat);
-
-            // Assert
-            actualLogOutput.Should().Contain("GITHUB TARGET PAT: ***");
-            _mockTargetGithubApiFactory.Verify(m => m.Create(null, githubTargetPat));
-        }
+        TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "actor", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "actor-type", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "github-target-pat", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
     }
 }

--- a/src/ado2gh/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/ado2gh/Commands/RevokeMigratorRoleCommand.cs
@@ -1,92 +1,19 @@
 using System;
-using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.Threading.Tasks;
+using OctoshiftCLI.Commands;
+using OctoshiftCLI.Contracts;
+using OctoshiftCLI.Extensions;
 
-namespace OctoshiftCLI.AdoToGithub.Commands
+namespace OctoshiftCLI.AdoToGithub.Commands;
+
+public sealed class RevokeMigratorRoleCommand : RevokeMigratorRoleCommandBase
 {
-    public class RevokeMigratorRoleCommand : Command
+    public RevokeMigratorRoleCommand(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base(log, githubApiFactory)
     {
-        private readonly OctoLogger _log;
-        private readonly GithubApiFactory _githubApiFactory;
+        Description += Environment.NewLine;
+        Description += $"Note: Expects GH_PAT env variable or --{GithubPat.GetLogFriendlyName()} option to be set.";
 
-        public RevokeMigratorRoleCommand(OctoLogger log, GithubApiFactory githubApiFactory) : base("revoke-migrator-role")
-        {
-            _log = log;
-            _githubApiFactory = githubApiFactory;
-            Description = "Allows an organization admin to revoke the migrator role for a USER or TEAM for a single GitHub organization. This will remove their ability to run a migration into the target organization.";
-            Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variable or --github-pat option to be set.";
-
-            var githubOrg = new Option<string>("--github-org")
-            {
-                IsRequired = true
-            };
-            var actor = new Option<string>("--actor")
-            {
-                IsRequired = true
-            };
-            var actorType = new Option<string>("--actor-type")
-            {
-                IsRequired = true
-            };
-            var githubPat = new Option<string>("--github-pat")
-            {
-                IsRequired = false
-            };
-            var verbose = new Option("--verbose")
-            {
-                IsRequired = false
-            };
-
-            AddOption(githubOrg);
-            AddOption(actor);
-            AddOption(actorType);
-            AddOption(githubPat);
-            AddOption(verbose);
-
-            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
-        }
-
-        public async Task Invoke(string githubOrg, string actor, string actorType, string githubPat = null, bool verbose = false)
-        {
-            _log.Verbose = verbose;
-
-            _log.LogInformation("Granting migrator role ...");
-            _log.LogInformation($"GITHUB ORG: {githubOrg}");
-            _log.LogInformation($"ACTOR: {actor}");
-            if (githubPat is not null)
-            {
-                _log.LogInformation("GITHUB PAT: ***");
-            }
-
-            actorType = actorType?.ToUpper();
-            _log.LogInformation($"ACTOR TYPE: {actorType}");
-
-            actorType = actorType.ToUpper();
-
-            if (actorType is "TEAM" or "USER")
-            {
-                _log.LogInformation("Actor type is valid...");
-            }
-            else
-            {
-                _log.LogError("Actor type must be either TEAM or USER.");
-                return;
-            }
-
-            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubPat);
-            var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
-            var success = await githubApi.RevokeMigratorRole(githubOrgId, actor, actorType);
-
-            if (success)
-            {
-                _log.LogSuccess($"Migrator role successfully revoked for the {actorType} \"{actor}\"");
-            }
-            else
-            {
-                _log.LogError($"Migrator role couldn't be revoked for the {actorType} \"{actor}\"");
-            }
-        }
+        AddOptions();
+        Handler = CommandHandler.Create<string, string, string, string, bool>(Handle);
     }
 }

--- a/src/gei/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/gei/Commands/RevokeMigratorRoleCommand.cs
@@ -2,92 +2,25 @@ using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;
+using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;
+using OctoshiftCLI.Extensions;
 
-namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
+namespace OctoshiftCLI.GithubEnterpriseImporter.Commands;
+
+public sealed class RevokeMigratorRoleCommand : RevokeMigratorRoleCommandBase
 {
-    public class RevokeMigratorRoleCommand : Command
+    public RevokeMigratorRoleCommand(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base(log, githubApiFactory)
     {
-        private readonly OctoLogger _log;
-        private readonly ITargetGithubApiFactory _githubApiFactory;
+        Description += Environment.NewLine;
+        Description += $"Note: Expects GH_PAT env variable or --{GithubPat.GetLogFriendlyName()} option to be set.";
 
-        public RevokeMigratorRoleCommand(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base("revoke-migrator-role")
-        {
-            _log = log;
-            _githubApiFactory = githubApiFactory;
-            Description = "Allows an organization admin to revoke the migrator role for a USER or TEAM for a single GitHub organization. This will remove their ability to run a migration into the target organization.";
-            Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variable or --github-target-pat option to be set.";
-
-            var githubOrg = new Option<string>("--github-org")
-            {
-                IsRequired = true
-            };
-            var actor = new Option<string>("--actor")
-            {
-                IsRequired = true
-            };
-            var actorType = new Option<string>("--actor-type")
-            {
-                IsRequired = true
-            };
-            var githubTargetPat = new Option<string>("--github-target-pat")
-            {
-                IsRequired = false
-            };
-            var verbose = new Option("--verbose")
-            {
-                IsRequired = false
-            };
-
-            AddOption(githubOrg);
-            AddOption(actor);
-            AddOption(actorType);
-            AddOption(githubTargetPat);
-            AddOption(verbose);
-
-            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
-        }
-
-        public async Task Invoke(string githubOrg, string actor, string actorType, string githubTargetPat = null, bool verbose = false)
-        {
-            _log.Verbose = verbose;
-
-            _log.LogInformation("Granting migrator role ...");
-            _log.LogInformation($"GITHUB ORG: {githubOrg}");
-            _log.LogInformation($"ACTOR: {actor}");
-            if (githubTargetPat is not null)
-            {
-                _log.LogInformation("GITHUB TARGET PAT: ***");
-            }
-
-            actorType = actorType?.ToUpper();
-            _log.LogInformation($"ACTOR TYPE: {actorType}");
-
-            actorType = actorType.ToUpper();
-
-            if (actorType is "TEAM" or "USER")
-            {
-                _log.LogInformation("Actor type is valid...");
-            }
-            else
-            {
-                _log.LogError("Actor type must be either TEAM or USER.");
-                return;
-            }
-
-            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubTargetPat);
-            var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
-            var success = await githubApi.RevokeMigratorRole(githubOrgId, actor, actorType);
-
-            if (success)
-            {
-                _log.LogSuccess($"Migrator role successfully revoked for the {actorType} \"{actor}\"");
-            }
-            else
-            {
-                _log.LogError($"Migrator role couldn't be revoked for the {actorType} \"{actor}\"");
-            }
-        }
+        AddOptions();
+        Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
     }
+
+    protected override Option<string> GithubPat { get; } = new("--github-target-pat") { IsRequired = false };
+
+    public async Task Invoke(string githubOrg, string actor, string actorType, string githubTargetPat = null, bool verbose = false) =>
+        await Handle(githubOrg, actor, actorType, githubTargetPat, verbose);
 }


### PR DESCRIPTION
Closes #502 

Same as other ones, this one refactors `revoke-migrator-role` command.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
