### PR TITLE
retry linking IdP group on 400

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- If `create-team` fails when linking an IdP group with an HTTP 400, we will retry

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -505,7 +505,8 @@ namespace OctoshiftCLI
             var url = $"{_apiUrl}/orgs/{org}/teams/{teamSlug}/external-groups";
             var payload = new { group_id = groupId };
 
-            await _client.PatchAsync(url, payload);
+            await _retryPolicy.HttpRetry(async () => await _client.PatchAsync(url, payload),
+                ex => ex.StatusCode == HttpStatusCode.BadRequest);
         }
 
         public virtual async Task<bool> GrantMigratorRole(string org, string actor, string actorType)

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -1233,6 +1233,27 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task AddEmuGroupToTeam_Retries_On_400()
+        {
+            // Arrange
+            const string teamSlug = "TEAM_SLUG";
+            const int groupId = 1;
+
+            var url = $"https://api.github.com/orgs/{GITHUB_ORG}/teams/{teamSlug}/external-groups";
+            var payload = new { group_id = groupId };
+
+            _githubClientMock.SetupSequence(m => m.PatchAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
+                .ThrowsAsync(new HttpRequestException(null, null, HttpStatusCode.BadRequest))
+                .ReturnsAsync("");
+
+            // Act
+            await _githubApi.AddEmuGroupToTeam(GITHUB_ORG, teamSlug, groupId);
+
+            // Assert
+            _githubClientMock.Verify(m => m.PatchAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null), Times.Exactly(2));
+        }
+
+        [Fact]
         public async Task GrantMigratorRole_Returns_True_On_Success()
         {
             // Arrange


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->
We see occasional integration test failures with the `create-team` command. This is to address one specific circumstance: when we get a HTTP 400 while trying to link the IdP group (the error message is saying that there are members in the team, even though we just finished successfully deleting them). The theory here is that there's some kind of race condition in github, and that hopefully retrying this API will succeed.

Closes #590 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->