### PR TITLE
Retries for Integration Test setup

### DIFF
--- a/src/Octoshift/RetryPolicy.cs
+++ b/src/Octoshift/RetryPolicy.cs
@@ -21,7 +21,7 @@ namespace OctoshiftCLI
             var policy = Policy.Handle(filter)
                                .WaitAndRetryAsync(5, retry => retry * TimeSpan.FromMilliseconds(_httpRetryInterval), (ex, _) =>
                                {
-                                   _log.LogVerbose($"Call failed with HTTP {((HttpRequestException)ex).StatusCode}, retrying...");
+                                   _log?.LogVerbose($"Call failed with HTTP {((HttpRequestException)ex).StatusCode}, retrying...");
                                });
 
             return await policy.ExecuteAsync(func);
@@ -32,10 +32,21 @@ namespace OctoshiftCLI
             var policy = Policy.HandleResult(resultFilter)
                                .WaitAndRetryAsync(5, retry => retry * TimeSpan.FromMilliseconds(_retryOnResultInterval), (_, _) =>
                                {
-                                   _log.LogVerbose(retryLogMessage ?? "Retrying...");
+                                   _log?.LogVerbose(retryLogMessage ?? "Retrying...");
                                });
 
             return await policy.ExecuteAndCaptureAsync(func);
+        }
+
+        public async Task Retry(Func<Task> func)
+        {
+            var policy = Policy.Handle<Exception>()
+                               .WaitAndRetryAsync(5, retry => retry * TimeSpan.FromMilliseconds(_retryOnResultInterval), (_, _) =>
+                               {
+                                   _log?.LogVerbose("Retrying...");
+                               });
+
+            await policy.ExecuteAsync(func);
         }
     }
 }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Closes #634 

Adds retry logic when calling `ResetAdoTestEnvironment()` or `ResetGithubTestEnvironment()`

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->