### PR TITLE
Upgrade System.CommandLine NuGet the the latest beta4 version

### DIFF
--- a/src/Octoshift/Commands/CreateTeamCommandBase.cs
+++ b/src/Octoshift/Commands/CreateTeamCommandBase.cs
@@ -11,12 +11,12 @@ public class CreateTeamCommandBase : Command
     private readonly OctoLogger _log;
     private readonly ITargetGithubApiFactory _githubApiFactory;
 
-    public CreateTeamCommandBase(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base("create-team")
+    public CreateTeamCommandBase(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base(
+        name: "create-team",
+        description: "Creates a GitHub team and optionally links it to an IdP group.")
     {
         _log = log;
         _githubApiFactory = githubApiFactory;
-
-        Description = "Creates a GitHub team and optionally links it to an IdP group.";
     }
 
     protected virtual Option<string> GithubOrg { get; } = new("--github-org") { IsRequired = true };

--- a/src/Octoshift/Commands/DownloadLogsCommandBase.cs
+++ b/src/Octoshift/Commands/DownloadLogsCommandBase.cs
@@ -24,14 +24,12 @@ public class DownloadLogsCommandBase : Command
         OctoLogger log,
         ITargetGithubApiFactory githubApiFactory,
         HttpDownloadService httpDownloadService,
-        RetryPolicy retryPolicy) : base("download-logs")
+        RetryPolicy retryPolicy) : base(name: "download-logs", description: "Downloads migration logs for migrations.")
     {
         _log = log;
         _githubApiFactory = githubApiFactory;
         _httpDownloadService = httpDownloadService;
         _retryPolicy = retryPolicy;
-
-        Description = "Downloads migration logs for migrations.";
     }
 
     protected virtual Option<string> GithubOrg { get; } = new("--github-org")

--- a/src/Octoshift/Commands/GenerateMannequinCsvCommandBase.cs
+++ b/src/Octoshift/Commands/GenerateMannequinCsvCommandBase.cs
@@ -17,12 +17,12 @@ public class GenerateMannequinCsvCommandBase : Command
     private readonly OctoLogger _log;
     private readonly ITargetGithubApiFactory _targetGithubApiFactory;
 
-    public GenerateMannequinCsvCommandBase(OctoLogger log, ITargetGithubApiFactory targetGithubApiFactory) : base("generate-mannequin-csv")
+    public GenerateMannequinCsvCommandBase(OctoLogger log, ITargetGithubApiFactory targetGithubApiFactory) : base(
+        name: "generate-mannequin-csv",
+        description: "Generates a CSV with unreclaimed mannequins to reclaim them in bulk.")
     {
         _log = log;
         _targetGithubApiFactory = targetGithubApiFactory;
-
-        Description = "Generates a CSV with unreclaimed mannequins to reclaim them in bulk.";
     }
 
     protected virtual Option<string> GithubOrg { get; } = new("--github-org")

--- a/src/Octoshift/Commands/GrantMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/GrantMigratorRoleCommandBase.cs
@@ -10,12 +10,12 @@ public class GrantMigratorRoleCommandBase : Command
     private readonly OctoLogger _log;
     private readonly ITargetGithubApiFactory _githubApiFactory;
 
