### PR TITLE
Add CommandArg classes for all ado2gh commands

### DIFF
--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/AddTeamToRepoCommandTests.cs
@@ -48,7 +48,14 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockGithubApi.Setup(x => x.GetTeamSlug(GITHUB_ORG, TEAM)).ReturnsAsync(teamSlug);
             _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
 
-            await _command.Invoke(GITHUB_ORG, GITHUB_REPO, TEAM, role);
+            var args = new AddTeamToRepoCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                Team = TEAM,
+                Role = role
+            };
+            await _command.Invoke(args);
 
             _mockGithubApi.Verify(x => x.AddTeamToRepo(GITHUB_ORG, GITHUB_REPO, teamSlug, role));
         }
@@ -60,7 +67,15 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(_mockGithubApi.Object);
 
-            await _command.Invoke(GITHUB_ORG, GITHUB_REPO, TEAM, "role", githubPat);
+            var args = new AddTeamToRepoCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                Team = TEAM,
+                Role = "role",
+                GithubPat = githubPat
+            };
+            await _command.Invoke(args);
 
             _mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
         }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ConfigureAutoLinkCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ConfigureAutoLinkCommandTests.cs
@@ -50,7 +50,14 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                       .ReturnsAsync(new List<(int Id, string KeyPrefix, string UrlTemplate)>());
             _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>())).Returns(_mockGithubApi.Object);
 
-            await _command.Invoke(GITHUB_ORG, GITHUB_REPO, ADO_ORG, ADO_TEAM_PROJECT);
+            var args = new ConfigureAutoLinkCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+            };
+            await _command.Invoke(args);
 
             _mockGithubApi.Verify(x => x.DeleteAutoLink(GITHUB_ORG, GITHUB_REPO, 1), Times.Never);
             _mockGithubApi.Verify(x => x.AddAutoLink(GITHUB_ORG, GITHUB_REPO, KEY_PREFIX, URL_TEMPLATE));
@@ -65,7 +72,15 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 .ReturnsAsync(new List<(int Id, string KeyPrefix, string UrlTemplate)>());
             _mockGithubApiFactory.Setup(m => m.Create(It.IsAny<string>(), githubPat)).Returns(_mockGithubApi.Object);
 
-            await _command.Invoke("githubOrg", "githubRepo", "adoOrg", "adoTeamProject", githubPat);
+            var args = new ConfigureAutoLinkCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                GithubPat = githubPat,
+            };
+            await _command.Invoke(args);
 
             _mockGithubApiFactory.Verify(m => m.Create(null, githubPat));
         }
@@ -84,7 +99,14 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
             _mockOctoLogger.Setup(m => m.LogSuccess(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
 
-            await _command.Invoke(GITHUB_ORG, GITHUB_REPO, ADO_ORG, ADO_TEAM_PROJECT);
+            var args = new ConfigureAutoLinkCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+            };
+            await _command.Invoke(args);
 
             _mockGithubApi.Verify(x => x.DeleteAutoLink(GITHUB_ORG, GITHUB_REPO, 1), Times.Never);
             _mockGithubApi.Verify(x => x.AddAutoLink(GITHUB_ORG, GITHUB_REPO, KEY_PREFIX, URL_TEMPLATE), Times.Never);
@@ -105,7 +127,14 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
             _mockOctoLogger.Setup(m => m.LogSuccess(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
 
-            await _command.Invoke(GITHUB_ORG, GITHUB_REPO, ADO_ORG, ADO_TEAM_PROJECT);
+            var args = new ConfigureAutoLinkCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+            };
+            await _command.Invoke(args);
 
             _mockGithubApi.Verify(x => x.DeleteAutoLink(GITHUB_ORG, GITHUB_REPO, 1));
             _mockGithubApi.Verify(x => x.AddAutoLink(GITHUB_ORG, GITHUB_REPO, KEY_PREFIX, URL_TEMPLATE));

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/DisableRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/DisableRepoCommandTests.cs
@@ -49,7 +49,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockAdoApi.Setup(x => x.GetRepos(ADO_ORG, ADO_TEAM_PROJECT).Result).Returns(repos);
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO);
+            var args = new DisableRepoCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                AdoRepo = ADO_REPO
+            };
+            await _command.Invoke(args);
 
             _mockAdoApi.Verify(x => x.DisableRepo(ADO_ORG, ADO_TEAM_PROJECT, REPO_ID));
         }
