### PR TITLE
Add --lock-source-repo option.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 - Add `migrate-repo` command to `bbs2gh`.
+- Added `--lock-source-repo` option to `gh gei migrate-repo` and `gh gei generate-script` commands. This will make the source repo read-only as part of the migration.

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -458,7 +458,7 @@ namespace OctoshiftCLI
             return (int)data["id"];
         }
 
-        public virtual async Task<int> StartMetadataArchiveGeneration(string org, string repo, bool skipReleases)
+        public virtual async Task<int> StartMetadataArchiveGeneration(string org, string repo, bool skipReleases, bool lockSourceRepo)
         {
             var url = $"{_apiUrl}/orgs/{org}/migrations";
 
@@ -467,6 +467,7 @@ namespace OctoshiftCLI
                 repositories = new[] { repo },
                 exclude_git_data = true,
                 exclude_releases = skipReleases,
+                lock_repositories = lockSourceRepo,
                 exclude_owner_projects = true
             };
 

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -197,7 +197,7 @@ namespace OctoshiftCLI
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
 
-        public virtual async Task<string> StartMigration(string migrationSourceId, string sourceRepoUrl, string orgId, string repo, string sourceToken, string targetToken, string gitArchiveUrl = null, string metadataArchiveUrl = null, bool skipReleases = false)
+        public virtual async Task<string> StartMigration(string migrationSourceId, string sourceRepoUrl, string orgId, string repo, string sourceToken, string targetToken, string gitArchiveUrl = null, string metadataArchiveUrl = null, bool skipReleases = false, bool lockSource = false)
         {
             var url = $"{_apiUrl}/graphql";
 
@@ -212,7 +212,8 @@ namespace OctoshiftCLI
                     $metadataArchiveUrl: String,
                     $accessToken: String!,
                     $githubPat: String,
-                    $skipReleases: Boolean)";
+                    $skipReleases: Boolean
+                    $lockSource: Boolean)";
             var gql = @"
                 startRepositoryMigration(
                     input: { 
@@ -225,7 +226,8 @@ namespace OctoshiftCLI
                         metadataArchiveUrl: $metadataArchiveUrl,
                         accessToken: $accessToken,
                         githubPat: $githubPat,
-                        skipReleases: $skipReleases
+                        skipReleases: $skipReleases,
+                        lockSource: $lockSource
                     }
                 ) {
                     repositoryMigration {
@@ -255,7 +257,8 @@ namespace OctoshiftCLI
                     metadataArchiveUrl,
                     accessToken = sourceToken,
                     githubPat = targetToken,
-                    skipReleases
+                    skipReleases,
+                    lockSource
                 },
                 operationName = "startRepositoryMigration"
             };
@@ -458,7 +461,7 @@ namespace OctoshiftCLI
             return (int)data["id"];
         }
 
-        public virtual async Task<int> StartMetadataArchiveGeneration(string org, string repo, bool skipReleases, bool lockSourceRepo)
+        public virtual async Task<int> StartMetadataArchiveGeneration(string org, string repo, bool skipReleases, bool lockSource)
         {
             var url = $"{_apiUrl}/orgs/{org}/migrations";
 
@@ -467,7 +470,7 @@ namespace OctoshiftCLI
                 repositories = new[] { repo },
                 exclude_git_data = true,
                 exclude_releases = skipReleases,
-                lock_repositories = lockSourceRepo,
+                lock_repositories = lockSource,
                 exclude_owner_projects = true
             };
 

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -238,7 +238,7 @@ namespace OctoshiftCLI
                     $metadataArchiveUrl: String,
                     $accessToken: String!,
                     $githubPat: String,
