### PR TITLE
warn users  not running ado2gh as a  gh extension

### DIFF
--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -3,6 +3,7 @@ using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -64,7 +65,7 @@ namespace OctoshiftCLI.AdoToGithub
 
         private static void WarnIfNotUsingExtension()
         {
-            if (!AppContext.BaseDirectory.EndsWith("extensions\\gh-ado2gh\\") && !AppContext.BaseDirectory.EndsWith("extensions/gh-ado2gh/"))
+            if (!Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory).EndsWith(Path.Combine("extensions", "gh-ado2gh").ToString()))
             {
                 Logger.LogWarning("You are not running the ado2gh CLI as a gh extension. This is not recommended, please run: gh extension install github/gh-ado2gh");
             }

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -47,17 +47,27 @@ namespace OctoshiftCLI.AdoToGithub
 
             SetContext(parser.Parse(args));
 
+            WarnIfNotUsingExtension();
+
             try
             {
                 await LatestVersionCheck(serviceProvider);
             }
             catch (Exception ex)
             {
-                Logger.LogWarning("Could not retrieve latest ado2gh version from github.com, please ensure you are using the latest version by downloading it from https://github.com/github/gh-gei/releases/latest");
+                Logger.LogWarning("Could not retrieve latest ado2gh CLI version from github.com, please ensure you are using the latest version by running: gh extension upgrade ado2gh");
                 Logger.LogVerbose(ex.ToString());
             }
 
             await parser.InvokeAsync(args);
+        }
+
+        private static void WarnIfNotUsingExtension()
+        {
+            if (!AppContext.BaseDirectory.EndsWith("extensions\\gh-ado2gh\\") && !AppContext.BaseDirectory.EndsWith("extensions/gh-ado2gh/"))
+            {
+                Logger.LogWarning("You are not running the ado2gh CLI as a gh extension. This is not recommended, please run: gh extension install github/gh-ado2gh");
+            }
         }
 
         private static void SetContext(ParseResult parseResult)
@@ -77,7 +87,7 @@ namespace OctoshiftCLI.AdoToGithub
             else
             {
                 Logger.LogWarning($"You are running an older version of the ado2gh CLI [v{versionChecker.GetCurrentVersion()}]. The latest version is v{await versionChecker.GetLatestVersion()}.");
-                Logger.LogWarning($"Please download the latest version from https://github.com/github/gh-gei/releases/latest");
+                Logger.LogWarning($"Please update by running: gh extension upgrade ado2gh");
             }
         }
 


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Checking if the user is running ado2gh via a GH CLI extension or as a stand-alone executable.  Doing the check by looking at the path the executable lives in, if it's being run as a GH CLI extension it should have a specific path it lives under:
```
Windows: AppContext.BaseDirectory:C:\Users\Dylan\AppData\Local\GitHub CLI\extensions\gh-gei\
Linux: AppContext.BaseDirectory:/home/dylan/.local/share/gh/extensions/gh-gei/
MacOS: AppContext.BaseDirectory:/Users/iomekam/.local/share/gh/extensions/gh-gei/
```

If they are NOT using it via GH extension we'll spit out a warning recommending that they switch.

Closes #584 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->