### PR TITLE
Retry non-200 GET requests from AdoClient, BbsClient and GithubClient

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Retry failed GET requests made to GitHub APIs.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-- Retry failed GET requests made to GitHub APIs.
+- Retry all failed GET requests made to Github, Azure Devops, and Bitbucket Server.

--- a/src/Octoshift/AdoClient.cs
+++ b/src/Octoshift/AdoClient.cs
@@ -40,8 +40,7 @@ namespace OctoshiftCLI
 
         public virtual async Task<string> GetAsync(string url)
         {
-            return await _retryPolicy.HttpRetry(async () => await SendAsync(HttpMethod.Get, url),
-                                            ex => ex.StatusCode == HttpStatusCode.ServiceUnavailable);
+            return await _retryPolicy.HttpRetry(async () => await SendAsync(HttpMethod.Get, url), _ => true);
         }
 
         public virtual async Task<string> DeleteAsync(string url) => await SendAsync(HttpMethod.Delete, url);

--- a/src/Octoshift/AdoClient.cs
+++ b/src/Octoshift/AdoClient.cs
@@ -40,7 +40,8 @@ namespace OctoshiftCLI
 
         public virtual async Task<string> GetAsync(string url)
         {
-            return await _retryPolicy.HttpRetry(async () => await SendAsync(HttpMethod.Get, url), _ => true);
+            return await _retryPolicy.HttpRetry(async () => await SendAsync(HttpMethod.Get, url),
+                                            ex => ex.StatusCode == HttpStatusCode.ServiceUnavailable);
         }
 
         public virtual async Task<string> DeleteAsync(string url) => await SendAsync(HttpMethod.Delete, url);

--- a/src/Octoshift/BbsClient.cs
+++ b/src/Octoshift/BbsClient.cs
@@ -35,8 +35,7 @@ public class BbsClient
 
     public virtual async Task<string> GetAsync(string url)
     {
-        return await _retryPolicy.HttpRetry(async () => await SendAsync(HttpMethod.Get, url),
-                                        ex => ex.StatusCode == HttpStatusCode.ServiceUnavailable);
+        return await _retryPolicy.HttpRetry(async () => await SendAsync(HttpMethod.Get, url), _ => true);
     }
 
     public virtual async Task<string> PostAsync(string url, object body) => await SendAsync(HttpMethod.Post, url, body);
@@ -62,6 +61,8 @@ public class BbsClient
         };
         var content = await response.Content.ReadAsStringAsync();
         _log.LogVerbose($"RESPONSE ({response.StatusCode}): {content}");
+
+        response.EnsureSuccessStatusCode();
 
         return content;
 