-                    $skipReleases: Boolean
+                    $skipReleases: Boolean,
                     $lockSource: Boolean)";
             var gql = @"
                 startRepositoryMigration(

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -568,7 +568,7 @@ namespace OctoshiftCLI.Tests
                     $metadataArchiveUrl: String,
                     $accessToken: String!,
                     $githubPat: String,
-                    $skipReleases: Boolean
+                    $skipReleases: Boolean,
                     $lockSource: Boolean)";
             const string gql = @"
                 startRepositoryMigration(

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -532,7 +532,8 @@ namespace OctoshiftCLI.Tests
                     $metadataArchiveUrl: String,
                     $accessToken: String!,
                     $githubPat: String,
-                    $skipReleases: Boolean)";
+                    $skipReleases: Boolean
+                    $lockSource: Boolean)";
             const string gql = @"
                 startRepositoryMigration(
                     input: { 
@@ -545,7 +546,8 @@ namespace OctoshiftCLI.Tests
                         metadataArchiveUrl: $metadataArchiveUrl,
                         accessToken: $accessToken,
                         githubPat: $githubPat,
-                        skipReleases: $skipReleases
+                        skipReleases: $skipReleases,
+                        lockSource: $lockSource
                     }
                 ) {
                     repositoryMigration {
@@ -574,7 +576,8 @@ namespace OctoshiftCLI.Tests
                     metadataArchiveUrl,
                     accessToken = sourceToken,
                     githubPat = targetToken,
-                    skipReleases = false
+                    skipReleases = false,
+                    lockSource = false
                 },
                 operationName = "startRepositoryMigration"
             };

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -715,7 +715,8 @@ namespace OctoshiftCLI.Tests
                     metadataArchiveUrl = unusedMetadataArchiveUrl,
                     accessToken = unusedSourceToken,
                     githubPat = targetToken,
-                    skipReleases = false
+                    skipReleases = false,
+                    lockSource = false
                 },
                 operationName = "startRepositoryMigration"
             };

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -1811,7 +1811,7 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task StartMetadataArchiveGeneration_Excludes_Releases_When_Lock_Source_Repo_Is_True()
+        public async Task StartMetadataArchiveGeneration_Locks_Repos_When_Lock_Source_Repo_Is_True()
         {
             // Arrange
             const string url = $"https://api.github.com/orgs/{GITHUB_ORG}/migrations";

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -1807,6 +1807,7 @@ namespace OctoshiftCLI.Tests
             _githubClientMock.Verify(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson())));
         }
 
+        [Fact]
         public async Task StartMetadataArchiveGeneration_Excludes_Releases_When_Lock_Source_Repo_Is_True()
         {
             // Arrange

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -673,7 +673,8 @@ namespace OctoshiftCLI.Tests
                     $metadataArchiveUrl: String,
                     $accessToken: String!,
                     $githubPat: String,
-                    $skipReleases: Boolean)";
+                    $skipReleases: Boolean,
+                    $lockSource: Boolean)";
             const string gql = @"
                 startRepositoryMigration(
                     input: { 
@@ -686,7 +687,8 @@ namespace OctoshiftCLI.Tests
                         metadataArchiveUrl: $metadataArchiveUrl,
                         accessToken: $accessToken,
                         githubPat: $githubPat,
-                        skipReleases: $skipReleases
+                        skipReleases: $skipReleases,
+                        lockSource: $lockSource
                     }
                 ) {
                     repositoryMigration {

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
@@ -70,6 +70,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                     GITHUB_TOKEN,
                     null,
                     null,
+                    false,
                     false).Result)
                 .Returns(MIGRATION_ID);
             _mockGithubApi.Setup(x => x.GetMigration(MIGRATION_ID).Result).Returns((State: RepositoryMigrationStatus.Succeeded, GITHUB_REPO, null));
@@ -103,7 +104,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             // Assert
             _mockGithubApi.Verify(m => m.GetOrganizationId(GITHUB_ORG));
             _mockGithubApi.Verify(m => m.CreateAdoMigrationSource(GITHUB_ORG_ID, null));
-            _mockGithubApi.Verify(m => m.StartMigration(MIGRATION_SOURCE_ID, ADO_REPO_URL, GITHUB_ORG_ID, GITHUB_REPO, ADO_TOKEN, GITHUB_TOKEN, null, null, false));
+            _mockGithubApi.Verify(m => m.StartMigration(MIGRATION_SOURCE_ID, ADO_REPO_URL, GITHUB_ORG_ID, GITHUB_REPO, ADO_TOKEN, GITHUB_TOKEN, null, null, false, false));
 
             _mockOctoLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
             actualLogOutput.Should().Equal(expectedLogOutput);
@@ -128,6 +129,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                     GITHUB_TOKEN,
                     null,
                     null,
+                    false,
                     false).Result)
                 .Throws(new OctoshiftCliException($"A repository called {GITHUB_ORG}/{GITHUB_REPO} already exists"));
 
@@ -169,6 +171,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                         GITHUB_TOKEN,
                         null,
                         null,