@@ -62,7 +68,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockAdoApi.Setup(x => x.GetRepos(ADO_ORG, ADO_TEAM_PROJECT).Result).Returns(repos);
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO);
+            var args = new DisableRepoCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                AdoRepo = ADO_REPO
+            };
+            await _command.Invoke(args);
 
             _mockAdoApi.Verify(x => x.DisableRepo(ADO_ORG, ADO_TEAM_PROJECT, REPO_ID), Times.Never);
         }
@@ -76,7 +88,14 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockAdoApi.Setup(x => x.GetRepos(It.IsAny<string>(), It.IsAny<string>()).Result).Returns(repos);
             _mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke("adoOrg", "adoTeamProject", ADO_REPO, adoPat);
+            var args = new DisableRepoCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                AdoRepo = ADO_REPO,
+                AdoPat = adoPat
+            };
+            await _command.Invoke(args);
 
             _mockAdoApiFactory.Verify(m => m.Create(adoPat));
         }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/IntegrateBoardsCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/IntegrateBoardsCommandTests.cs
@@ -66,7 +66,14 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke(ADO_ORG, ADO_TEAM_PROJECT, GITHUB_ORG, GITHUB_REPO);
+            var args = new IntegrateBoardsCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+            };
+            await _command.Invoke(args);
 
             _mockAdoApi.Verify(x => x.CreateBoardsGithubConnection(ADO_ORG, ADO_TEAM_PROJECT, ENDPOINT_ID, NEW_REPO_ID));
         }
@@ -87,7 +94,14 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke(ADO_ORG, ADO_TEAM_PROJECT, GITHUB_ORG, GITHUB_REPO);
+            var args = new IntegrateBoardsCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+            };
+            await _command.Invoke(args);
 
             _mockAdoApi.Verify(x => x.CreateBoardsGithubEndpoint(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             _mockAdoApi.Verify(x => x.AddRepoToBoardsGithubConnection(ADO_ORG, ADO_TEAM_PROJECT, CONNECTION_ID, CONNECTION_NAME, ENDPOINT_ID, Moq.It.Is<IEnumerable<string>>(x => x.Contains(repoIds[0]) &&
@@ -111,7 +125,14 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke(ADO_ORG, ADO_TEAM_PROJECT, GITHUB_ORG, GITHUB_REPO);
+            var args = new IntegrateBoardsCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+            };
+            await _command.Invoke(args);
 
             _mockAdoApi.Verify(x => x.CreateBoardsGithubEndpoint(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             _mockAdoApi.Verify(x => x.AddRepoToBoardsGithubConnection(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()), Times.Never);
@@ -129,7 +150,16 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke("adoOrg", "adoTeamProject", "githubOrg", "githubRepo", adoPat, githubPat);
+            var args = new IntegrateBoardsCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                AdoPat = adoPat,
+                GithubPat = githubPat,
+            };
+            await _command.Invoke(args);
 
             _mockAdoApiFactory.Verify(m => m.Create(adoPat));
             _mockEnvironmentVariableProvider.Verify(m => m.GithubPersonalAccessToken(), Times.Never);
@@ -147,7 +177,15 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke("adoOrg", "adoTeamProject", "githubOrg", "githubRepo", adoPat);
+            var args = new IntegrateBoardsCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                AdoPat = adoPat,
+            };
+            await _command.Invoke(args);
 
             _mockAdoApiFactory.Verify(m => m.Create(adoPat));
             _mockEnvironmentVariableProvider.Verify(m => m.GithubPersonalAccessToken(), Times.Once);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReportCommandTests.cs
@@ -94,7 +94,8 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockReposCsvGenerator.Setup(m => m.Generate(null, false)).ReturnsAsync(expectedReposCsv);
             _mockPipelinesCsvGenerator.Setup(m => m.Generate(null)).ReturnsAsync(expectedPipelinesCsv);
 
-            await _command.Invoke(null);
+            var args = new InventoryReportCommandArgs();
+            await _command.Invoke(args);
 
             _orgsCsvOutput.Should().Be(expectedOrgsCsv);
             _teamProjectsCsvOutput.Should().Be(expectedTeamProjectsCsv);
@@ -117,7 +118,11 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockReposCsvGenerator.Setup(m => m.Generate(null, false)).ReturnsAsync(expectedReposCsv);
             _mockPipelinesCsvGenerator.Setup(m => m.Generate(null)).ReturnsAsync(expectedPipelinesCsv);
 
-            await _command.Invoke(ADO_ORG);
+            var args = new InventoryReportCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+            };
+            await _command.Invoke(args);
 
             _orgsCsvOutput.Should().Be(expectedOrgsCsv);
             _teamProjectsCsvOutput.Should().Be(expectedTeamProjectsCsv);
@@ -133,7 +138,12 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             const string adoPat = "ado-pat";
             _mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke("some org", adoPat);
+            var args = new InventoryReportCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoPat = adoPat,
+            };
+            await _command.Invoke(args);
 
             _mockAdoApiFactory.Verify(m => m.Create(adoPat));
             _mockOrgsCsvGenerator.Verify(m => m.Generate(adoPat, It.IsAny<bool>()));
@@ -159,7 +169,11 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             _mockPipelinesCsvGenerator.Setup(m => m.Generate(null)).ReturnsAsync(expectedPipelinesCsv);
 
             // Act
-            await _command.Invoke(null, minimal: true);
+            var args = new InventoryReportCommandArgs
+            {
+                Minimal = true,
+            };
+            await _command.Invoke(args);
 
             // Assert
             _orgsCsvOutput.Should().Be(expectedOrgsCsv);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/LockRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/LockRepoCommandTests.cs
@@ -50,7 +50,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO);
+            var args = new LockRepoCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                AdoRepo = ADO_REPO
+            };
+            await _command.Invoke(args);
 
             _mockAdoApi.Verify(x => x.LockRepo(ADO_ORG, TEAM_PROJECT_ID, REPO_ID, IDENTITY_DESCRIPTOR));
         }