--- a/src/Octoshift/BbsClient.cs
+++ b/src/Octoshift/BbsClient.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -42,12 +42,12 @@ namespace OctoshiftCLI
 
         public virtual async Task<string> GetAsync(string url, Dictionary<string, string> customHeaders = null)
         {
-            var (Content, ResponseHeaders) = await _retryPolicy.HttpRetry(
+            var (content, _) = await _retryPolicy.HttpRetry(
                 async () => await SendAsync(HttpMethod.Get, url, customHeaders: customHeaders),
-                ex => ex.StatusCode == HttpStatusCode.ServiceUnavailable
+                _ => true
             );
 
-            return Content;
+            return content;
         }
 
         public virtual async IAsyncEnumerable<JToken> GetAllAsync(string url, Dictionary<string, string> customHeaders = null)

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -131,7 +131,6 @@ namespace OctoshiftCLI
         {
             url = url?.Replace(" ", "%20");
 
-            await ApplyRetryDelayAsync();
             _log.LogVerbose($"HTTP {httpMethod}: {url}");
 
             using var request = new HttpRequestMessage(httpMethod, url).AddHeaders(customHeaders);
@@ -183,16 +182,6 @@ namespace OctoshiftCLI
                 .FirstOrDefault(x => x.Rel == "next").Url;
 
             return nextUrl;
-        }
-
-        private async Task ApplyRetryDelayAsync()
-        {
-            if (_retryDelay > 0.0)
-            {
-                _log.LogWarning($"THROTTLING IN EFFECT. Waiting {(int)_retryDelay} ms");
-                await Task.Delay((int)_retryDelay);
-                _retryDelay = 0.0;
-            }
         }
 
         private string ExtractLinkHeader(IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers) =>

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -16,7 +16,6 @@ namespace OctoshiftCLI
     {
         private readonly HttpClient _httpClient;
         private readonly OctoLogger _log;
-        private double _retryDelay;
         private readonly RetryPolicy _retryPolicy;
 
         public GithubClient(OctoLogger log, HttpClient httpClient, IVersionProvider versionProvider, RetryPolicy retryPolicy, string personalAccessToken)

--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -36,7 +36,7 @@ namespace OctoshiftCLI.IntegrationTests
 
             var githubToken = Environment.GetEnvironmentVariable("GHEC_PAT");
             _githubHttpClient = new HttpClient();
-            var githubClient = new GithubClient(logger, _githubHttpClient, new VersionChecker(_versionClient, logger), githubToken);
+            var githubClient = new GithubClient(logger, _githubHttpClient, new VersionChecker(_versionClient, logger), new RetryPolicy(logger), githubToken);
             var githubApi = new GithubApi(githubClient, "https://api.github.com", new RetryPolicy(logger));
 
             _tokens = new Dictionary<string, string>

--- a/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
@@ -47,11 +47,11 @@ public sealed class GhesToGithub : IDisposable
         _versionClient = new HttpClient();
 
         _sourceGithubHttpClient = new HttpClient();
-        _sourceGithubClient = new GithubClient(logger, _sourceGithubHttpClient, new VersionChecker(_versionClient, logger), sourceGithubToken);
+        _sourceGithubClient = new GithubClient(logger, _sourceGithubHttpClient, new VersionChecker(_versionClient, logger), new RetryPolicy(logger), sourceGithubToken);
         _sourceGithubApi = new GithubApi(_sourceGithubClient, GHES_API_URL, new RetryPolicy(logger));
 
         _targetGithubHttpClient = new HttpClient();
-        _targetGithubClient = new GithubClient(logger, _targetGithubHttpClient, new VersionChecker(_versionClient, logger), targetGithubToken);
+        _targetGithubClient = new GithubClient(logger, _targetGithubHttpClient, new VersionChecker(_versionClient, logger), new RetryPolicy(logger), targetGithubToken);
         _targetGithubApi = new GithubApi(_targetGithubClient, "https://api.github.com", new RetryPolicy(logger));
 
         _blobServiceClient = new BlobServiceClient(azureStorageConnectionString);

--- a/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
@@ -33,7 +33,7 @@ namespace OctoshiftCLI.IntegrationTests
 
             _githubHttpClient = new HttpClient();
             _versionClient = new HttpClient();
-            _githubClient = new GithubClient(logger, _githubHttpClient, new VersionChecker(_versionClient, logger), githubToken);
+            _githubClient = new GithubClient(logger, _githubHttpClient, new VersionChecker(_versionClient, logger), new RetryPolicy(logger), githubToken);
             _githubApi = new GithubApi(_githubClient, "https://api.github.com", new RetryPolicy(logger));
 
             _helper = new TestHelper(_output, _githubApi, _githubClient);

--- a/src/OctoshiftCLI.Tests/AdoClientTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoClientTests.cs
@@ -76,43 +76,13 @@ namespace OctoshiftCLI.Tests
                 ItExpr.IsAny<CancellationToken>());
         }
 