+                        false,
                         false).Result)
                 .Returns(MIGRATION_ID);
             _mockGithubApi.Setup(x => x.GetMigration(MIGRATION_ID).Result).Returns((State: RepositoryMigrationStatus.Succeeded, GITHUB_REPO, null));

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -54,7 +54,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         {
             _command.Should().NotBeNull();
             _command.Name.Should().Be("generate-script");
-            _command.Options.Count.Should().Be(16);
+            _command.Options.Count.Should().Be(17);
 
             TestHelpers.VerifyCommandOption(_command.Options, "github-source-org", false);
             TestHelpers.VerifyCommandOption(_command.Options, "ado-server-url", false, true);
@@ -65,6 +65,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(_command.Options, "azure-storage-connection-string", false);
             TestHelpers.VerifyCommandOption(_command.Options, "no-ssl-verify", false);
             TestHelpers.VerifyCommandOption(_command.Options, "skip-releases", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "lock-source-repo", false);
             TestHelpers.VerifyCommandOption(_command.Options, "download-migration-logs", false);
             TestHelpers.VerifyCommandOption(_command.Options, "output", false);
             TestHelpers.VerifyCommandOption(_command.Options, "ssh", false, true);
@@ -1500,6 +1501,70 @@ if ($Failed -ne 0) {
                 GithubTargetOrg = TARGET_ORG,
                 Output = new FileInfo("unit-test-output"),
                 SkipReleases = true
+            };
+            await _command.Invoke(args);
+
+            _script = TrimNonExecutableLines(_script, 22, 7);
+
+            // Assert
+            _script.Should().Be(expected.ToString());
+        }
+
+        [Fact]
+        public async Task It_Adds_Lock_Source_Repo_To_Migrate_Repo_Command_When_Provided_In_Sequential_Script()
+        {
+            // Arrange
+            _mockGithubApi
+                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .ReturnsAsync(new[] { REPO });
+
+            _mockSourceGithubApiFactory
+                .Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(_mockGithubApi.Object);
+
+            var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{REPO}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{REPO}\" --wait --lock-source-repo }}";
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                GithubTargetOrg = TARGET_ORG,
+                Output = new FileInfo("unit-test-output"),
+                Sequential = true,
+                LockSourceRepo = true
+            };
+            await _command.Invoke(args);
+
+            _script = TrimNonExecutableLines(_script);
+
+            // Assert
+            _script.Should().Be(expected);
+        }
+
+        [Fact]
+        public async Task Parallel_It_Adds_Lock_Source_Repo_To_Migrate_Repo_Command_When_Provided_In_Parallel_Script()
+        {
+            // Arrange
+            _mockGithubApi
+                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .ReturnsAsync(new[] { REPO });
+
+            _mockSourceGithubApiFactory
+                .Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(_mockGithubApi.Object);
+
+            var expected = new StringBuilder();
+            expected.AppendLine($"$MigrationID = ExecAndGetMigrationID {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{REPO}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{REPO}\" --lock-source-repo }}");
+            expected.AppendLine($"$RepoMigrations[\"{REPO}\"] = $MigrationID");
+            expected.Append($"gh gei wait-for-migration --migration-id $RepoMigrations[\"{REPO}\"]");
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                GithubTargetOrg = TARGET_ORG,
+                Output = new FileInfo("unit-test-output"),
+                LockSourceRepo = true
             };
             await _command.Invoke(args);
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -48,7 +48,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         {
             _command.Should().NotBeNull();
             _command.Name.Should().Be("migrate-repo");
-            _command.Options.Count.Should().Be(20);
+            _command.Options.Count.Should().Be(21);
 
             TestHelpers.VerifyCommandOption(_command.Options, "github-source-org", false);
             TestHelpers.VerifyCommandOption(_command.Options, "ado-server-url", false, true);
@@ -353,7 +353,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             _mockGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null));
 
             _mockGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
+            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false, false).Result).Returns(metadataArchiveId);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
@@ -601,7 +601,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             _mockGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null));
 
             _mockGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
+            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false, false).Result).Returns(metadataArchiveId);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
@@ -673,7 +673,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             _mockGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null));
 
             _mockGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
+            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false, false).Result).Returns(metadataArchiveId);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
@@ -717,7 +717,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var metadataArchiveId = 2;
 
             _mockGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
+            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false, false).Result).Returns(metadataArchiveId);
             _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Failed);
 
             _mockSourceGithubApiFactory.Setup(m => m.Create(GHES_API_URL, It.IsAny<string>())).Returns(_mockGithubApi.Object);
@@ -975,7 +975,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             await _command.Invoke(args);
 
             // Assert