@@ -62,7 +68,14 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke("adoOrg", "adoTeamProject", "adoRepo", adoPat);
+            var args = new LockRepoCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                AdoRepo = ADO_REPO,
+                AdoPat = adoPat
+            };
+            await _command.Invoke(args);
 
             _mockAdoApiFactory.Verify(m => m.Create(adoPat));
         }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepoCommandTests.cs
@@ -98,7 +98,16 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             };
 
             // Act
-            await _command.Invoke(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO, GITHUB_ORG, GITHUB_REPO, wait: false);
+            var args = new MigrateRepoCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                AdoRepo = ADO_REPO,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                Wait = false,
+            };
+            await _command.Invoke(args);
 
             // Assert
             _mockGithubApi.Verify(m => m.GetOrganizationId(GITHUB_ORG));
@@ -148,7 +157,16 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
             var expectedLogOutput = $"The Org '{GITHUB_ORG}' already contains a repository with the name '{GITHUB_REPO}'. No operation will be performed";
 
             // Act
-            await _command.Invoke(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO, GITHUB_ORG, GITHUB_REPO, wait: false);
+            var args = new MigrateRepoCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                AdoRepo = ADO_REPO,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                Wait = false,
+            };
+            await _command.Invoke(args);
 
             // Assert
             _mockOctoLogger.Verify(m => m.LogWarning(It.IsAny<string>()), Times.Exactly(1));
@@ -184,7 +202,16 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 .Setup(m => m.AdoPersonalAccessToken())
                 .Returns(ADO_TOKEN);
 
-            await _command.Invoke(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO, GITHUB_ORG, GITHUB_REPO, wait: true);
+            var args = new MigrateRepoCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                AdoRepo = ADO_REPO,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                Wait = true,
+            };
+            await _command.Invoke(args);
 
             _mockGithubApi.Verify(x => x.GetMigration(MIGRATION_ID));
         }
@@ -202,7 +229,18 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 .Setup(m => m.AdoPersonalAccessToken())
                 .Returns(ADO_TOKEN);
 