-        [Fact]
-        public async Task GetAsync_Retries_On_ServiceUnavailable()
+        [Theory]
+        [InlineData(HttpStatusCode.Unauthorized)]
+        [InlineData(HttpStatusCode.ServiceUnavailable)]
+        public async Task GetAsync_Retries_On_Non_Success(HttpStatusCode httpStatusCode)
         {
             // Arrange
-            using var firstHttpResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
-            {
-                Content = new StringContent("FIRST_RESPONSE")
-            };
-            using var secondHttpResponse = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("SECOND_RESPONSE")
-            };
-            var handlerMock = new Mock<HttpMessageHandler>();
-            handlerMock
-                .Protected()
-                .SetupSequence<Task<HttpResponseMessage>>(
-                    "SendAsync",
-                    ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
-                    ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(firstHttpResponse)
-                .ReturnsAsync(secondHttpResponse);
-
-            using var httpClient = new HttpClient(handlerMock.Object);
-            var adoClient = new AdoClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
-
-            // Act
-            var returnedContent = await adoClient.GetAsync(URL);
-
-            // Assert
-            returnedContent.Should().Be("SECOND_RESPONSE");
-        }
-
-        [Fact]
-        public async Task GetAsync_Retries_On_Unauthorized()
-        {
-            // Arrange
-            using var firstHttpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            using var firstHttpResponse = new HttpResponseMessage(httpStatusCode)
             {
                 Content = new StringContent("FIRST_RESPONSE")
             };

--- a/src/OctoshiftCLI.Tests/AdoClientTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoClientTests.cs
@@ -77,71 +77,6 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task GetAsync_Retries_On_ServiceUnavailable()
-        {
-            // Arrange
-            using var firstHttpResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
-            {
-                Content = new StringContent("FIRST_RESPONSE")
-            };
-            using var secondHttpResponse = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("SECOND_RESPONSE")
-            };
-            var handlerMock = new Mock<HttpMessageHandler>();
-            handlerMock
-                .Protected()
-                .SetupSequence<Task<HttpResponseMessage>>(
-                    "SendAsync",
-                    ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
-                    ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(firstHttpResponse)
-                .ReturnsAsync(secondHttpResponse);
-
-            using var httpClient = new HttpClient(handlerMock.Object);
-            var adoClient = new AdoClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
-
-            // Act
-            var returnedContent = await adoClient.GetAsync(URL);
-
-            // Assert
-            returnedContent.Should().Be("SECOND_RESPONSE");
-        }
-
-        [Fact]
-        public async Task GetAsync_Retries_On_Unauthorized()
-        {
-            // Arrange
-            using var firstHttpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized)
-            {
-                Content = new StringContent("FIRST_RESPONSE")
-            };
-            using var secondHttpResponse = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("SECOND_RESPONSE")
-            };
-            var handlerMock = new Mock<HttpMessageHandler>();
-            handlerMock
-                .Protected()
-                .SetupSequence<Task<HttpResponseMessage>>(
-                    "SendAsync",
-                    ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
-                    ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(firstHttpResponse)
-                .ReturnsAsync(secondHttpResponse);
-
-            using var httpClient = new HttpClient(handlerMock.Object);
-            var adoClient = new AdoClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
-
-            // Act
-            var returnedContent = await adoClient.GetAsync(URL);
-
-            // Assert
-            returnedContent.Should().Be("SECOND_RESPONSE");
-        }
-
-
-        [Fact]
         public async Task GetAsync_Applies_Retry_Delay()
         {
             // Arrange
@@ -253,22 +188,17 @@ namespace OctoshiftCLI.Tests
         public async Task GetAsync_Throws_HttpRequestException_On_Non_Success_Response()
         {
             // Arrange
-            var httpResponse = () => new HttpResponseMessage(HttpStatusCode.InternalServerError);
-            var handlerMock = new Mock<HttpMessageHandler>();
-            handlerMock
-                .Protected()
-                .Setup<Task<HttpResponseMessage>>(
-                    "SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(httpResponse);
+            using var httpResponse = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            var handlerMock = MockHttpHandler(_ => true, httpResponse);
 
             // Act
             // Assert
             await FluentActions
-                .Invoking(async () =>
+                .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
                     var adoClient = new AdoClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
-                    return await adoClient.GetAsync(URL);
+                    return adoClient.GetAsync(URL);
                 })
                 .Should()
                 .ThrowExactlyAsync<HttpRequestException>();

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -44,7 +44,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, null);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, null);
 
             // Act
             var actualContent = await githubClient.GetAsync("http://example.com");
@@ -61,7 +62,8 @@ namespace OctoshiftCLI.Tests
             const string graphQLSchemaHeaderValue = "internal";
             var handlerMock = MockHttpHandlerForGet();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, null);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, null);
 
             // Act
             var internalSchemaHeader = new Dictionary<string, string>() { { graphQLSchemaHeaderName, graphQLSchemaHeaderValue } };
@@ -81,7 +83,8 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForGet();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -102,7 +105,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP GET: {url}";
@@ -120,7 +124,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
             _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
@@ -140,7 +145,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({HttpStatusCode.OK}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -170,7 +176,8 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+                    var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+                    var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
                     return githubClient.GetAsync("http://example.com");
                 })
                 .Should()
@@ -182,7 +189,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var actualContent = await githubClient.PostAsync("http://example.com", _rawRequestBody);
@@ -197,7 +205,8 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForPost();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -218,7 +227,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP POST: {url}";
@@ -236,7 +246,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
             _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
@@ -256,7 +267,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"HTTP BODY: {EXPECTED_JSON_REQUEST_BODY}";
 