-            _mockGithubApi.Verify(m => m.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, true));
+            _mockGithubApi.Verify(m => m.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, true, false));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -85,7 +85,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             _mockGithubApi.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
-            _mockGithubApi.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false).Result).Returns(migrationId);
+            _mockGithubApi.Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false, false).Result).Returns(migrationId);
 
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken()).Returns(sourceGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
@@ -121,7 +121,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             // Assert
             _mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG));
             _mockGithubApi.Verify(m => m.CreateGhecMigrationSource(githubOrgId));
-            _mockGithubApi.Verify(m => m.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false));
+            _mockGithubApi.Verify(m => m.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false, false));
 
             _mockOctoLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
             actualLogOutput.Should().Equal(expectedLogOutput);
@@ -143,7 +143,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             _mockGithubApi.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
             _mockGithubApi
-                .Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false).Result)
+                .Setup(x => x.StartMigration(migrationSourceId, githubRepoUrl, githubOrgId, TARGET_REPO, sourceGithubPat, targetGithubPat, null, null, false, false).Result)
                 .Throws(new OctoshiftCliException($"A repository called {TARGET_ORG}/{TARGET_REPO} already exists"));
 
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken()).Returns(sourceGithubPat);
@@ -196,6 +196,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     targetGithubPat,
                     null,
                     null,
+                    false,
                     false).Result)
                 .Returns(migrationId);
             _mockGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null));
@@ -243,6 +244,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     targetGithubPat,
                     null,
                     null,
+                    false,
                     false).Result)
                 .Returns(migrationId);
             _mockGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null));
@@ -292,6 +294,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     targetGithubPat,
                     null,
                     null,
+                    false,
                     false).Result)
                 .Returns(migrationId);
             _mockGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null));
@@ -348,6 +351,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     targetGithubPat,
                     authenticatedGitArchiveUrl.ToString(),
                     authenticatedMetadataArchiveUrl.ToString(),
+                    false,
                     false).Result)
                 .Returns(migrationId);
             _mockGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null));
@@ -432,6 +436,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     targetGithubPat,
                     gitArchiveUrl,
                     metadataArchiveUrl,
+                    false,
                     false).Result)
                 .Returns(migrationId);
             _mockGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null));
@@ -527,6 +532,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     targetGithubPat,
                     null,
                     null,
+                    false,
                     false).Result)
                 .Returns(migrationId);
             _mockGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, SOURCE_REPO, null));
@@ -596,6 +602,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     targetGithubPat,
                     authenticatedGitArchiveUrl.ToString(),
                     authenticatedMetadataArchiveUrl.ToString(),
+                    false,
                     false).Result)
                 .Returns(migrationId);
             _mockGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null));
@@ -668,6 +675,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     targetGithubPat,
                     authenticatedGitArchiveUrl.ToString(),
                     authenticatedMetadataArchiveUrl.ToString(),
+                    false,
                     false).Result)
                 .Returns(migrationId);
             _mockGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null));
@@ -776,6 +784,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()));
         }
 
@@ -818,6 +827,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 GITHUB_TARGET_PAT,
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()));
         }
 
@@ -868,6 +878,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()));
         }
 
@@ -909,6 +920,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 GITHUB_TARGET_PAT,
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()));
         }
 
@@ -944,6 +956,44 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                true,
+                It.IsAny<bool>()));
+        }
+
+        [Fact]
+        public async Task It_Locks_Source_Repo_When_Option_Is_True()
+        {
+            // Arrange
+            _mockTargetGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
+
+            var actualLogOutput = new List<string>();
+            _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
+
+            // Act
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                SkipReleases = false,
+                LockSourceRepo = true
+            };
+            await _command.Invoke(args);
+
+            // Assert
+            actualLogOutput.Should().Contain("LOCK SOURCE REPO: true");
+
+            _mockGithubApi.Verify(m => m.StartMigration(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
                 true));
         }
 
@@ -995,6 +1045,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
+                    false,
                     false).Result)
                 .Returns("migrationId");
 
@@ -1029,6 +1080,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                false,
                 false));
         }
 
@@ -1049,6 +1101,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
+                    false,
                     false).Result)
                 .Returns("migrationId");
 
@@ -1083,6 +1136,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                false,
                 false));
         }
     }

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -253,7 +253,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             }
         }
 