-            await _command.Invoke(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO, GITHUB_ORG, GITHUB_REPO, wait: true, adoPat: ADO_TOKEN, githubPat: GITHUB_TOKEN);
+            var args = new MigrateRepoCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                AdoRepo = ADO_REPO,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                Wait = true,
+                AdoPat = ADO_TOKEN,
+                GithubPat = GITHUB_TOKEN,
+            };
+            await _command.Invoke(args);
 
             _mockGithubApiFactory.Verify(m => m.Create(null, GITHUB_TOKEN));
             _mockEnvironmentVariableProvider.Verify(m => m.AdoPersonalAccessToken(), Times.Never);
@@ -223,7 +261,16 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
                 .Setup(m => m.AdoPersonalAccessToken())
                 .Returns(ADO_TOKEN);
 
-            await _command.Invoke(ADO_ORG, ADO_TEAM_PROJECT, ADO_REPO, GITHUB_ORG, GITHUB_REPO, wait: true);
+            var args = new MigrateRepoCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                AdoRepo = ADO_REPO,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                Wait = true,
+            };
+            await _command.Invoke(args);
 
             _mockGithubApiFactory.Verify(m => m.Create(null, GITHUB_TOKEN));
             _mockEnvironmentVariableProvider.Verify(m => m.AdoPersonalAccessToken());

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ShareServiceConnectionCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ShareServiceConnectionCommandTests.cs
@@ -15,6 +15,11 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
         private readonly ShareServiceConnectionCommand _command;
 
+        private const string ADO_ORG = "FooOrg";
+        private const string ADO_TEAM_PROJECT = "BlahTeamProject";
+        private readonly string SERVICE_CONNECTION_ID = Guid.NewGuid().ToString();
+        private readonly string TEAM_PROJECT_ID = Guid.NewGuid().ToString();
+
         public ShareServiceConnectionCommandTests()
         {
             _command = new ShareServiceConnectionCommand(_mockOctoLogger.Object, _mockAdoApiFactory.Object);
@@ -37,35 +42,37 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         [Fact]
         public async Task Happy_Path()
         {
-            var adoOrg = "FooOrg";
-            var adoTeamProject = "BlahTeamProject";
-            var serviceConnectionId = Guid.NewGuid().ToString();
-            var teamProjectId = Guid.NewGuid().ToString();
-
-            _mockAdoApi.Setup(x => x.GetTeamProjectId(adoOrg, adoTeamProject).Result).Returns(teamProjectId);
-            _mockAdoApi.Setup(x => x.ContainsServiceConnection(adoOrg, adoTeamProject, serviceConnectionId).Result).Returns(false);
+            _mockAdoApi.Setup(x => x.GetTeamProjectId(ADO_ORG, ADO_TEAM_PROJECT).Result).Returns(TEAM_PROJECT_ID);
+            _mockAdoApi.Setup(x => x.ContainsServiceConnection(ADO_ORG, ADO_TEAM_PROJECT, SERVICE_CONNECTION_ID).Result).Returns(false);
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke(adoOrg, adoTeamProject, serviceConnectionId);
+            var args = new ShareServiceConnectionCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                ServiceConnectionId = SERVICE_CONNECTION_ID,
+            };
+            await _command.Invoke(args);
 
-            _mockAdoApi.Verify(x => x.ShareServiceConnection(adoOrg, adoTeamProject, teamProjectId, serviceConnectionId));
+            _mockAdoApi.Verify(x => x.ShareServiceConnection(ADO_ORG, ADO_TEAM_PROJECT, TEAM_PROJECT_ID, SERVICE_CONNECTION_ID));
         }
 
         [Fact]
         public async Task It_Skips_When_Already_Shared()
         {
-            var adoOrg = "FooOrg";
-            var adoTeamProject = "BlahTeamProject";
-            var serviceConnectionId = Guid.NewGuid().ToString();
-            var teamProjectId = Guid.NewGuid().ToString();
-
-            _mockAdoApi.Setup(x => x.GetTeamProjectId(adoOrg, adoTeamProject).Result).Returns(teamProjectId);
-            _mockAdoApi.Setup(x => x.ContainsServiceConnection(adoOrg, adoTeamProject, serviceConnectionId).Result).Returns(true);
+            _mockAdoApi.Setup(x => x.GetTeamProjectId(ADO_ORG, ADO_TEAM_PROJECT).Result).Returns(TEAM_PROJECT_ID);
+            _mockAdoApi.Setup(x => x.ContainsServiceConnection(ADO_ORG, ADO_TEAM_PROJECT, SERVICE_CONNECTION_ID).Result).Returns(true);
             _mockAdoApiFactory.Setup(m => m.Create(null)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke(adoOrg, adoTeamProject, serviceConnectionId);
+            var args = new ShareServiceConnectionCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                ServiceConnectionId = SERVICE_CONNECTION_ID,
+            };
+            await _command.Invoke(args);
 
-            _mockAdoApi.Verify(x => x.ShareServiceConnection(adoOrg, adoTeamProject, teamProjectId, serviceConnectionId), Times.Never);
+            _mockAdoApi.Verify(x => x.ShareServiceConnection(ADO_ORG, ADO_TEAM_PROJECT, TEAM_PROJECT_ID, SERVICE_CONNECTION_ID), Times.Never);
         }
 
         [Fact]