@@ -273,7 +285,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -308,7 +321,8 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+                    var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
                     return githubClient.PostAsync("http://example.com", _rawRequestBody);
                 })
                 .Should()
@@ -320,7 +334,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var actualContent = await githubClient.PutAsync("http://example.com", _rawRequestBody);
@@ -335,7 +350,8 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForPut();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -356,7 +372,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP PUT: {url}";
@@ -374,7 +391,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
             _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
@@ -394,7 +412,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"HTTP BODY: {EXPECTED_JSON_REQUEST_BODY}";
 
@@ -411,7 +430,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -446,7 +466,8 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+                    var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
                     return githubClient.PutAsync("http://example.com", _rawRequestBody);
                 })
                 .Should()
@@ -458,7 +479,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var actualContent = await githubClient.PatchAsync("http://example.com", _rawRequestBody);
@@ -473,7 +495,8 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForPatch();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -494,7 +517,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP PATCH: {url}";
@@ -512,7 +536,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
             _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
@@ -532,7 +557,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"HTTP BODY: {EXPECTED_JSON_REQUEST_BODY}";
 
@@ -549,7 +575,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -584,7 +611,8 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+                    var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
                     return githubClient.PatchAsync("http://example.com", _rawRequestBody);
                 })
                 .Should()
@@ -596,7 +624,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var actualContent = await githubClient.DeleteAsync("http://example.com");
@@ -611,7 +640,8 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForDelete();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -632,7 +662,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP DELETE: {url}";
@@ -650,7 +681,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
             _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
@@ -682,7 +714,8 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+                    var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+                    var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
                     return githubClient.GetNonSuccessAsync("http://example.com", HttpStatusCode.Moved);
                 })
                 .Should()
@@ -702,7 +735,8 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(httpResponse);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             await githubClient.GetNonSuccessAsync("http://example.com", HttpStatusCode.Moved);
@@ -721,7 +755,8 @@ namespace OctoshiftCLI.Tests
             var handlerMock = MockHttpHandler(req => req.Method == HttpMethod.Get, httpResponse);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             await githubClient.GetNonSuccessAsync("http://example.com", HttpStatusCode.Moved);
@@ -735,7 +770,8 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({HttpStatusCode.OK}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -767,7 +803,8 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+                    var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
                     return githubClient.DeleteAsync("http://example.com");
                 })
                 .Should()
@@ -839,7 +876,8 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(thirdResponse);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var results = new List<JToken>();
@@ -898,7 +936,8 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(secondResponse);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             await foreach (var _ in githubClient.GetAllAsync(url)) { }
@@ -948,7 +987,8 @@ namespace OctoshiftCLI.Tests
                 handlerMock);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             await foreach (var _ in githubClient.GetAllAsync(url)) { }
@@ -1001,7 +1041,8 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(secondResponse);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             await foreach (var _ in githubClient.GetAllAsync(url)) { }
@@ -1054,7 +1095,8 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(failureResponse);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act, Assert
             await FluentActions
