### PR TITLE
Refactor create team command

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Added `create-team` command to `gh gei`.

--- a/src/Octoshift/Commands/CreateTeamCommandBase.cs
+++ b/src/Octoshift/Commands/CreateTeamCommandBase.cs
@@ -1,0 +1,91 @@
+using System.CommandLine;
+using System.Linq;
+using System.Threading.Tasks;
+using OctoshiftCLI.Contracts;
+using OctoshiftCLI.Extensions;
+
+namespace OctoshiftCLI.Commands;
+
+public class CreateTeamCommandBase : Command
+{
+    private readonly OctoLogger _log;
+    private readonly ITargetGithubApiFactory _githubApiFactory;
+
+    public CreateTeamCommandBase(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base("create-team")
+    {
+        _log = log;
+        _githubApiFactory = githubApiFactory;
+
+        Description = "Creates a GitHub team and optionally links it to an IdP group.";
+    }
+
+    protected virtual Option<string> GithubOrg { get; } = new("--github-org") { IsRequired = true };
+
+    protected virtual Option<string> TeamName { get; } = new("--team-name") { IsRequired = true };
+
+    protected virtual Option<string> IdpGroup { get; } = new("--idp-group") { IsRequired = false };
+
+    protected virtual Option<string> GithubPat { get; } = new("--github-pat") { IsRequired = false };
+
+    protected virtual Option<bool> Verbose { get; } = new("--verbose") { IsRequired = false };
+
+    protected void AddOptions()
+    {
+        AddOption(GithubOrg);
+        AddOption(TeamName);
+        AddOption(IdpGroup);
+        AddOption(GithubPat);
+        AddOption(Verbose);
+    }
+
+    public async Task Handle(string githubOrg, string teamName, string idpGroup, string githubPat = null, bool verbose = false)
+    {
+        _log.Verbose = verbose;
+
+        _log.LogInformation("Creating GitHub team...");
+        _log.LogInformation($"{GithubOrg.GetLogFriendlyName()}: {githubOrg}");
+        _log.LogInformation($"{TeamName.GetLogFriendlyName()}: {teamName}");
+        _log.LogInformation($"{IdpGroup.GetLogFriendlyName()}: {idpGroup}");
+
+        if (githubPat is not null)
+        {
+            _log.LogInformation($"{GithubPat.GetLogFriendlyName()}: ***");
+        }
+
+        var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubPat);
+
+        var teams = await githubApi.GetTeams(githubOrg);
+        if (teams.Contains(teamName))
+        {
+            _log.LogSuccess($"Team '{teamName}' already exists - New team will not be created");
+        }
+        else
+        {
+            await githubApi.CreateTeam(githubOrg, teamName);
+            _log.LogSuccess("Successfully created team");
+        }
+
+        // TODO: Can improve perf by capturing slug in the response from CreateTeam or GetTeams
+        var teamSlug = await githubApi.GetTeamSlug(githubOrg, teamName);
+
+        if (string.IsNullOrWhiteSpace(idpGroup))
+        {
+            _log.LogInformation("No IdP Group provided, skipping the IdP linking step");
+        }
+        else
+        {
+            var members = await githubApi.GetTeamMembers(githubOrg, teamSlug);
+
+            foreach (var member in members)
+            {
+                await githubApi.RemoveTeamMember(githubOrg, teamSlug, member);
+            }
+
+            var idpGroupId = await githubApi.GetIdpGroupId(githubOrg, idpGroup);
+
+            await githubApi.AddEmuGroupToTeam(githubOrg, teamSlug, idpGroupId);
+
+            _log.LogSuccess("Successfully linked team to Idp group");
+        }
+    }
+}

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/CreateTeamCommandBaseTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/CreateTeamCommandBaseTests.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using OctoshiftCLI.Commands;
+using OctoshiftCLI.Contracts;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.Octoshift.Commands;
+
+public class CreateTeamCommandBaseTests
+{
+    private readonly Mock<GithubApi> _mockGithubApi = TestHelpers.CreateMock<GithubApi>();
+    private readonly Mock<ITargetGithubApiFactory> _mockGithubApiFactory = new();
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+
+    private readonly CreateTeamCommandBase _command;
+
+    private const string GITHUB_ORG = "FooOrg";
+    private const string TEAM_NAME = "foo-team";
+    private const string IDP_GROUP = "foo-group";
+    private readonly List<string> TEAM_MEMBERS = new() { "dylan", "dave" };
+    private const int IDP_GROUP_ID = 42;
+    private const string TEAM_SLUG = "foo-slug";
+
+    public CreateTeamCommandBaseTests()
+    {
+        _command = new CreateTeamCommandBase(_mockOctoLogger.Object, _mockGithubApiFactory.Object);
+    }
+
+    [Fact]
+    public async Task Happy_Path()
+    {
+        _mockGithubApi.Setup(x => x.GetTeamMembers(GITHUB_ORG, TEAM_SLUG).Result).Returns(TEAM_MEMBERS);
+        _mockGithubApi.Setup(x => x.GetIdpGroupId(GITHUB_ORG, IDP_GROUP).Result).Returns(IDP_GROUP_ID);
+        _mockGithubApi.Setup(x => x.GetTeamSlug(GITHUB_ORG, TEAM_NAME).Result).Returns(TEAM_SLUG);
+        _mockGithubApi.Setup(x => x.GetTeams(GITHUB_ORG).Result).Returns(new List<string>());
+
+        _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
+
+        await _command.Handle(GITHUB_ORG, TEAM_NAME, IDP_GROUP);
+
+        _mockGithubApi.Verify(x => x.CreateTeam(GITHUB_ORG, TEAM_NAME));
+        _mockGithubApi.Verify(x => x.RemoveTeamMember(GITHUB_ORG, TEAM_SLUG, TEAM_MEMBERS[0]));
+        _mockGithubApi.Verify(x => x.RemoveTeamMember(GITHUB_ORG, TEAM_SLUG, TEAM_MEMBERS[1]));
+        _mockGithubApi.Verify(x => x.AddEmuGroupToTeam(GITHUB_ORG, TEAM_SLUG, IDP_GROUP_ID));
+    }
+
+    [Fact]
+    public async Task It_Uses_The_Github_Pat_When_Provided()
+    {
+        const string githubPat = "github-pat";
+
+        _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(_mockGithubApi.Object);
+
+        await _command.Handle("GITHUB_ORG", "TEAM_NAME", "IDP_GROUP", githubPat);
+
+        _mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
+    }
+
+    [Fact]
+    public async Task Idempotency_Team_Exists()
+    {
+        _mockGithubApi.Setup(x => x.GetTeamMembers(GITHUB_ORG, TEAM_SLUG).Result).Returns(TEAM_MEMBERS);
+        _mockGithubApi.Setup(x => x.GetIdpGroupId(GITHUB_ORG, IDP_GROUP).Result).Returns(IDP_GROUP_ID);
+        _mockGithubApi.Setup(x => x.GetTeamSlug(GITHUB_ORG, TEAM_NAME).Result).Returns(TEAM_SLUG);
+        _mockGithubApi.Setup(x => x.GetTeams(GITHUB_ORG).Result).Returns(new List<string> { TEAM_NAME });
+
+        _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
+
+        var actualLogOutput = new List<string>();
+        _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
+        _mockOctoLogger.Setup(m => m.LogSuccess(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
+
+        await _command.Handle(GITHUB_ORG, TEAM_NAME, IDP_GROUP);
+
+        _mockGithubApi.Verify(x => x.CreateTeam(GITHUB_ORG, TEAM_NAME), Times.Never);
+        _mockGithubApi.Verify(x => x.RemoveTeamMember(GITHUB_ORG, TEAM_SLUG, TEAM_MEMBERS[0]));
+        _mockGithubApi.Verify(x => x.RemoveTeamMember(GITHUB_ORG, TEAM_SLUG, TEAM_MEMBERS[1]));
+        _mockGithubApi.Verify(x => x.AddEmuGroupToTeam(GITHUB_ORG, TEAM_SLUG, IDP_GROUP_ID));
+        actualLogOutput.Contains($"Team '{TEAM_NAME}' already exists. New team will not be created");
+    }
+}

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/CreateTeamCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/CreateTeamCommandTests.cs
@@ -1,97 +1,33 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Moq;
 using OctoshiftCLI.AdoToGithub;
 using OctoshiftCLI.AdoToGithub.Commands;
 using Xunit;
 
-namespace OctoshiftCLI.Tests.AdoToGithub.Commands
+namespace OctoshiftCLI.Tests.AdoToGithub.Commands;
+
+public class CreateTeamCommandTests
 {
-    public class CreateTeamCommandTests
+    private readonly Mock<GithubApiFactory> _mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+
+    private readonly CreateTeamCommand _command;
+
+    public CreateTeamCommandTests()
     {
-        private readonly Mock<GithubApi> _mockGithubApi = TestHelpers.CreateMock<GithubApi>();
-        private readonly Mock<GithubApiFactory> _mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
-        private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+        _command = new CreateTeamCommand(_mockOctoLogger.Object, _mockGithubApiFactory.Object);
+    }
 
-        private readonly CreateTeamCommand _command;
+    [Fact]
+    public void Should_Have_Options()
+    {
+        Assert.NotNull(_command);
+        Assert.Equal("create-team", _command.Name);
+        Assert.Equal(5, _command.Options.Count);
 
-        private const string GITHUB_ORG = "FooOrg";
-        private const string TEAM_NAME = "foo-team";
-        private const string IDP_GROUP = "foo-group";
-        private readonly List<string> TEAM_MEMBERS = new() { "dylan", "dave" };
-        private const int IDP_GROUP_ID = 42;
-        private const string TEAM_SLUG = "foo-slug";
-
-        public CreateTeamCommandTests()
-        {
-            _command = new CreateTeamCommand(_mockOctoLogger.Object, _mockGithubApiFactory.Object);
-        }
-
-        [Fact]
-        public void Should_Have_Options()
-        {
-            Assert.NotNull(_command);
-            Assert.Equal("create-team", _command.Name);
-            Assert.Equal(5, _command.Options.Count);
-
-            TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
-            TestHelpers.VerifyCommandOption(_command.Options, "team-name", true);
-            TestHelpers.VerifyCommandOption(_command.Options, "idp-group", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "github-pat", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
-        }
-
-        [Fact]
-        public async Task Happy_Path()
-        {
-            _mockGithubApi.Setup(x => x.GetTeamMembers(GITHUB_ORG, TEAM_SLUG).Result).Returns(TEAM_MEMBERS);
-            _mockGithubApi.Setup(x => x.GetIdpGroupId(GITHUB_ORG, IDP_GROUP).Result).Returns(IDP_GROUP_ID);
-            _mockGithubApi.Setup(x => x.GetTeamSlug(GITHUB_ORG, TEAM_NAME).Result).Returns(TEAM_SLUG);
-            _mockGithubApi.Setup(x => x.GetTeams(GITHUB_ORG).Result).Returns(new List<string>());
-
-            _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
-
-            await _command.Invoke(GITHUB_ORG, TEAM_NAME, IDP_GROUP);
-
-            _mockGithubApi.Verify(x => x.CreateTeam(GITHUB_ORG, TEAM_NAME));
-            _mockGithubApi.Verify(x => x.RemoveTeamMember(GITHUB_ORG, TEAM_SLUG, TEAM_MEMBERS[0]));
-            _mockGithubApi.Verify(x => x.RemoveTeamMember(GITHUB_ORG, TEAM_SLUG, TEAM_MEMBERS[1]));
-            _mockGithubApi.Verify(x => x.AddEmuGroupToTeam(GITHUB_ORG, TEAM_SLUG, IDP_GROUP_ID));
-        }
-
-        [Fact]
-        public async Task It_Uses_The_Github_Pat_When_Provided()
-        {
-            const string githubPat = "github-pat";
-
-            _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(_mockGithubApi.Object);
-
-            await _command.Invoke("GITHUB_ORG", "TEAM_NAME", "IDP_GROUP", githubPat);
-
-            _mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
-        }
-
-        [Fact]
-        public async Task Idempotency_Team_Exists()
-        {
-            _mockGithubApi.Setup(x => x.GetTeamMembers(GITHUB_ORG, TEAM_SLUG).Result).Returns(TEAM_MEMBERS);
-            _mockGithubApi.Setup(x => x.GetIdpGroupId(GITHUB_ORG, IDP_GROUP).Result).Returns(IDP_GROUP_ID);
-            _mockGithubApi.Setup(x => x.GetTeamSlug(GITHUB_ORG, TEAM_NAME).Result).Returns(TEAM_SLUG);
-            _mockGithubApi.Setup(x => x.GetTeams(GITHUB_ORG).Result).Returns(new List<string> { TEAM_NAME });
-
-            _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
-
-            var actualLogOutput = new List<string>();
-            _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
-            _mockOctoLogger.Setup(m => m.LogSuccess(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
-
-            await _command.Invoke(GITHUB_ORG, TEAM_NAME, IDP_GROUP);
-
-            _mockGithubApi.Verify(x => x.CreateTeam(GITHUB_ORG, TEAM_NAME), Times.Never);
-            _mockGithubApi.Verify(x => x.RemoveTeamMember(GITHUB_ORG, TEAM_SLUG, TEAM_MEMBERS[0]));
-            _mockGithubApi.Verify(x => x.RemoveTeamMember(GITHUB_ORG, TEAM_SLUG, TEAM_MEMBERS[1]));
-            _mockGithubApi.Verify(x => x.AddEmuGroupToTeam(GITHUB_ORG, TEAM_SLUG, IDP_GROUP_ID));
-            actualLogOutput.Contains($"Team '{TEAM_NAME}' already exists. New team will not be created");
-        }
+        TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "team-name", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "idp-group", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "github-pat", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/CreateTeamCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/CreateTeamCommandTests.cs
@@ -1,0 +1,33 @@
+using Moq;
+using OctoshiftCLI.Contracts;
+using OctoshiftCLI.GithubEnterpriseImporter.Commands;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands;
+
+public class CreateTeamCommandTests
+{
+    private readonly Mock<ITargetGithubApiFactory> _mockGithubApiFactory = new();
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+
+    private readonly CreateTeamCommand _command;
+
+    public CreateTeamCommandTests()
+    {
+        _command = new CreateTeamCommand(_mockOctoLogger.Object, _mockGithubApiFactory.Object);
+    }
+
+    [Fact]
+    public void Should_Have_Options()
+    {
+        Assert.NotNull(_command);
+        Assert.Equal("create-team", _command.Name);
+        Assert.Equal(5, _command.Options.Count);
+
+        TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "team-name", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "idp-group", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "github-target-pat", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
+    }
+}

--- a/src/ado2gh/Commands/CreateTeamCommand.cs
+++ b/src/ado2gh/Commands/CreateTeamCommand.cs
@@ -1,103 +1,18 @@
 ﻿using System;
-using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.Linq;
-using System.Threading.Tasks;
+using OctoshiftCLI.Commands;
+using OctoshiftCLI.Contracts;
 
-namespace OctoshiftCLI.AdoToGithub.Commands
+namespace OctoshiftCLI.AdoToGithub.Commands;
+
+public sealed class CreateTeamCommand : CreateTeamCommandBase
 {
-    public class CreateTeamCommand : Command
+    public CreateTeamCommand(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base(log, githubApiFactory)
     {
-        private readonly OctoLogger _log;
-        private readonly GithubApiFactory _githubApiFactory;
+        Description += Environment.NewLine;
+        Description += $"Note: Expects GH_PAT env variable or --{GithubPat.ArgumentHelpName} option to be set.";
 
-        public CreateTeamCommand(OctoLogger log, GithubApiFactory githubApiFactory) : base("create-team")
-        {
-            _log = log;
-            _githubApiFactory = githubApiFactory;
-
-            Description = "Creates a GitHub team and optionally links it to an IdP group.";
-            Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variable or --github-pat option to be set.";
-
-            var githubOrg = new Option<string>("--github-org")
-            {
-                IsRequired = true
-            };
-            var teamName = new Option<string>("--team-name")
-            {
-                IsRequired = true
-            };
-            var idpGroup = new Option<string>("--idp-group")
-            {
-                IsRequired = false
-            };
-            var githubPat = new Option<string>("--github-pat")
-            {
-                IsRequired = false
-            };
-            var verbose = new Option("--verbose")
-            {
-                IsRequired = false
-            };
-
-            AddOption(githubOrg);
-            AddOption(teamName);
-            AddOption(idpGroup);
-            AddOption(githubPat);
-            AddOption(verbose);
-
-            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
-        }
-
-        public async Task Invoke(string githubOrg, string teamName, string idpGroup, string githubPat = null, bool verbose = false)
-        {
-            _log.Verbose = verbose;
-
-            _log.LogInformation("Creating GitHub team...");
-            _log.LogInformation($"GITHUB ORG: {githubOrg}");
-            _log.LogInformation($"TEAM NAME: {teamName}");
-            _log.LogInformation($"IDP GROUP: {idpGroup}");
-            if (githubPat is not null)
-            {
-                _log.LogInformation("GITHUB PAT: ***");
-            }
-
-            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubPat);
-
-            var teams = await githubApi.GetTeams(githubOrg);
-            if (teams.Contains(teamName))
-            {
-                _log.LogSuccess($"Team '{teamName}' already exists - New team will not be created");
-            }
-            else
-            {
-                await githubApi.CreateTeam(githubOrg, teamName);
-                _log.LogSuccess("Successfully created team");
-            }
-
-            // TODO: Can improve perf by capturing slug in the response from CreateTeam or GetTeams
-            var teamSlug = await githubApi.GetTeamSlug(githubOrg, teamName);
-
-            if (string.IsNullOrWhiteSpace(idpGroup))
-            {
-                _log.LogInformation("No IdP Group provided, skipping the IdP linking step");
-            }
-            else
-            {
-                var members = await githubApi.GetTeamMembers(githubOrg, teamSlug);
-
-                foreach (var member in members)
-                {
-                    await githubApi.RemoveTeamMember(githubOrg, teamSlug, member);
-                }
-
-                var idpGroupId = await githubApi.GetIdpGroupId(githubOrg, idpGroup);
-
-                await githubApi.AddEmuGroupToTeam(githubOrg, teamSlug, idpGroupId);
-
-                _log.LogSuccess("Successfully linked team to Idp group");
-            }
-        }
+        AddOptions();
+        Handler = CommandHandler.Create<string, string, string, string, bool>(Handle);
     }
 }

--- a/src/gei/Commands/CreateTeamCommand.cs
+++ b/src/gei/Commands/CreateTeamCommand.cs
@@ -1,0 +1,25 @@
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading.Tasks;
+using OctoshiftCLI.Commands;
+using OctoshiftCLI.Contracts;
+
+namespace OctoshiftCLI.GithubEnterpriseImporter.Commands;
+
+public sealed class CreateTeamCommand : CreateTeamCommandBase
+{
+    public CreateTeamCommand(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base(log, githubApiFactory)
+    {
+        Description += Environment.NewLine;
+        Description += $"Note: Expects GH_PAT env variable or --{GithubPat.ArgumentHelpName} option to be set.";
+
+        AddOptions();
+        Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
+    }
+
+    protected override Option<string> GithubPat { get; } = new("--github-target-pat") { IsRequired = false };
+
+    public async Task Invoke(string githubOrg, string teamName, string idpGroup, string githubTargetPat = null, bool verbose = false) =>
+        await Handle(githubOrg, teamName, idpGroup, githubTargetPat, verbose);
+}


### PR DESCRIPTION
Closes #504 

1. Refactor the `ado2gh create-team` command to use the shared `create-team` command.
1. Add `create-team` command to `gei`.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)