@@ -75,7 +82,14 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
 
             _mockAdoApiFactory.Setup(m => m.Create(adoPat)).Returns(_mockAdoApi.Object);
 
-            await _command.Invoke("adoOrg", "adoTeamProject", "serviceConnectionId", adoPat);
+            var args = new ShareServiceConnectionCommandArgs
+            {
+                AdoOrg = ADO_ORG,
+                AdoTeamProject = ADO_TEAM_PROJECT,
+                ServiceConnectionId = SERVICE_CONNECTION_ID,
+                AdoPat = adoPat,
+            };
+            await _command.Invoke(args);
 
             _mockAdoApiFactory.Verify(m => m.Create(adoPat));
         }

--- a/src/ado2gh/Commands/AddTeamToRepoCommand.cs
+++ b/src/ado2gh/Commands/AddTeamToRepoCommand.cs
@@ -52,28 +52,43 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(githubPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<AddTeamToRepoCommandArgs>(Invoke);
         }
 
-        public async Task Invoke(string githubOrg, string githubRepo, string team, string role, string githubPat = null, bool verbose = false)
+        public async Task Invoke(AddTeamToRepoCommandArgs args)
         {
-            _log.Verbose = verbose;
+            if (args is null)
+            {
+                throw new ArgumentNullException(nameof(args));
+            }
+
+            _log.Verbose = args.Verbose;
 
             _log.LogInformation("Adding team to repo...");
-            _log.LogInformation($"GITHUB ORG: {githubOrg}");
-            _log.LogInformation($"GITHUB REPO: {githubRepo}");
-            _log.LogInformation($"TEAM: {team}");
-            _log.LogInformation($"ROLE: {role}");
-            if (githubPat is not null)
+            _log.LogInformation($"GITHUB ORG: {args.GithubOrg}");
+            _log.LogInformation($"GITHUB REPO: {args.GithubRepo}");
+            _log.LogInformation($"TEAM: {args.Team}");
+            _log.LogInformation($"ROLE: {args.Role}");
+            if (args.GithubPat is not null)
             {
                 _log.LogInformation("GITHUB PAT: ***");
             }
 
-            var github = _githubApiFactory.Create(targetPersonalAccessToken: githubPat);
-            var teamSlug = await github.GetTeamSlug(githubOrg, team);
-            await github.AddTeamToRepo(githubOrg, githubRepo, teamSlug, role);
+            var github = _githubApiFactory.Create(targetPersonalAccessToken: args.GithubPat);
+            var teamSlug = await github.GetTeamSlug(args.GithubOrg, args.Team);
+            await github.AddTeamToRepo(args.GithubOrg, args.GithubRepo, teamSlug, args.Role);
 
             _log.LogSuccess("Successfully added team to repo");
         }
+    }
+
+    public class AddTeamToRepoCommandArgs
+    {
+        public string GithubOrg { get; set; }
+        public string GithubRepo { get; set; }
+        public string Team { get; set; }
+        public string Role { get; set; }
+        public string GithubPat { get; set; }
+        public bool Verbose { get; set; }
     }
 }