-    public GrantMigratorRoleCommandBase(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base("grant-migrator-role")
+    public GrantMigratorRoleCommandBase(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base(
+        name: "grant-migrator-role",
+        description: "Allows an organization admin to grant a USER or TEAM the migrator role for a single GitHub organization. The migrator role allows the role assignee to perform migrations into the target organization.")
     {
         _log = log;
         _githubApiFactory = githubApiFactory;
-
-        Description = "Allows an organization admin to grant a USER or TEAM the migrator role for a single GitHub organization. The migrator role allows the role assignee to perform migrations into the target organization.";
     }
 
     protected virtual Option<string> GithubOrg { get; } = new("--github-org") { IsRequired = true };

--- a/src/Octoshift/Commands/ReclaimMannequinCommandBase.cs
+++ b/src/Octoshift/Commands/ReclaimMannequinCommandBase.cs
@@ -18,20 +18,20 @@ public class ReclaimMannequinCommandBase : Command
     internal Func<string, bool> FileExists = path => File.Exists(path);
     internal Func<string, string[]> GetFileContent = path => File.ReadLines(path).ToArray();
 
-    public ReclaimMannequinCommandBase(OctoLogger log, ITargetGithubApiFactory githubApiFactory, ReclaimService reclaimService = null) : base("reclaim-mannequin")
+    public ReclaimMannequinCommandBase(OctoLogger log, ITargetGithubApiFactory githubApiFactory, ReclaimService reclaimService = null) : base(
+        name: "reclaim-mannequin",
+        description: "Reclaims one or more mannequin user(s). An invite will be sent and the user(s) will have to accept for the remapping to occur." +
+                     "You can reclaim a single user by using --mannequin-user and --target-user or reclaim mannequins in bulk by using the --csv parameter" +
+                     Environment.NewLine +
+                     "The CSV file should contain a column with the user's login name (source) and reclaiming user login (target)." +
+                     Environment.NewLine +
+                     "The first line is considered the header and is ignored." +
+                     Environment.NewLine +
+                     "If both options are specified The CSV file takes precedence and other options will be ignored")
     {
         _log = log;
         _githubApiFactory = githubApiFactory;
         _reclaimService = reclaimService;
-
-        Description = "Reclaims one or more mannequin user(s). An invite will be sent and the user(s) will have to accept for the remapping to occur."
-          + "You can reclaim a single user by using --mannequin-user and --target-user or reclaim mannequins in bulk by using the --csv parameter"
-          + Environment.NewLine
-          + "The CSV file should contain a column with the user's login name (source) and reclaiming user login (target)."
-          + Environment.NewLine
-          + "The first line is considered the header and is ignored."
-          + Environment.NewLine
-          + "If both options are specified The CSV file takes precedence and other options will be ignored";
     }
 
     protected virtual Option<string> GithubOrg { get; } = new("--github-org")

--- a/src/Octoshift/Commands/RevokeMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/RevokeMigratorRoleCommandBase.cs
@@ -10,12 +10,12 @@ public class RevokeMigratorRoleCommandBase : Command
     private readonly OctoLogger _log;
     private readonly ITargetGithubApiFactory _githubApiFactory;
 
-    public RevokeMigratorRoleCommandBase(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base("revoke-migrator-role")
+    public RevokeMigratorRoleCommandBase(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base(
+        name: "revoke-migrator-role",
+        description: "Allows an organization admin to revoke the migrator role for a USER or TEAM for a single GitHub organization. This will remove their ability to run a migration into the target organization.")
     {
         _log = log;
         _githubApiFactory = githubApiFactory;
-
-        Description = "Allows an organization admin to revoke the migrator role for a USER or TEAM for a single GitHub organization. This will remove their ability to run a migration into the target organization.";
     }
 
     protected virtual Option<string> GithubOrg { get; } = new("--github-org") { IsRequired = true };

--- a/src/Octoshift/Commands/WaitForMigrationCommandBase.cs
+++ b/src/Octoshift/Commands/WaitForMigrationCommandBase.cs
@@ -18,12 +18,12 @@ public class WaitForMigrationCommandBase : Command
     private const string REPO_MIGRATION_ID_PREFIX = "RM_";
     private const string ORG_MIGRATION_ID_PREFIX = "OM_";
 
-    public WaitForMigrationCommandBase(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base("wait-for-migration")
+    public WaitForMigrationCommandBase(OctoLogger log, ITargetGithubApiFactory githubApiFactory) : base(
+        name: "wait-for-migration",
+        description: "Waits for migration(s) to finish and reports all in progress and queued ones.")
     {
         _log = log;
         _githubApiFactory = githubApiFactory;
-
-        Description = "Waits for migration(s) to finish and reports all in progress and queued ones.";
     }
 
     protected virtual Option<string> MigrationId { get; } = new("--migration-id")

--- a/src/Octoshift/Extensions/CommandLineOptionExtensions.cs
+++ b/src/Octoshift/Extensions/CommandLineOptionExtensions.cs
@@ -4,5 +4,5 @@ namespace OctoshiftCLI.Extensions;
 
 public static class CommandLineOptionExtensions
 {
-    public static string GetLogFriendlyName(this Option option) => option?.ArgumentHelpName.ToUpper().Replace("-", " ");
+    public static string GetLogFriendlyName(this Option option) => option?.Name.ToUpper().Replace("-", " ");
 }

--- a/src/Octoshift/Octoshift.csproj
+++ b/src/Octoshift/Octoshift.csproj
@@ -10,7 +10,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Linq.Async" Version="5.1.0" />
   </ItemGroup>
 

--- a/src/OctoshiftCLI.Tests/OctoshiftCLI.Tests.csproj
+++ b/src/OctoshiftCLI.Tests/OctoshiftCLI.Tests.csproj
@@ -20,7 +20,9 @@
 
     <PackageReference Include="Moq" Version="4.16.1" />
 
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ado2gh/Commands/AddTeamToRepoCommand.cs
+++ b/src/ado2gh/Commands/AddTeamToRepoCommand.cs
@@ -10,14 +10,14 @@ namespace OctoshiftCLI.AdoToGithub.Commands
         private readonly OctoLogger _log;
         private readonly GithubApiFactory _githubApiFactory;
 
-        public AddTeamToRepoCommand(OctoLogger log, GithubApiFactory githubApiFactory) : base("add-team-to-repo")
+        public AddTeamToRepoCommand(OctoLogger log, GithubApiFactory githubApiFactory) : base(
+            name: "add-team-to-repo",
+            description: "Adds a team to a repo with a specific role/permission" +
+                         Environment.NewLine +
+                         "Note: Expects GH_PAT env variable or --github-pat option to be set.")
         {
             _log = log;
             _githubApiFactory = githubApiFactory;
-
-            Description = "Adds a team to a repo with a specific role/permission";
-            Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variable or --github-pat option to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/AddTeamToRepoCommand.cs
+++ b/src/ado2gh/Commands/AddTeamToRepoCommand.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Threading.Tasks;
 
 namespace OctoshiftCLI.AdoToGithub.Commands
 {
-    public class AddTeamToRepoCommand : Command
+    public sealed class AddTeamToRepoCommand : Command
     {
         private readonly OctoLogger _log;
         private readonly GithubApiFactory _githubApiFactory;
@@ -40,7 +40,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = false
             };
-            var verbose = new Option("--verbose")
+            var verbose = new Option<bool>("--verbose")
             {
                 IsRequired = false
             };

--- a/src/ado2gh/Commands/ConfigureAutoLinkCommand.cs
+++ b/src/ado2gh/Commands/ConfigureAutoLinkCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -40,7 +40,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = false
             };
-            var verbose = new Option("--verbose")
+            var verbose = new Option<bool>("--verbose")
             {
                 IsRequired = false
             };

--- a/src/ado2gh/Commands/ConfigureAutoLinkCommand.cs
+++ b/src/ado2gh/Commands/ConfigureAutoLinkCommand.cs
@@ -11,14 +11,14 @@ namespace OctoshiftCLI.AdoToGithub.Commands
         private readonly OctoLogger _log;
         private readonly GithubApiFactory _githubApiFactory;
 
-        public ConfigureAutoLinkCommand(OctoLogger log, GithubApiFactory githubApiFactory) : base("configure-autolink")
+        public ConfigureAutoLinkCommand(OctoLogger log, GithubApiFactory githubApiFactory) : base(
+            name: "configure-autolink",
+            description: "Configures Autolink References in GitHub so that references to Azure Boards work items become hyperlinks in GitHub" +
+                         Environment.NewLine +
+                         "Note: Expects GH_PAT env variable or --github-pat option to be set.")
         {
             _log = log;
             _githubApiFactory = githubApiFactory;
-
-            Description = "Configures Autolink References in GitHub so that references to Azure Boards work items become hyperlinks in GitHub";
-            Description += Environment.NewLine;
-            Description += "Note: Expects GH_PAT env variable or --github-pat option to be set.";
 
             var githubOrg = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/CreateTeamCommand.cs
+++ b/src/ado2gh/Commands/CreateTeamCommand.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;
 

--- a/src/ado2gh/Commands/DisableRepoCommand.cs
+++ b/src/ado2gh/Commands/DisableRepoCommand.cs
@@ -11,14 +11,14 @@ namespace OctoshiftCLI.AdoToGithub.Commands
         private readonly OctoLogger _log;
         private readonly AdoApiFactory _adoApiFactory;
 
-        public DisableRepoCommand(OctoLogger log, AdoApiFactory adoApiFactory) : base("disable-ado-repo")
+        public DisableRepoCommand(OctoLogger log, AdoApiFactory adoApiFactory) : base(
+            name: "disable-ado-repo",
+            description: "Disables the repo in Azure DevOps. This makes the repo non-readable for all." +
+                         Environment.NewLine +
+                         "Note: Expects ADO_PAT env variable or --ado-pat option to be set.")
         {
             _log = log;
             _adoApiFactory = adoApiFactory;
-
-            Description = "Disables the repo in Azure DevOps. This makes the repo non-readable for all.";
-            Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT env variable or --ado-pat option to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/DisableRepoCommand.cs
+++ b/src/ado2gh/Commands/DisableRepoCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -36,7 +36,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = false
             };
-            var verbose = new Option("--verbose")
+            var verbose = new Option<bool>("--verbose")
             {
                 IsRequired = false
             };

--- a/src/ado2gh/Commands/DownloadLogsCommand.cs
+++ b/src/ado2gh/Commands/DownloadLogsCommand.cs
@@ -1,4 +1,4 @@
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Runtime.CompilerServices;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;

--- a/src/ado2gh/Commands/GenerateMannequinCsvCommand.cs
+++ b/src/ado2gh/Commands/GenerateMannequinCsvCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.CommandLine.Invocation;
+﻿using System.CommandLine.NamingConventionBinder;
 using System.IO;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -23,16 +23,16 @@ namespace OctoshiftCLI.AdoToGithub.Commands
 
         private AdoInspectorService _adoInspectorService;
 
-        public GenerateScriptCommand(OctoLogger log, AdoApiFactory adoApiFactory, IVersionProvider versionProvider, AdoInspectorServiceFactory adoInspectorServiceFactory) : base("generate-script")
+        public GenerateScriptCommand(OctoLogger log, AdoApiFactory adoApiFactory, IVersionProvider versionProvider, AdoInspectorServiceFactory adoInspectorServiceFactory) : base(
+            name: "generate-script",
+            description: "Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it." +
+                         Environment.NewLine +
+                         "Note: Expects ADO_PAT env variable or --ado-pat option to be set.")
         {
             _log = log;
             _adoApiFactory = adoApiFactory;
             _versionProvider = versionProvider;
             _adoInspectorServiceFactory = adoInspectorServiceFactory;
-
-            Description = "Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it.";
-            Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT env variable or --ado-pat option to be set.";
 
             var githubOrgOption = new Option<string>("--github-org")
             {

--- a/src/ado2gh/Commands/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScriptCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -50,12 +50,12 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = false
             };
-            var sshOption = new Option("--ssh")
+            var sshOption = new Option<bool>("--ssh")
             {
                 IsRequired = false,
                 IsHidden = true
             };
-            var sequential = new Option("--sequential")
+            var sequential = new Option<bool>("--sequential")
             {
                 IsRequired = false,
                 Description = "Waits for each migration to finish before moving on to the next one."
@@ -64,47 +64,47 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = false
             };
-            var verbose = new Option("--verbose")
+            var verbose = new Option<bool>("--verbose")
             {
                 IsRequired = false
             };
-            var downloadMigrationLogs = new Option("--download-migration-logs")
+            var downloadMigrationLogs = new Option<bool>("--download-migration-logs")
             {
                 IsRequired = false,
                 Description = "Downloads the migration log for each repository migration."
             };
 
-            var createTeams = new Option("--create-teams")
+            var createTeams = new Option<bool>("--create-teams")
             {
                 IsRequired = false,
                 Description = "Includes create-team scripts that creates admins and maintainers teams and adds them to repos."
             };
-            var linkIdpGroups = new Option("--link-idp-groups")
+            var linkIdpGroups = new Option<bool>("--link-idp-groups")
             {
                 IsRequired = false,
                 Description = "Adds --idp-group to the end of create teams scripts that links the created team to an idP group."
             };
-            var lockAdoRepos = new Option("--lock-ado-repos")
+            var lockAdoRepos = new Option<bool>("--lock-ado-repos")
             {
                 IsRequired = false,
                 Description = "Includes lock-ado-repo scripts that lock repos before migrating them."
             };
-            var disableAdoRepos = new Option("--disable-ado-repos")
+            var disableAdoRepos = new Option<bool>("--disable-ado-repos")
             {
                 IsRequired = false,
                 Description = "Includes disable-ado-repo scripts that disable repos after migrating them."
             };
-            var integrateBoards = new Option("--integrate-boards")
+            var integrateBoards = new Option<bool>("--integrate-boards")
             {
                 IsRequired = false,
                 Description = "Includes configure-autolink and integrate-boards scripts that configure Azure Boards integrations."
             };
-            var rewirePipelines = new Option("--rewire-pipelines")
+            var rewirePipelines = new Option<bool>("--rewire-pipelines")
             {
                 IsRequired = false,
                 Description = "Includes share-service-connection and rewire-pipeline scripts that rewire Azure Pipelines to point to GitHub repos."
             };
-            var all = new Option("--all")
+            var all = new Option<bool>("--all")
             {
                 IsRequired = false,
                 Description = "Includes all script generation options."

--- a/src/ado2gh/Commands/GrantMigratorRoleCommand.cs
+++ b/src/ado2gh/Commands/GrantMigratorRoleCommand.cs
@@ -1,5 +1,5 @@
 using System;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;
 

--- a/src/ado2gh/Commands/IntegrateBoardsCommand.cs
+++ b/src/ado2gh/Commands/IntegrateBoardsCommand.cs
@@ -13,18 +13,15 @@ namespace OctoshiftCLI.AdoToGithub.Commands
         private readonly AdoApiFactory _adoApiFactory;
         private readonly EnvironmentVariableProvider _environmentVariableProvider;
 
-        public IntegrateBoardsCommand(
-            OctoLogger log,
-            AdoApiFactory adoApiFactory,
-            EnvironmentVariableProvider environmentVariableProvider) : base("integrate-boards")
+        public IntegrateBoardsCommand(OctoLogger log, AdoApiFactory adoApiFactory, EnvironmentVariableProvider environmentVariableProvider) : base(
+            name: "integrate-boards",
+            description: "Configures the Azure Boards<->GitHub integration in Azure DevOps." +
+                         Environment.NewLine +
+                         "Note: Expects ADO_PAT and GH_PAT env variables or --ado-pat and --github-pat options to be set.")
         {
             _log = log;
             _adoApiFactory = adoApiFactory;
             _environmentVariableProvider = environmentVariableProvider;
-
-            Description = "Configures the Azure Boards<->GitHub integration in Azure DevOps.";
-            Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT and GH_PAT env variables or --ado-pat and --github-pat options to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/IntegrateBoardsCommand.cs
+++ b/src/ado2gh/Commands/IntegrateBoardsCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -50,7 +50,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = false
             };
-            var verbose = new Option("--verbose")
+            var verbose = new Option<bool>("--verbose")
             {
                 IsRequired = false
             };

--- a/src/ado2gh/Commands/InventoryReportCommand.cs
+++ b/src/ado2gh/Commands/InventoryReportCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -55,7 +55,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
                 IsRequired = false,
                 Description = "Significantly speeds up the generation of the CSV files by including the bare minimum info."
             };
-            var verbose = new Option("--verbose")
+            var verbose = new Option<bool>("--verbose")
             {
                 IsRequired = false
             };

--- a/src/ado2gh/Commands/InventoryReportCommand.cs
+++ b/src/ado2gh/Commands/InventoryReportCommand.cs
@@ -27,7 +27,11 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             OrgsCsvGeneratorService orgsCsvGeneratorService,
             TeamProjectsCsvGeneratorService teamProjectsCsvGeneratorService,
             ReposCsvGeneratorService reposCsvGeneratorService,
-            PipelinesCsvGeneratorService pipelinesCsvGeneratorService) : base("inventory-report")
+            PipelinesCsvGeneratorService pipelinesCsvGeneratorService) : base(
+                name: "inventory-report",
+                description: "Generates several CSV files containing lists of ADO orgs, team projects, repos, and pipelines. Useful for planning large migrations." +
+                             Environment.NewLine +
+                             "Note: Expects ADO_PAT env variable or --ado-pat option to be set.")
         {
             _log = log;
             _adoApiFactory = adoApiFactory;
@@ -36,10 +40,6 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             _teamProjectsCsvGenerator = teamProjectsCsvGeneratorService;
             _reposCsvGenerator = reposCsvGeneratorService;
             _pipelinesCsvGenerator = pipelinesCsvGeneratorService;
-
-            Description = "Generates several CSV files containing lists of ADO orgs, team projects, repos, and pipelines. Useful for planning large migrations.";
-            Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT env variable or --ado-pat option to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/LockRepoCommand.cs
+++ b/src/ado2gh/Commands/LockRepoCommand.cs
@@ -10,14 +10,14 @@ namespace OctoshiftCLI.AdoToGithub.Commands
         private readonly OctoLogger _log;
         private readonly AdoApiFactory _adoApiFactory;
 
-        public LockRepoCommand(OctoLogger log, AdoApiFactory adoApiFactory) : base("lock-ado-repo")
+        public LockRepoCommand(OctoLogger log, AdoApiFactory adoApiFactory) : base(
+            name: "lock-ado-repo",
+            description: "Makes the ADO repo read-only for all users. It does this by adding Deny permissions for the Project Valid Users group on the repo." +
+                         Environment.NewLine +
+                         "Note: Expects ADO_PAT env variable or --ado-pat option to be set.")
         {
             _log = log;
             _adoApiFactory = adoApiFactory;
-
-            Description = "Makes the ADO repo read-only for all users. It does this by adding Deny permissions for the Project Valid Users group on the repo.";
-            Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT env variable or --ado-pat option to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/LockRepoCommand.cs
+++ b/src/ado2gh/Commands/LockRepoCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Threading.Tasks;
 
 namespace OctoshiftCLI.AdoToGithub.Commands
@@ -35,7 +35,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = false
             };
-            var verbose = new Option("--verbose")
+            var verbose = new Option<bool>("--verbose")
             {
                 IsRequired = false
             };

--- a/src/ado2gh/Commands/MigrateRepoCommand.cs
+++ b/src/ado2gh/Commands/MigrateRepoCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Threading.Tasks;
 
 namespace OctoshiftCLI.AdoToGithub.Commands
@@ -44,13 +44,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = true
             };
-            var ssh = new Option("--ssh")
+            var ssh = new Option<bool>("--ssh")
             {
                 IsRequired = false,
                 IsHidden = true,
                 Description = "Uses SSH protocol instead of HTTPS to push a Git repository into the target repository on GitHub."
             };
-            var wait = new Option("--wait")
+            var wait = new Option<bool>("--wait")
             {
                 IsRequired = false,
                 Description = "Synchronously waits for the repo migration to finish."
@@ -63,7 +63,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = false
             };
-            var verbose = new Option("--verbose")
+            var verbose = new Option<bool>("--verbose")
             {
                 IsRequired = false
             };

--- a/src/ado2gh/Commands/MigrateRepoCommand.cs
+++ b/src/ado2gh/Commands/MigrateRepoCommand.cs
@@ -11,18 +11,15 @@ namespace OctoshiftCLI.AdoToGithub.Commands
         private readonly GithubApiFactory _githubApiFactory;
         private readonly EnvironmentVariableProvider _environmentVariableProvider;
 
-        public MigrateRepoCommand(
-            OctoLogger log,
-            GithubApiFactory githubApiFactory,
-            EnvironmentVariableProvider environmentVariableProvider) : base("migrate-repo")
+        public MigrateRepoCommand(OctoLogger log, GithubApiFactory githubApiFactory, EnvironmentVariableProvider environmentVariableProvider) : base(
+            name: "migrate-repo",
+            description: "Invokes the GitHub API's to migrate the repo and all PR data" +
+                         Environment.NewLine +
+                         "Note: Expects ADO_PAT and GH_PAT env variables or --ado-pat and --github-pat options to be set.")
         {
             _log = log;
             _githubApiFactory = githubApiFactory;
             _environmentVariableProvider = environmentVariableProvider;
-
-            Description = "Invokes the GitHub API's to migrate the repo and all PR data";
-            Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT and GH_PAT env variables or --ado-pat and --github-pat options to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/ReclaimMannequinCommand.cs
+++ b/src/ado2gh/Commands/ReclaimMannequinCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.CommandLine.Invocation;
+﻿using System.CommandLine.NamingConventionBinder;
 using Octoshift;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;

--- a/src/ado2gh/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/ado2gh/Commands/RevokeMigratorRoleCommand.cs
@@ -1,5 +1,5 @@
 using System;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;
 using OctoshiftCLI.Extensions;

--- a/src/ado2gh/Commands/RewirePipelineCommand.cs
+++ b/src/ado2gh/Commands/RewirePipelineCommand.cs
@@ -10,14 +10,14 @@ namespace OctoshiftCLI.AdoToGithub.Commands
         private readonly OctoLogger _log;
         private readonly AdoApiFactory _adoApiFactory;
 
-        public RewirePipelineCommand(OctoLogger log, AdoApiFactory adoApiFactory) : base("rewire-pipeline")
+        public RewirePipelineCommand(OctoLogger log, AdoApiFactory adoApiFactory) : base(
+            name: "rewire-pipeline",
+            description: "Updates an Azure Pipeline to point to a GitHub repo instead of an Azure Repo." +
+                         Environment.NewLine +
+                         "Note: Expects ADO_PAT env variable or --ado-pat option to be set.")
         {
             _log = log;
             _adoApiFactory = adoApiFactory;
-
-            Description = "Updates an Azure Pipeline to point to a GitHub repo instead of an Azure Repo.";
-            Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT env variable or --ado-pat option to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/RewirePipelineCommand.cs
+++ b/src/ado2gh/Commands/RewirePipelineCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Threading.Tasks;
 
 namespace OctoshiftCLI.AdoToGithub.Commands
@@ -48,7 +48,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = false
             };
-            var verbose = new Option("--verbose")
+            var verbose = new Option<bool>("--verbose")
             {
                 IsRequired = false
             };

--- a/src/ado2gh/Commands/ShareServiceConnectionCommand.cs
+++ b/src/ado2gh/Commands/ShareServiceConnectionCommand.cs
@@ -10,14 +10,14 @@ namespace OctoshiftCLI.AdoToGithub.Commands
         private readonly OctoLogger _log;
         private readonly AdoApiFactory _adoApiFactory;
 
-        public ShareServiceConnectionCommand(OctoLogger log, AdoApiFactory adoApiFactory) : base("share-service-connection")
+        public ShareServiceConnectionCommand(OctoLogger log, AdoApiFactory adoApiFactory) : base(
+            name: "share-service-connection",
+            description: "Makes an existing GitHub Pipelines App service connection available in another team project. This is required before you can rewire pipelines." +
+                         Environment.NewLine +
+                         "Note: Expects ADO_PAT env variable or --ado-pat option to be set.")
         {
             _log = log;
             _adoApiFactory = adoApiFactory;
-
-            Description = "Makes an existing GitHub Pipelines App service connection available in another team project. This is required before you can rewire pipelines.";
-            Description += Environment.NewLine;
-            Description += "Note: Expects ADO_PAT env variable or --ado-pat option to be set.";
 
             var adoOrg = new Option<string>("--ado-org")
             {

--- a/src/ado2gh/Commands/ShareServiceConnectionCommand.cs
+++ b/src/ado2gh/Commands/ShareServiceConnectionCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Threading.Tasks;
 
 namespace OctoshiftCLI.AdoToGithub.Commands
@@ -35,7 +35,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 IsRequired = false
             };
-            var verbose = new Option("--verbose")
+            var verbose = new Option<bool>("--verbose")
             {
                 IsRequired = false
             };

--- a/src/ado2gh/Commands/WaitForMigrationCommand.cs
+++ b/src/ado2gh/Commands/WaitForMigrationCommand.cs
@@ -1,5 +1,5 @@
 using System;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;
 

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -88,7 +88,7 @@ namespace OctoshiftCLI.AdoToGithub
 
             foreach (var command in serviceProvider.GetServices<Command>())
             {
-                commandLineBuilder.AddCommand(command);
+                commandLineBuilder.Command.AddCommand(command);
             }
 
             return commandLineBuilder

--- a/src/ado2gh/ado2gh.csproj
+++ b/src/ado2gh/ado2gh.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />    
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
-    <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.21216.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />    
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ado2gh/ado2gh.csproj
+++ b/src/ado2gh/ado2gh.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>ado2gh</AssemblyName>
     <LangVersion>10</LangVersion>
+    <RootNamespace>OctoshiftCLI.AdoToGithub</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/bbs2gh/Commands/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScriptCommand.cs
@@ -1,6 +1,6 @@
 using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/src/bbs2gh/Commands/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScriptCommand.cs
@@ -23,15 +23,15 @@ public class GenerateScriptCommand : Command
         IVersionProvider versionProvider,
         FileSystemProvider fileSystemProvider,
         BbsApiFactory bbsApiFactory,
-        EnvironmentVariableProvider environmentVariableProvider) : base("generate-script")
+        EnvironmentVariableProvider environmentVariableProvider) : base(
+            name: "generate-script",
+            description: "Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it.")
     {
         _log = log;
         _versionProvider = versionProvider;
         _fileSystemProvider = fileSystemProvider;
         _bbsApiFactory = bbsApiFactory;
         _environmentVariableProvider = environmentVariableProvider;
-
-        Description = "Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it.";
 
         var bbsServerUrl = new Option<string>("--bbs-server-url")
         {

--- a/src/bbs2gh/Commands/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepoCommand.cs
@@ -24,8 +24,11 @@ public class MigrateRepoCommand : Command
         EnvironmentVariableProvider environmentVariableProvider,
         BbsArchiveDownloaderFactory bbsArchiveDownloaderFactory,
         IAzureApiFactory azureApiFactory,
-        FileSystemProvider fileSystemProvider
-    ) : base("migrate-repo")
+        FileSystemProvider fileSystemProvider) : base(
+            name: "migrate-repo",
+            description: "Import a Bitbucket Server archive to GitHub." +
+                         Environment.NewLine +
+                         "Note: Expects GH_PAT env variable or --github-pat option to be set.")
     {
         _log = log;
         _githubApiFactory = githubApiFactory;
@@ -34,10 +37,6 @@ public class MigrateRepoCommand : Command
         _environmentVariableProvider = environmentVariableProvider;
         _bbsArchiveDownloaderFactory = bbsArchiveDownloaderFactory;
         _fileSystemProvider = fileSystemProvider;
-
-        Description = "Import a Bitbucket Server archive to GitHub.";
-        Description += Environment.NewLine;
-        Description += "Note: Expects GH_PAT env variable or --github-pat option to be set.";
 
         // Arguments to generate a new archive
         var bbsServerUrl = new Option<string>("--bbs-server-url")

--- a/src/bbs2gh/Commands/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepoCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Threading.Tasks;
 using OctoshiftCLI.Extensions;
 
@@ -141,11 +141,11 @@ public class MigrateRepoCommand : Command
         {
             IsRequired = false
         };
-        var wait = new Option("--wait")
+        var wait = new Option<bool>("--wait")
         {
             Description = "Synchronously waits for the repo migration to finish."
         };
-        var verbose = new Option("--verbose")
+        var verbose = new Option<bool>("--verbose")
         {
             IsRequired = false
         };

--- a/src/bbs2gh/Program.cs
+++ b/src/bbs2gh/Program.cs
@@ -86,7 +86,7 @@ namespace OctoshiftCLI.BbsToGithub
 
             foreach (var command in serviceProvider.GetServices<Command>())
             {
-                commandLineBuilder.AddCommand(command);
+                commandLineBuilder.Command.AddCommand(command);
             }
 
             return commandLineBuilder

--- a/src/bbs2gh/bbs2gh.csproj
+++ b/src/bbs2gh/bbs2gh.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="SSH.NET" Version="2020.0.2" />    
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
-    <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.21216.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />    
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/bbs2gh/bbs2gh.csproj
+++ b/src/bbs2gh/bbs2gh.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>bbs2gh</AssemblyName>
     <LangVersion>10</LangVersion>
+    <RootNamespace>OctoshiftCLI.BbsToGithub</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/gei/Commands/CreateTeamCommand.cs
+++ b/src/gei/Commands/CreateTeamCommand.cs
@@ -1,6 +1,6 @@
 using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Threading.Tasks;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;

--- a/src/gei/Commands/DownloadLogsCommand.cs
+++ b/src/gei/Commands/DownloadLogsCommand.cs
@@ -1,5 +1,5 @@
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using OctoshiftCLI.Commands;

--- a/src/gei/Commands/GenerateMannequinCsvCommand.cs
+++ b/src/gei/Commands/GenerateMannequinCsvCommand.cs
@@ -1,5 +1,5 @@
 ﻿using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.IO;
 using System.Threading.Tasks;
 using OctoshiftCLI.Commands;

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -28,15 +28,15 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             ISourceGithubApiFactory sourceGithubApiFactory,
             AdoApiFactory sourceAdoApiFactory,
             EnvironmentVariableProvider environmentVariableProvider,
-            IVersionProvider versionProvider) : base("generate-script")
+            IVersionProvider versionProvider) : base(
+                name: "generate-script",
+                description: "Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it.")
         {
             _log = log;
             _sourceGithubApiFactory = sourceGithubApiFactory;
             _sourceAdoApiFactory = sourceAdoApiFactory;
             _environmentVariableProvider = environmentVariableProvider;
             _versionProvider = versionProvider;
-
-            Description = "Generates a migration script. This provides you the ability to review the steps that this tool will take, and optionally modify the script if desired before running it.";
 
             var githubSourceOrgOption = new Option<string>("--github-source-org")
             {

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -76,23 +76,23 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 IsRequired = false,
                 Description = "Required if migrating from GHES. The connection string for the Azure storage account, used to upload data archives pre-migration. For example: \"DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net\""
             };
-            var noSslVerify = new Option("--no-ssl-verify")
+            var noSslVerify = new Option<bool>("--no-ssl-verify")
             {
                 IsRequired = false,
                 Description = "Only effective if migrating from GHES. Disables SSL verification when communicating with your GHES instance. All other migration steps will continue to verify SSL. If your GHES instance has a self-signed SSL certificate then setting this flag will allow data to be extracted."
             };
-            var skipReleases = new Option("--skip-releases")
+            var skipReleases = new Option<bool>("--skip-releases")
             {
                 IsRequired = false,
                 Description = "Skip releases when migrating."
             };
-            var lockSourceRepo = new Option("--lock-source-repo")
+            var lockSourceRepo = new Option<bool>("--lock-source-repo")
             {
                 IsRequired = false,
                 Description = "Lock the source repository when migrating."
             };
 
-            var downloadMigrationLogs = new Option("--download-migration-logs")
+            var downloadMigrationLogs = new Option<bool>("--download-migration-logs")
             {
                 IsRequired = false,
                 Description = "Downloads the migration log for each repository migration."
@@ -102,12 +102,12 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 IsRequired = false
             };
-            var ssh = new Option("--ssh")
+            var ssh = new Option<bool>("--ssh")
             {
                 IsRequired = false,
                 IsHidden = true
             };
-            var sequential = new Option("--sequential")
+            var sequential = new Option<bool>("--sequential")
             {
                 IsRequired = false,
                 Description = "Waits for each migration to finish before moving on to the next one."
@@ -121,7 +121,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 IsRequired = false,
                 IsHidden = true
             };
-            var verbose = new Option("--verbose")
+            var verbose = new Option<bool>("--verbose")
             {
                 IsRequired = false
             };

--- a/src/gei/Commands/GrantMigratorRoleCommand.cs
+++ b/src/gei/Commands/GrantMigratorRoleCommand.cs
@@ -1,6 +1,6 @@
 using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Threading.Tasks;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;

--- a/src/gei/Commands/MigrateOrgCommand.cs
+++ b/src/gei/Commands/MigrateOrgCommand.cs
@@ -14,14 +14,14 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         private readonly EnvironmentVariableProvider _environmentVariableProvider;
         private const string DEFAULT_GITHUB_BASE_URL = "https://github.com";
 
-        public MigrateOrgCommand(OctoLogger log, ITargetGithubApiFactory targetGithubApiFactory, EnvironmentVariableProvider environmentVariableProvider) : base("migrate-org")
+        public MigrateOrgCommand(OctoLogger log, ITargetGithubApiFactory targetGithubApiFactory, EnvironmentVariableProvider environmentVariableProvider) : base(
+            name: "migrate-org",
+            description: "Invokes the GitHub APIs to migrate a GitHub org with its teams and the repositories.")
         {
             IsHidden = true;
             _log = log;
             _targetGithubApiFactory = targetGithubApiFactory;
             _environmentVariableProvider = environmentVariableProvider;
-
-            Description = "Invokes the GitHub APIs to migrate a GitHub org with its teams and the repositories.";
 
             var githubSourceOrg = new Option<string>("--github-source-org")
             {

--- a/src/gei/Commands/MigrateOrgCommand.cs
+++ b/src/gei/Commands/MigrateOrgCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Threading.Tasks;
 using OctoshiftCLI.Contracts;
 using OctoshiftCLI.Extensions;
@@ -46,12 +46,12 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 IsRequired = false
             };
-            var wait = new Option("--wait")
+            var wait = new Option<bool>("--wait")
             {
                 IsRequired = false,
                 Description = "Synchronously waits for the org migration to finish."
             };
-            var verbose = new Option("--verbose")
+            var verbose = new Option<bool>("--verbose")
             {
                 IsRequired = false
             };

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -85,7 +85,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 IsRequired = false,
                 Description = "Required if migrating from GHES. The connection string for the Azure storage account, used to upload data archives pre-migration. For example: \"DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net\""
             };
-            var noSslVerify = new Option("--no-ssl-verify")
+            var noSslVerify = new Option<bool>("--no-ssl-verify")
             {
                 IsRequired = false,
                 Description = "Only effective if migrating from GHES. Disables SSL verification when communicating with your GHES instance. All other migration steps will continue to verify SSL. If your GHES instance has a self-signed SSL certificate then setting this flag will allow data to be extracted."
@@ -104,23 +104,23 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 IsRequired = false,
                 Description = "An authenticated SAS URL to an Azure Blob Storage container with a pre-generated metadata archive. Only used when an archive has been generated and uploaded prior to running a migration (not common). Must be passed in when also using --git-archive-url"
             };
-            var skipReleases = new Option("--skip-releases")
+            var skipReleases = new Option<bool>("--skip-releases")
             {
                 IsRequired = false,
                 Description = "Skip releases when migrating."
             };
-            var lockSourceRepo = new Option("--lock-source-repo")
+            var lockSourceRepo = new Option<bool>("--lock-source-repo")
             {
                 IsRequired = false,
                 Description = "Lock source repo when migrating."
             };
-            var ssh = new Option("--ssh")
+            var ssh = new Option<bool>("--ssh")
             {
                 IsRequired = false,
                 IsHidden = true,
                 Description = "Uses SSH protocol instead of HTTPS to push a Git repository into the target repository on GitHub."
             };
-            var wait = new Option("--wait")
+            var wait = new Option<bool>("--wait")
             {
                 IsRequired = false,
                 Description = "Synchronously waits for the repo migration to finish."
@@ -138,7 +138,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 IsRequired = false,
                 IsHidden = true
             };
-            var verbose = new Option("--verbose")
+            var verbose = new Option<bool>("--verbose")
             {
                 IsRequired = false
             };

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -22,15 +22,15 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         private const string METADATA_ARCHIVE_FILE_NAME = "metadata_archive.tar.gz";
         private const string DEFAULT_GITHUB_BASE_URL = "https://github.com";
 
-        public MigrateRepoCommand(OctoLogger log, ISourceGithubApiFactory sourceGithubApiFactory, ITargetGithubApiFactory targetGithubApiFactory, EnvironmentVariableProvider environmentVariableProvider, IAzureApiFactory azureApiFactory) : base("migrate-repo")
+        public MigrateRepoCommand(OctoLogger log, ISourceGithubApiFactory sourceGithubApiFactory, ITargetGithubApiFactory targetGithubApiFactory, EnvironmentVariableProvider environmentVariableProvider, IAzureApiFactory azureApiFactory) : base(
+            name: "migrate-repo",
+            description: "Invokes the GitHub APIs to migrate the repo and all repo data.")
         {
             _log = log;
             _sourceGithubApiFactory = sourceGithubApiFactory;
             _targetGithubApiFactory = targetGithubApiFactory;
             _environmentVariableProvider = environmentVariableProvider;
             _azureApiFactory = azureApiFactory;
-
-            Description = "Invokes the GitHub APIs to migrate the repo and all repo data.";
 
             var githubSourceOrg = new Option<string>("--github-source-org")
             {

--- a/src/gei/Commands/ReclaimMannequinCommand.cs
+++ b/src/gei/Commands/ReclaimMannequinCommand.cs
@@ -1,5 +1,5 @@
 ﻿using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Threading.Tasks;
 using Octoshift;
 using OctoshiftCLI.Commands;

--- a/src/gei/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/gei/Commands/RevokeMigratorRoleCommand.cs
@@ -1,6 +1,6 @@
 using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Threading.Tasks;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;

--- a/src/gei/Commands/WaitForMigrationCommand.cs
+++ b/src/gei/Commands/WaitForMigrationCommand.cs
@@ -1,6 +1,6 @@
 using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.Threading.Tasks;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -96,7 +96,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
             foreach (var command in serviceProvider.GetServices<Command>())
             {
-                commandLineBuilder.AddCommand(command);
+                commandLineBuilder.Command.AddCommand(command);
             }
 
             return commandLineBuilder

--- a/src/gei/gei.csproj
+++ b/src/gei/gei.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
-    <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.21216.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/gei/gei.csproj
+++ b/src/gei/gei.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>OctoshiftCLI.GithubEnterpriseImporter</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #636 

### Description
1. Upgraded `System.CommandLine` to the latest beta4 version (`2.0.0-beta4.22272.1`).
2. Removed unnecessary `System.CommandLine.Hosting`.
3. Added a reference to `System.CommandLine.NamingConventionBinder` in order for `CommandHandler.Create<>()` to continue working. 
4. In the new `Command` class, the `Description` property is marked as virtual, so I had to pass it as a constructor arg to the base class. In addition for clarity, I used name args for calling the base `Command` class.
5. **[Bonus]** I finally fixed the root namespace for all 3 projects.  


- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
