### PR TITLE
Hide ADO specific args from `gh gei`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Hide ADO specific args from `gh gei` in favor of `gh ado2gh`.

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -58,8 +58,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             TestHelpers.VerifyCommandOption(_command.Options, "github-source-org", false);
             TestHelpers.VerifyCommandOption(_command.Options, "ado-server-url", false, true);
-            TestHelpers.VerifyCommandOption(_command.Options, "ado-source-org", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "ado-team-project", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "ado-source-org", false, true);
+            TestHelpers.VerifyCommandOption(_command.Options, "ado-team-project", false, true);
             TestHelpers.VerifyCommandOption(_command.Options, "github-target-org", true);
             TestHelpers.VerifyCommandOption(_command.Options, "ghes-api-url", false);
             TestHelpers.VerifyCommandOption(_command.Options, "azure-storage-connection-string", false);
@@ -71,7 +71,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(_command.Options, "ssh", false, true);
             TestHelpers.VerifyCommandOption(_command.Options, "sequential", false);
             TestHelpers.VerifyCommandOption(_command.Options, "github-source-pat", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "ado-pat", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "ado-pat", false, true);
             TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
         }
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -52,8 +52,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             TestHelpers.VerifyCommandOption(_command.Options, "github-source-org", false);
             TestHelpers.VerifyCommandOption(_command.Options, "ado-server-url", false, true);
-            TestHelpers.VerifyCommandOption(_command.Options, "ado-source-org", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "ado-team-project", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "ado-source-org", false, true);
+            TestHelpers.VerifyCommandOption(_command.Options, "ado-team-project", false, true);
             TestHelpers.VerifyCommandOption(_command.Options, "source-repo", true);
             TestHelpers.VerifyCommandOption(_command.Options, "github-target-org", true);
             TestHelpers.VerifyCommandOption(_command.Options, "target-repo", false);
@@ -68,7 +68,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(_command.Options, "wait", false);
             TestHelpers.VerifyCommandOption(_command.Options, "github-source-pat", false);
             TestHelpers.VerifyCommandOption(_command.Options, "github-target-pat", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "ado-pat", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "ado-pat", false, true);
             TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
         }
 

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -52,11 +52,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var adoSourceOrgOption = new Option<string>("--ado-source-org")
             {
                 IsRequired = false,
+                IsHidden = true,
                 Description = "Uses ADO_PAT env variable or --ado-pat option."
             };
             var adoTeamProject = new Option<string>("--ado-team-project")
             {
-                IsRequired = false
+                IsRequired = false,
+                IsHidden = true
             };
             var githubTargetOrgOption = new Option<string>("--github-target-org")
             {
@@ -116,7 +118,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             };
             var adoPat = new Option<string>("--ado-pat")
             {
-                IsRequired = false
+                IsRequired = false,
+                IsHidden = true
             };
             var verbose = new Option("--verbose")
             {
@@ -157,6 +160,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             _log.Verbose = args.Verbose;
 
             _log.LogInformation("Generating Script...");
+
+            var hasAdoSpecificArg = new[] { args.AdoPat, args.AdoServerUrl, args.AdoSourceOrg, args.AdoTeamProject }.Any(arg => arg.HasValue());
+            if (hasAdoSpecificArg)
+            {
+                _log.LogWarning("ADO migration feature will be removed from `gh gei` in near future, please consider switching to `gh ado2gh` for ADO migrations instead.");
+            }
+            
             if (args.GithubSourceOrg.HasValue())
             {
                 _log.LogInformation($"GITHUB SOURCE ORG: {args.GithubSourceOrg}");

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -166,7 +166,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 _log.LogWarning("ADO migration feature will be removed from `gh gei` in near future, please consider switching to `gh ado2gh` for ADO migrations instead.");
             }
-            
+
             if (args.GithubSourceOrg.HasValue())
             {
                 _log.LogInformation($"GITHUB SOURCE ORG: {args.GithubSourceOrg}");

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using OctoshiftCLI.Contracts;
@@ -45,11 +46,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var adoSourceOrg = new Option<string>("--ado-source-org")
             {
                 IsRequired = false,
+                IsHidden = true,
                 Description = "Uses ADO_PAT env variable or --ado-pat option."
             };
             var adoTeamProject = new Option<string>("--ado-team-project")
             {
-                IsRequired = false
+                IsRequired = false,
+                IsHidden = true
             };
             var sourceRepo = new Option<string>("--source-repo")
             {
@@ -132,7 +135,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             };
             var adoPat = new Option<string>("--ado-pat")
             {
-                IsRequired = false
+                IsRequired = false,
+                IsHidden = true
             };
             var verbose = new Option("--verbose")
             {
@@ -369,6 +373,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         private void LogOptions(MigrateRepoCommandArgs args)
         {
             _log.LogInformation("Migrating Repo...");
+
+            var hasAdoSpecificArg = new[] { args.AdoPat, args.AdoServerUrl, args.AdoSourceOrg, args.AdoTeamProject }.Any(arg => arg.HasValue());
+            if (hasAdoSpecificArg)
+            {
+                _log.LogWarning("ADO migration feature will be removed from `gh gei` in near future, please consider switching to `gh ado2gh` for ADO migrations instead.");
+            }
+
             if (args.GithubSourceOrg.HasValue())
             {
                 _log.LogInformation($"GITHUB SOURCE ORG: {args.GithubSourceOrg}");


### PR DESCRIPTION
Related to #516 

The first step to remove ADO specific functionality from `gh gei` in favor of `gh ado2gh` is to set all the ADO related args to hidden and spit out a warning message to customers asking them to move to `gh ado2gh` for ADO migrations.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