@@ -1188,7 +1230,8 @@ query($id: ID!, $first: Int, $after: String) {
                 handlerMock); // third request
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var result = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1268,7 +1311,8 @@ query($id: ID!, $first: Int, $after: String) {
                 response);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var result = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1344,7 +1388,8 @@ query($id: ID!, $first: Int, $after: String) {
                 response);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var result = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1420,7 +1465,8 @@ query($id: ID!, $first: Int, $after: String) {
                 response);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var result = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1443,7 +1489,8 @@ query($id: ID!, $first: Int, $after: String) {
             // Arrange
             const string url = "https://example.com/graphql";
             using var httpClient = new HttpClient();
-            var githubClient = new GithubClient(null, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(null, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act, Assert
             await githubClient
@@ -1511,7 +1558,8 @@ query($id: ID!, $first: Int, $after: String) {
                 response);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var result = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1592,7 +1640,8 @@ query($id: ID!, $first: Int, $after: String) {
                 response);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var result = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1620,7 +1669,8 @@ query($id: ID!, $first: Int, $after: String) {
             // Arrange
             const string url = "https://example.com/graphql";
             using var httpClient = new HttpClient();
-            var githubClient = new GithubClient(null, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(null, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act, Assert
             await githubClient
@@ -1697,7 +1747,8 @@ query($id: ID!, $first: Int, $after: String) {
                 handlerMock); // second request
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             _ = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1727,7 +1778,8 @@ query($id: ID!, $first: Int, $after: String) {
             mockVersionProvider.Setup(m => m.GetVersionComments()).Returns(versionComments);
 
             // Act
-            _ = new GithubClient(null, httpClient, mockVersionProvider.Object, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            _ = new GithubClient(null, httpClient, mockVersionProvider.Object, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Assert
             httpClient.DefaultRequestHeaders.UserAgent.Should().HaveCount(2);
@@ -1741,7 +1793,8 @@ query($id: ID!, $first: Int, $after: String) {
             using var httpClient = new HttpClient();
 
             // Act
-            _ = new GithubClient(null, httpClient, null, PERSONAL_ACCESS_TOKEN);
+            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            _ = new GithubClient(null, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Assert
             httpClient.DefaultRequestHeaders.UserAgent.Should().HaveCount(1);

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -237,9 +237,9 @@ namespace OctoshiftCLI.Tests
             await FluentActions
                 .Invoking(async () =>
                 {
-                     using var httpClient = new HttpClient(handlerMock.Object);
-                     var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
-                     return await githubClient.GetAsync("http://example.com");
+                    using var httpClient = new HttpClient(handlerMock.Object);
+                    var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
+                    return await githubClient.GetAsync("http://example.com");
                 })
                 .Should()
                 .ThrowExactlyAsync<HttpRequestException>();

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -224,7 +224,7 @@ namespace OctoshiftCLI.Tests
         public async Task GetAsync_Throws_HttpRequestException_On_Non_Success_Response()
         {
             // Arrange
-            using var httpResponse = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            var httpResponse = () => new HttpResponseMessage(HttpStatusCode.InternalServerError);
             var handlerMock = new Mock<HttpMessageHandler>();
             handlerMock
                 .Protected()
@@ -235,11 +235,11 @@ namespace OctoshiftCLI.Tests
             // Act
             // Assert
             await FluentActions
-                .Invoking(() =>
+                .Invoking(async () =>
                 {
-                    using var httpClient = new HttpClient(handlerMock.Object);
-                    var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
-                    return githubClient.GetAsync("http://example.com");
+                     using var httpClient = new HttpClient(handlerMock.Object);
+                     var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
+                     return await githubClient.GetAsync("http://example.com");
                 })
                 .Should()
                 .ThrowExactlyAsync<HttpRequestException>();

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -19,6 +19,7 @@ namespace OctoshiftCLI.Tests
     {
         private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
         private readonly HttpResponseMessage _httpResponse;
+        private readonly RetryPolicy _retryPolicy;
         private readonly object _rawRequestBody;
         private const string EXPECTED_JSON_REQUEST_BODY = "{\"id\":\"ID\"}";
         private const string EXPECTED_RESPONSE_CONTENT = "RESPONSE_CONTENT";
@@ -32,6 +33,8 @@ namespace OctoshiftCLI.Tests
             {
                 Content = new StringContent(EXPECTED_RESPONSE_CONTENT)
             };
+
+            _retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
         }
 
         public void Dispose()
@@ -44,8 +47,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, null);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, null);
 
             // Act
             var actualContent = await githubClient.GetAsync("http://example.com");
@@ -62,8 +64,7 @@ namespace OctoshiftCLI.Tests
             const string graphQLSchemaHeaderValue = "internal";
             var handlerMock = MockHttpHandlerForGet();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, null);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, null);
 
             // Act
             var internalSchemaHeader = new Dictionary<string, string>() { { graphQLSchemaHeaderName, graphQLSchemaHeaderValue } };
@@ -83,8 +84,7 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForGet();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -105,8 +105,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP GET: {url}";
@@ -124,8 +123,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
             _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
@@ -145,8 +143,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({HttpStatusCode.OK}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -176,8 +173,7 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-                    var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+                    var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
                     return githubClient.GetAsync("http://example.com");
                 })
                 .Should()
@@ -189,8 +185,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var actualContent = await githubClient.PostAsync("http://example.com", _rawRequestBody);
@@ -205,8 +200,7 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForPost();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -227,8 +221,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP POST: {url}";
@@ -246,8 +239,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
             _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
@@ -267,8 +259,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"HTTP BODY: {EXPECTED_JSON_REQUEST_BODY}";
 
@@ -285,8 +276,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -321,8 +311,7 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
                     return githubClient.PostAsync("http://example.com", _rawRequestBody);
                 })
                 .Should()
@@ -334,8 +323,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var actualContent = await githubClient.PutAsync("http://example.com", _rawRequestBody);
@@ -350,8 +338,7 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForPut();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -372,8 +359,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP PUT: {url}";
@@ -391,8 +377,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
             _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
@@ -412,8 +397,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"HTTP BODY: {EXPECTED_JSON_REQUEST_BODY}";
 
@@ -430,8 +414,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -466,8 +449,7 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
                     return githubClient.PutAsync("http://example.com", _rawRequestBody);
                 })
                 .Should()
@@ -479,8 +461,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var actualContent = await githubClient.PatchAsync("http://example.com", _rawRequestBody);
@@ -495,8 +476,7 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForPatch();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -517,8 +497,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP PATCH: {url}";
@@ -536,8 +515,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
             _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
@@ -557,8 +535,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"HTTP BODY: {EXPECTED_JSON_REQUEST_BODY}";
 
@@ -575,8 +552,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -611,8 +587,7 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
                     return githubClient.PatchAsync("http://example.com", _rawRequestBody);
                 })
                 .Should()
@@ -624,8 +599,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var actualContent = await githubClient.DeleteAsync("http://example.com");
@@ -640,8 +614,7 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var handlerMock = MockHttpHandlerForDelete();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string actualUrl = "http://example.com/param with space";
             const string expectedUrl = "http://example.com/param%20with%20space";
@@ -662,8 +635,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string url = "http://example.com";
             var expectedLogMessage = $"HTTP DELETE: {url}";
@@ -681,8 +653,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
             _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
@@ -714,8 +685,7 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-                    var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+                    var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
                     return githubClient.GetNonSuccessAsync("http://example.com", HttpStatusCode.Moved);
                 })
                 .Should()
