### PR TITLE
added bbs2gh to integration test setup in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -141,6 +141,7 @@ jobs:
       run: |
         New-Item -Path "./" -Name "gh-gei" -ItemType "directory"
         New-Item -Path "./" -Name "gh-ado2gh" -ItemType "directory"
+        New-Item -Path "./" -Name "gh-bbs2gh" -ItemType "directory"
         Copy-Item ./dist/linux-x64/gei-linux-amd64 ./gh-gei/gh-gei
         Copy-Item ./dist/linux-x64/ado2gh-linux-amd64 ./gh-ado2gh/gh-ado2gh
         Copy-Item ./dist/linux-x64/bbs2gh-linux-amd64 ./gh-bbs2gh/gh-bbs2gh
@@ -151,6 +152,7 @@ jobs:
       run: |
         New-Item -Path "./" -Name "gh-gei" -ItemType "directory"
         New-Item -Path "./" -Name "gh-ado2gh" -ItemType "directory"
+        New-Item -Path "./" -Name "gh-bbs2gh" -ItemType "directory"
         Copy-Item ./dist/win-x64/gei-windows-amd64.exe ./gh-gei/gh-gei.exe
         Copy-Item ./dist/win-x64/ado2gh-windows-amd64.exe ./gh-ado2gh/gh-ado2gh.exe
         Copy-Item ./dist/win-x64/bbs2gh-windows-amd64.exe ./gh-bbs2gh/gh-bbs2gh.exe
@@ -161,7 +163,9 @@ jobs:
       run: |
         New-Item -Path "./" -Name "gh-gei" -ItemType "directory"
         New-Item -Path "./" -Name "gh-ado2gh" -ItemType "directory"
+        New-Item -Path "./" -Name "gh-bbs2gh" -ItemType "directory"
         Copy-Item ./dist/osx-x64/gei-darwin-amd64 ./gh-gei/gh-gei
+        Copy-Item ./dist/osx-x64/ado2gh-darwin-amd64 ./gh-ado2gh/gh-ado2gh
         Copy-Item ./dist/osx-x64/bbs2gh-darwin-amd64 ./gh-bbs2gh/gh-bbs2gh
       shell: pwsh
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -143,6 +143,7 @@ jobs:
         New-Item -Path "./" -Name "gh-ado2gh" -ItemType "directory"
         Copy-Item ./dist/linux-x64/gei-linux-amd64 ./gh-gei/gh-gei
         Copy-Item ./dist/linux-x64/ado2gh-linux-amd64 ./gh-ado2gh/gh-ado2gh
+        Copy-Item ./dist/linux-x64/bbs2gh-linux-amd64 ./gh-bbs2gh/gh-bbs2gh
       shell: pwsh
 
     - name: Copy binary to root (windows)
@@ -152,6 +153,7 @@ jobs:
         New-Item -Path "./" -Name "gh-ado2gh" -ItemType "directory"
         Copy-Item ./dist/win-x64/gei-windows-amd64.exe ./gh-gei/gh-gei.exe
         Copy-Item ./dist/win-x64/ado2gh-windows-amd64.exe ./gh-ado2gh/gh-ado2gh.exe
+        Copy-Item ./dist/win-x64/bbs2gh-windows-amd64.exe ./gh-bbs2gh/gh-bbs2gh.exe
       shell: pwsh
 
     - name: Copy binary to root (macos)
@@ -160,7 +162,7 @@ jobs:
         New-Item -Path "./" -Name "gh-gei" -ItemType "directory"
         New-Item -Path "./" -Name "gh-ado2gh" -ItemType "directory"
         Copy-Item ./dist/osx-x64/gei-darwin-amd64 ./gh-gei/gh-gei
-        Copy-Item ./dist/osx-x64/ado2gh-darwin-amd64 ./gh-ado2gh/gh-ado2gh
+        Copy-Item ./dist/osx-x64/bbs2gh-darwin-amd64 ./gh-bbs2gh/gh-bbs2gh
       shell: pwsh
 
     - name: Install gh-gei extension
@@ -174,6 +176,13 @@ jobs:
       run: gh extension install .
       shell: pwsh
       working-directory: ./gh-ado2gh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Install gh-bbs2gh extension
+      run: gh extension install .
+      shell: pwsh
+      working-directory: ./gh-bbs2gh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -71,8 +71,10 @@ jobs:
       run: |
         New-Item -Path "./" -Name "gh-gei" -ItemType "directory"
         New-Item -Path "./" -Name "gh-ado2gh" -ItemType "directory"
+        New-Item -Path "./" -Name "gh-bbs2gh" -ItemType "directory"
         Copy-Item ./dist/linux-x64/gei-linux-amd64 ./gh-gei/gh-gei
         Copy-Item ./dist/linux-x64/ado2gh-linux-amd64 ./gh-ado2gh/gh-ado2gh
+        Copy-Item ./dist/linux-x64/bbs2gh-linux-amd64 ./gh-bbs2gh/gh-bbs2gh
       shell: pwsh
 
     - name: Copy binary to root (windows)
@@ -80,8 +82,10 @@ jobs:
       run: |
         New-Item -Path "./" -Name "gh-gei" -ItemType "directory"
         New-Item -Path "./" -Name "gh-ado2gh" -ItemType "directory"
+        New-Item -Path "./" -Name "gh-bbs2gh" -ItemType "directory"
         Copy-Item ./dist/win-x64/gei-windows-amd64.exe ./gh-gei/gh-gei.exe
         Copy-Item ./dist/win-x64/ado2gh-windows-amd64.exe ./gh-ado2gh/gh-ado2gh.exe
+        Copy-Item ./dist/win-x64/bbs2gh-windows-amd64.exe ./gh-bbs2gh/gh-bbs2gh.exe
       shell: pwsh
 
     - name: Copy binary to root (macos)
@@ -89,8 +93,10 @@ jobs:
       run: |
         New-Item -Path "./" -Name "gh-gei" -ItemType "directory"
         New-Item -Path "./" -Name "gh-ado2gh" -ItemType "directory"
+        New-Item -Path "./" -Name "gh-bbs2gh" -ItemType "directory"
         Copy-Item ./dist/osx-x64/gei-darwin-amd64 ./gh-gei/gh-gei
         Copy-Item ./dist/osx-x64/ado2gh-darwin-amd64 ./gh-ado2gh/gh-ado2gh
+        Copy-Item ./dist/osx-x64/bbs2gh-darwin-amd64 ./gh-bbs2gh/gh-bbs2gh
       shell: pwsh
 
     - name: Install gh-gei extension
@@ -104,6 +110,13 @@ jobs:
       run: gh extension install .
       shell: pwsh
       working-directory: ./gh-ado2gh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Install gh-bbs2gh extension
+      run: gh extension install .
+      shell: pwsh
+      working-directory: ./gh-bbs2gh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Installs bbs2gh extension as a local extension before running the integration tests.

Closes #569 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->