--- a/src/ado2gh/Commands/LockRepoCommand.cs
+++ b/src/ado2gh/Commands/LockRepoCommand.cs
@@ -55,7 +55,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             {
                 throw new ArgumentNullException(nameof(args));
             }
-            
+
             _log.Verbose = args.Verbose;
 
             _log.LogInformation("Locking repo...");

--- a/src/ado2gh/Commands/MigrateRepoCommand.cs
+++ b/src/ado2gh/Commands/MigrateRepoCommand.cs
@@ -72,59 +72,64 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(githubPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, string, bool, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<MigrateRepoCommandArgs>(Invoke);
         }
 
-        public async Task Invoke(string adoOrg, string adoTeamProject, string adoRepo, string githubOrg, string githubRepo, bool wait = false, string adoPat = null, string githubPat = null, bool verbose = false)
+        public async Task Invoke(MigrateRepoCommandArgs args)
         {
-            _log.Verbose = verbose;
+            if (args is null)
+            {
+                throw new ArgumentNullException(nameof(args));
+            }
+
+            _log.Verbose = args.Verbose;
 
             _log.LogInformation("Migrating Repo...");
-            _log.LogInformation($"ADO ORG: {adoOrg}");
-            _log.LogInformation($"ADO TEAM PROJECT: {adoTeamProject}");
-            _log.LogInformation($"ADO REPO: {adoRepo}");
-            _log.LogInformation($"GITHUB ORG: {githubOrg}");
-            _log.LogInformation($"GITHUB REPO: {githubRepo}");
-            if (wait)
+            _log.LogInformation($"ADO ORG: {args.AdoOrg}");
+            _log.LogInformation($"ADO TEAM PROJECT: {args.AdoTeamProject}");
+            _log.LogInformation($"ADO REPO: {args.AdoRepo}");
+            _log.LogInformation($"GITHUB ORG: {args.GithubOrg}");
+            _log.LogInformation($"GITHUB REPO: {args.GithubRepo}");
+            if (args.Wait)
             {
                 _log.LogInformation("WAIT: true");
             }
-            if (adoPat is not null)
+            if (args.AdoPat is not null)
             {
                 _log.LogInformation("ADO PAT: ***");
             }
-            if (githubPat is not null)
+            if (args.GithubPat is not null)
             {
                 _log.LogInformation("GITHUB PAT: ***");
             }
 
-            githubPat ??= _environmentVariableProvider.GithubPersonalAccessToken();
-            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: githubPat);
+            args.GithubPat ??= _environmentVariableProvider.GithubPersonalAccessToken();
+            var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: args.GithubPat);
 
-            var adoRepoUrl = GetAdoRepoUrl(adoOrg, adoTeamProject, adoRepo);
+            var adoRepoUrl = GetAdoRepoUrl(args.AdoOrg, args.AdoTeamProject, args.AdoRepo);
 
-            adoPat ??= _environmentVariableProvider.AdoPersonalAccessToken();
-            var githubOrgId = await githubApi.GetOrganizationId(githubOrg);
+            args.AdoPat ??= _environmentVariableProvider.AdoPersonalAccessToken();
+            var githubOrgId = await githubApi.GetOrganizationId(args.GithubOrg);
             var migrationSourceId = await githubApi.CreateAdoMigrationSource(githubOrgId, null);
 
             string migrationId;
 
             try
             {
-                migrationId = await githubApi.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, githubRepo, adoPat, githubPat);
+                migrationId = await githubApi.StartMigration(migrationSourceId, adoRepoUrl, githubOrgId, args.GithubRepo, args.AdoPat, args.GithubPat);
             }
             catch (OctoshiftCliException ex)
             {
-                if (ex.Message == $"A repository called {githubOrg}/{githubRepo} already exists")
+                if (ex.Message == $"A repository called {args.GithubOrg}/{args.GithubRepo} already exists")
                 {
-                    _log.LogWarning($"The Org '{githubOrg}' already contains a repository with the name '{githubRepo}'. No operation will be performed");
+                    _log.LogWarning($"The Org '{args.GithubOrg}' already contains a repository with the name '{args.GithubRepo}'. No operation will be performed");
                     return;
                 }
 
                 throw;
             }
 
