### PR TITLE
Adding LATEST-VERSION.txt

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -292,9 +292,15 @@ jobs:
         Get-Content ./RELEASENOTES.md | Out-File -FilePath ./releasenotes/$TAG_NAME.md
         "" | Out-File ./RELEASENOTES.md
         
-    - name: Commit Archived Release Notes
+    - name: Update LATEST-VERSION.TXT
+      shell: pwsh
+      run: |
+        $TAG_NAME = "${{ github.ref }}".Substring(10)
+        $TAG_NAME | Out-File ./LATEST-VERSION.txt
+        
+    - name: Commit Release Notes and Version
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: Automated commit of archived release notes [skip ci]
-        file_pattern: RELEASENOTES.md releasenotes/*.md
+        commit_message: Automated commit of archived release notes and version file [skip ci]
+        file_pattern: RELEASENOTES.md releasenotes/*.md LATEST-VERSION.txt
         branch: main


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Adding a file LATEST-VERSION.txt that will get updated in our publish workflow. This should allow us to optimize our automated version checks, since we can read a file in a repo without being subject to API rate limiting.

This is an alternative to caching ( #555 )

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->