### PR TITLE
Retry if removing a team member fails

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - 6 months ago in [v0.10](https://github.com/github/gh-gei/releases/tag/v0.10), we deprecated the --ssh flag, making it silently do nothing. Now, we’ve removed the flag entirely, so the CLI will error if you try to specify it. If you have any scripts that include the --ssh flag, you must remove that flag or the script will break.
 - If `create-team` fails when linking an IdP group with an HTTP 400, we will retry
+- If `create-team` fails when removing the initial team member, it will retry

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -104,7 +104,7 @@ namespace OctoshiftCLI
         {
             var url = $"{_apiUrl}/orgs/{org}/teams/{teamSlug}/memberships/{member}";
 
-            await _client.DeleteAsync(url);
+            await _retryPolicy.HttpRetry(() => _client.DeleteAsync(url), _ => true);
         }
 
         public virtual async Task AddTeamSync(string org, string teamName, string groupId, string groupName, string groupDesc)

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -329,6 +329,27 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task RemoveTeamMember_Retries_On_Exception()
+        {
+            // Arrange
+            const string teamName = "TEAM_NAME";
+            const string member = "MEMBER";
+
+            var url = $"https://api.github.com/orgs/{GITHUB_ORG}/teams/{teamName}/memberships/{member}";
+
+            _githubClientMock.SetupSequence(m => m.DeleteAsync(url, null))
+                             .ThrowsAsync(new HttpRequestException(null, null, HttpStatusCode.BadGateway))
+                             .ReturnsAsync(string.Empty);
+
+            // Act
+            var githubApi = new GithubApi(_githubClientMock.Object, API_URL, _retryPolicy);
+            await githubApi.RemoveTeamMember(GITHUB_ORG, teamName, member);
+
+            // Assert
+            _githubClientMock.Verify(m => m.DeleteAsync(url, null), Times.Exactly(2));
+        }
+
+        [Fact]
         public async Task AddTeamSync_Calls_The_Right_Endpoint_With_Payload()
         {
             // Arrange


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->
Closes #420 

If `RemoveTeamMember` fails for any reason retry it.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->