@@ -735,8 +705,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(httpResponse);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             await githubClient.GetNonSuccessAsync("http://example.com", HttpStatusCode.Moved);
@@ -755,8 +724,7 @@ namespace OctoshiftCLI.Tests
             var handlerMock = MockHttpHandler(req => req.Method == HttpMethod.Get, httpResponse);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             await githubClient.GetNonSuccessAsync("http://example.com", HttpStatusCode.Moved);
@@ -770,8 +738,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             var expectedLogMessage = $"RESPONSE ({HttpStatusCode.OK}): {EXPECTED_RESPONSE_CONTENT}";
 
@@ -803,8 +770,7 @@ namespace OctoshiftCLI.Tests
                 .Invoking(() =>
                 {
                     using var httpClient = new HttpClient(handlerMock.Object);
-                    var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+                    var githubClient = new GithubClient(loggerMock.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
                     return githubClient.DeleteAsync("http://example.com");
                 })
                 .Should()
@@ -876,8 +842,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(thirdResponse);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var results = new List<JToken>();
@@ -936,8 +901,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(secondResponse);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             await foreach (var _ in githubClient.GetAllAsync(url)) { }
@@ -987,8 +951,7 @@ namespace OctoshiftCLI.Tests
                 handlerMock);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             await foreach (var _ in githubClient.GetAllAsync(url)) { }
@@ -1041,8 +1004,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(secondResponse);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             await foreach (var _ in githubClient.GetAllAsync(url)) { }
@@ -1095,8 +1057,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(failureResponse);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act, Assert
             await FluentActions