-        private async Task<string> InvokeGithub(string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool sequential, string githubSourcePat, bool skipReleases, bool lockSourceRepo,bool downloadMigrationLogs)
+        private async Task<string> InvokeGithub(string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool sequential, string githubSourcePat, bool skipReleases, bool lockSourceRepo, bool downloadMigrationLogs)
         {
             var client = (ghesApiUrl.HasValue() && noSslVerify) ? _sourceGithubApiFactory.CreateClientNoSsl(ghesApiUrl, githubSourcePat) : _sourceGithubApiFactory.Create(ghesApiUrl, githubSourcePat);
 

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -218,7 +218,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                     targetToken,
                     args.GitArchiveUrl,
                     args.MetadataArchiveUrl,
-                    args.SkipReleases);
+                    args.SkipReleases,
+                    args.LockSourceRepo);
             }
             catch (OctoshiftCliException ex)
             {

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -220,7 +220,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                     args.GitArchiveUrl,
                     args.MetadataArchiveUrl,
                     args.SkipReleases,
-                    args.GhesApiUrl.HasValue() ? false : args.LockSourceRepo);
+                    args.GhesApiUrl.IsNullOrWhiteSpace() && args.LockSourceRepo);
             }
             catch (OctoshiftCliException ex)
             {

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -106,6 +106,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 IsRequired = false,
                 Description = "Skip releases when migrating."
             };
+            var lockSourceRepo = new Option("--lock-source-repo")
+            {
+                IsRequired = false,
+                Description = "Lock source repo when migrating."
+            };
             var ssh = new Option("--ssh")
             {
                 IsRequired = false,
@@ -151,6 +156,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(metadataArchiveUrl);
 
             AddOption(skipReleases);
+            AddOption(lockSourceRepo);
 
             AddOption(ssh);
             AddOption(wait);
@@ -182,6 +188,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                   args.AzureStorageConnectionString,
                   args.GithubSourcePat,
                   args.SkipReleases,
+                  args.LockSourceRepo,
                   args.NoSslVerify
                 );
 
@@ -283,6 +290,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
           string azureStorageConnectionString,
           string githubSourcePat,
           bool skipReleases,
+          bool lockSourceRepo,
           bool noSslVerify = false)
         {
             if (string.IsNullOrWhiteSpace(azureStorageConnectionString))
@@ -301,7 +309,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
             var gitDataArchiveId = await ghesApi.StartGitArchiveGeneration(githubSourceOrg, sourceRepo);
             _log.LogInformation($"Archive generation of git data started with id: {gitDataArchiveId}");
-            var metadataArchiveId = await ghesApi.StartMetadataArchiveGeneration(githubSourceOrg, sourceRepo, skipReleases);
+            var metadataArchiveId = await ghesApi.StartMetadataArchiveGeneration(githubSourceOrg, sourceRepo, skipReleases, lockSourceRepo);
             _log.LogInformation($"Archive generation of metadata started with id: {metadataArchiveId}");
 
             var timeNow = $"{DateTime.Now:yyyy-MM-dd_HH-mm-ss}";
@@ -453,6 +461,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 _log.LogInformation("SKIP RELEASES: true");
             }
 
+            if (args.LockSourceRepo)
+            {
+                _log.LogInformation("LOCK SOURCE REPO: true");
+            }
+
             if (string.IsNullOrWhiteSpace(args.GitArchiveUrl) != string.IsNullOrWhiteSpace(args.MetadataArchiveUrl))
             {
                 throw new OctoshiftCliException("When using archive urls, you must provide both --git-archive-url --metadata-archive-url");
@@ -482,6 +495,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         public string GitArchiveUrl { get; set; }
         public string MetadataArchiveUrl { get; set; }
         public bool SkipReleases { get; set; }
+        public bool LockSourceRepo { get; set; }
         public bool Ssh { get; set; }
         public bool Wait { get; set; }
         public bool Verbose { get; set; }

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -443,7 +443,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 _log.LogInformation($"METADATA ARCHIVE URL: {args.MetadataArchiveUrl}");
             }
-            
+
             if (args.LockSourceRepo)
             {
                 _log.LogInformation("LOCK SOURCE REPO: true");

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -220,7 +220,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                     args.GitArchiveUrl,
                     args.MetadataArchiveUrl,
                     args.SkipReleases,
-                    args.LockSourceRepo);
+                    args.GhesApiUrl.HasValue() ? false : args.LockSourceRepo);
             }
             catch (OctoshiftCliException ex)
             {


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->
This change addresses #385 by adding the cli option `--lock-source-repo`. 

For GHES source, this uses the `lock_repositories` option [as documented here](https://docs.github.com/en/rest/migrations/orgs#start-an-organization-migration).

For GHEC source, this uses the new lockSource option in the GraphAPI [mentioned here](https://github.com/github/migration-friction/issues/618#issuecomment-1221009872).

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created) #597 

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->