-            if (!wait)
+            if (!args.Wait)
             {
                 _log.LogInformation($"A repository migration (ID: {migrationId}) was successfully queued.");
                 return;
@@ -149,5 +154,18 @@ namespace OctoshiftCLI.AdoToGithub.Commands
         }
 
         private string GetAdoRepoUrl(string org, string project, string repo) => $"https://dev.azure.com/{org}/{project}/_git/{repo}".Replace(" ", "%20");
+    }
+
+    public class MigrateRepoCommandArgs
+    {
+        public string AdoOrg { get; set; }
+        public string AdoTeamProject { get; set; }
+        public string AdoRepo { get; set; }
+        public string GithubOrg { get; set; }
+        public string GithubRepo { get; set; }
+        public bool Wait { get; set; }
+        public string AdoPat { get; set; }
+        public string GithubPat { get; set; }
+        public bool Verbose { get; set; }
     }
 }

--- a/src/ado2gh/Commands/ShareServiceConnectionCommand.cs
+++ b/src/ado2gh/Commands/ShareServiceConnectionCommand.cs
@@ -46,35 +46,49 @@ namespace OctoshiftCLI.AdoToGithub.Commands
             AddOption(adoPat);
             AddOption(verbose);
 
-            Handler = CommandHandler.Create<string, string, string, string, bool>(Invoke);
+            Handler = CommandHandler.Create<ShareServiceConnectionCommandArgs>(Invoke);
         }
 
-        public async Task Invoke(string adoOrg, string adoTeamProject, string serviceConnectionId, string adoPat = null, bool verbose = false)
+        public async Task Invoke(ShareServiceConnectionCommandArgs args)
         {
-            _log.Verbose = verbose;
+            if (args is null)
+            {
+                throw new ArgumentNullException(nameof(args));
+            }
+
+            _log.Verbose = args.Verbose;
 
             _log.LogInformation("Sharing Service Connection...");
-            _log.LogInformation($"ADO ORG: {adoOrg}");
-            _log.LogInformation($"ADO TEAM PROJECT: {adoTeamProject}");
-            _log.LogInformation($"SERVICE CONNECTION ID: {serviceConnectionId}");
-            if (adoPat is not null)
+            _log.LogInformation($"ADO ORG: {args.AdoOrg}");
+            _log.LogInformation($"ADO TEAM PROJECT: {args.AdoTeamProject}");
+            _log.LogInformation($"SERVICE CONNECTION ID: {args.ServiceConnectionId}");
+            if (args.AdoPat is not null)
             {
                 _log.LogInformation("ADO PAT: ***");
             }
 
-            var ado = _adoApiFactory.Create(adoPat);
+            var ado = _adoApiFactory.Create(args.AdoPat);
 
-            var adoTeamProjectId = await ado.GetTeamProjectId(adoOrg, adoTeamProject);
+            var adoTeamProjectId = await ado.GetTeamProjectId(args.AdoOrg, args.AdoTeamProject);
 
-            if (await ado.ContainsServiceConnection(adoOrg, adoTeamProject, serviceConnectionId))
+            if (await ado.ContainsServiceConnection(args.AdoOrg, args.AdoTeamProject, args.ServiceConnectionId))
             {
                 _log.LogInformation("Service connection already shared with team project");
                 return;
             }
 
-            await ado.ShareServiceConnection(adoOrg, adoTeamProject, adoTeamProjectId, serviceConnectionId);
+            await ado.ShareServiceConnection(args.AdoOrg, args.AdoTeamProject, adoTeamProjectId, args.ServiceConnectionId);
 
             _log.LogSuccess("Successfully shared service connection");
         }
+    }
+
+    public class ShareServiceConnectionCommandArgs
+    {
+        public string AdoOrg { get; set; }
+        public string AdoTeamProject { get; set; }
+        public string ServiceConnectionId { get; set; }
+        public string AdoPat { get; set; }
+        public bool Verbose { get; set; }
     }
 }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->
This is part of the refactor to upgrade System.CommandLine. This is step 1 of the incremental refactor plan: getting all our commands to consistently use an Args class to capture all arguments.

This applies the refactoring to all the ado2gh commands (but not the common commands from Octoshift).

Part of #637 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->