@@ -1230,8 +1191,7 @@ query($id: ID!, $first: Int, $after: String) {
                 handlerMock); // third request
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var result = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1311,8 +1271,7 @@ query($id: ID!, $first: Int, $after: String) {
                 response);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var result = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1388,8 +1347,7 @@ query($id: ID!, $first: Int, $after: String) {
                 response);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var result = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1465,8 +1423,7 @@ query($id: ID!, $first: Int, $after: String) {
                 response);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var result = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1489,8 +1446,7 @@ query($id: ID!, $first: Int, $after: String) {
             // Arrange
             const string url = "https://example.com/graphql";
             using var httpClient = new HttpClient();
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(null, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(null, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act, Assert
             await githubClient
@@ -1558,8 +1514,7 @@ query($id: ID!, $first: Int, $after: String) {
                 response);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var result = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1640,8 +1595,7 @@ query($id: ID!, $first: Int, $after: String) {
                 response);
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var result = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1669,8 +1623,7 @@ query($id: ID!, $first: Int, $after: String) {
             // Arrange
             const string url = "https://example.com/graphql";
             using var httpClient = new HttpClient();
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(null, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(null, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act, Assert
             await githubClient
@@ -1747,8 +1700,7 @@ query($id: ID!, $first: Int, $after: String) {
                 handlerMock); // second request
 
             using var httpClient = new HttpClient(handlerMock.Object);
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Act
             _ = await githubClient.PostGraphQLWithPaginationAsync(
@@ -1778,8 +1730,7 @@ query($id: ID!, $first: Int, $after: String) {
             mockVersionProvider.Setup(m => m.GetVersionComments()).Returns(versionComments);
 
             // Act
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            _ = new GithubClient(null, httpClient, mockVersionProvider.Object, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            _ = new GithubClient(null, httpClient, mockVersionProvider.Object, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Assert
             httpClient.DefaultRequestHeaders.UserAgent.Should().HaveCount(2);
@@ -1793,8 +1744,7 @@ query($id: ID!, $first: Int, $after: String) {
             using var httpClient = new HttpClient();
 
             // Act
-            var retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
-            _ = new GithubClient(null, httpClient, null, retryPolicy, PERSONAL_ACCESS_TOKEN);
+            _ = new GithubClient(null, httpClient, null, _retryPolicy, PERSONAL_ACCESS_TOKEN);
 
             // Assert
             httpClient.DefaultRequestHeaders.UserAgent.Should().HaveCount(1);

--- a/src/ado2gh/GithubApiFactory.cs
+++ b/src/ado2gh/GithubApiFactory.cs
@@ -26,7 +26,7 @@ namespace OctoshiftCLI.AdoToGithub
         {
             apiUrl ??= DEFAULT_API_URL;
             targetPersonalAccessToken ??= _environmentVariableProvider.GithubPersonalAccessToken();
-            var githubClient = new GithubClient(_octoLogger, _client, _versionProvider, targetPersonalAccessToken);
+            var githubClient = new GithubClient(_octoLogger, _client, _versionProvider, _retryPolicy, targetPersonalAccessToken);
             return new GithubApi(githubClient, apiUrl, _retryPolicy);
         }
     }

--- a/src/bbs2gh/GithubApiFactory.cs
+++ b/src/bbs2gh/GithubApiFactory.cs
@@ -26,7 +26,7 @@ namespace OctoshiftCLI.BbsToGithub
         {
             apiUrl ??= DEFAULT_API_URL;
             targetPersonalAccessToken ??= _environmentVariableProvider.GithubPersonalAccessToken();
-            var githubClient = new GithubClient(_octoLogger, _client, _versionProvider, targetPersonalAccessToken);
+            var githubClient = new GithubClient(_octoLogger, _client, _versionProvider, _retryPolicy, targetPersonalAccessToken);
             return new GithubApi(githubClient, apiUrl, _retryPolicy);
         }
     }

--- a/src/gei/GithubApiFactory.cs
+++ b/src/gei/GithubApiFactory.cs
@@ -26,7 +26,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
         {
             apiUrl ??= DEFAULT_API_URL;
             sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
-            var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), _versionProvider, sourcePersonalAccessToken);
+            var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), _versionProvider, _retryPolicy, sourcePersonalAccessToken);
             return new GithubApi(githubClient, apiUrl, _retryPolicy);
         }
 
@@ -34,7 +34,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
         {
             apiUrl ??= DEFAULT_API_URL;
             sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
-            var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("NoSSL"), _versionProvider, sourcePersonalAccessToken);
+            var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("NoSSL"), _versionProvider, _retryPolicy, sourcePersonalAccessToken);
             return new GithubApi(githubClient, apiUrl, _retryPolicy);
         }
 
@@ -42,7 +42,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
         {
             apiUrl ??= DEFAULT_API_URL;
             targetPersonalAccessToken ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
-            var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), _versionProvider, targetPersonalAccessToken);
+            var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), _versionProvider, _retryPolicy, targetPersonalAccessToken);
             return new GithubApi(githubClient, apiUrl, _retryPolicy);
         }
     }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Closes https://github.com/github/gh-gei/issues/587! :sparkles: 

This PR ensures that all non-200 GET requests from `AdoClient`, `BbsClient` and `GithubClient` gets retried via `RetryPolicy.HttpRetry`.  This will allow us to retry on transient network issues for more robust and consistent migrations.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] ~~Docs updated (or issue created)~~ (n/a)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->