### PR TITLE
Speed up unit tests

### DIFF
--- a/src/Octoshift/RetryPolicy.cs
+++ b/src/Octoshift/RetryPolicy.cs
@@ -8,7 +8,7 @@ namespace OctoshiftCLI
     public class RetryPolicy
     {
         private readonly OctoLogger _log;
-        internal readonly int _httpRetryInterval = 1000;
+        internal int _httpRetryInterval = 1000;
         internal int _retryOnResultInterval = 4000;
 
         public RetryPolicy(OctoLogger log)

--- a/src/OctoshiftCLI.Tests/AdoClientTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoClientTests.cs
@@ -35,7 +35,10 @@ namespace OctoshiftCLI.Tests
                 Content = new StringContent(EXPECTED_RESPONSE_CONTENT)
             };
 
-            _retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            _retryPolicy = new RetryPolicy(_mockOctoLogger.Object)
+            {
+                _httpRetryInterval = 0
+            };
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -17,7 +17,7 @@ namespace OctoshiftCLI.Tests
     public class GithubApiTests
     {
         private const string API_URL = "https://api.github.com";
-        private readonly RetryPolicy _retryPolicy = new(TestHelpers.CreateMock<OctoLogger>().Object);
+        private readonly RetryPolicy _retryPolicy = new(TestHelpers.CreateMock<OctoLogger>().Object) { _httpRetryInterval = 0 };
         private readonly Mock<GithubClient> _githubClientMock = TestHelpers.CreateMock<GithubClient>();
 
         private readonly GithubApi _githubApi;

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -36,7 +36,10 @@ namespace OctoshiftCLI.Tests
                 Content = new StringContent(EXPECTED_RESPONSE_CONTENT)
             };
 
-            _retryPolicy = new RetryPolicy(_mockOctoLogger.Object);
+            _retryPolicy = new RetryPolicy(_mockOctoLogger.Object)
+            {
+                _httpRetryInterval = 0
+            };
         }
 
         public void Dispose()
@@ -221,7 +224,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             var now = DateTimeOffset.Now.ToUnixTimeSeconds();
-            var retryAt = now + 10;
+            var retryAt = now + 1;
 
             _dateTimeProvider.Setup(m => m.CurrentUnixTimeSeconds()).Returns(now);
 
@@ -263,7 +266,7 @@ namespace OctoshiftCLI.Tests
             await githubClient.GetAsync("http://example.com"); // normal call
 
             // Assert
-            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 10 seconds before continuing"), Times.Once);
+            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 1 seconds before continuing"), Times.Once);
         }
 
         [Fact]
@@ -271,7 +274,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             var now = DateTimeOffset.Now.ToUnixTimeSeconds();
-            var retryAt = now + 10;
+            var retryAt = now + 1;
 
             _dateTimeProvider.Setup(m => m.CurrentUnixTimeSeconds()).Returns(now);
 
@@ -312,7 +315,7 @@ namespace OctoshiftCLI.Tests
             await githubClient.GetAsync("http://example.com"); // call with delay and retry
 
             // Assert
-            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 10 seconds before continuing"), Times.Once);
+            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 1 seconds before continuing"), Times.Once);
         }
 
         [Fact]
@@ -334,7 +337,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             var now = DateTimeOffset.Now.ToUnixTimeSeconds();
-            var retryAt = now + 10;
+            var retryAt = now + 1;
 
             _dateTimeProvider.Setup(m => m.CurrentUnixTimeSeconds()).Returns(now);
 
@@ -376,7 +379,7 @@ namespace OctoshiftCLI.Tests
             await githubClient.PostAsync("http://example.com", "hello"); // normal call
 
             // Assert
-            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 10 seconds before continuing"), Times.Once);
+            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 1 seconds before continuing"), Times.Once);
         }
 
         [Fact]
@@ -384,7 +387,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             var now = DateTimeOffset.Now.ToUnixTimeSeconds();
-            var retryAt = now + 10;
+            var retryAt = now + 1;
 
             _dateTimeProvider.Setup(m => m.CurrentUnixTimeSeconds()).Returns(now);
 
@@ -425,7 +428,7 @@ namespace OctoshiftCLI.Tests
             var result = await githubClient.PostAsync("http://example.com", "hello"); // call with retry delay
 
             // Assert
-            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 10 seconds before continuing"), Times.Once);
+            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 1 seconds before continuing"), Times.Once);
             result.Should().Be("THIRD_RESPONSE");
         }
 
@@ -572,7 +575,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             var now = DateTimeOffset.Now.ToUnixTimeSeconds();
-            var retryAt = now + 10;
+            var retryAt = now + 1;
 
             _dateTimeProvider.Setup(m => m.CurrentUnixTimeSeconds()).Returns(now);
 
@@ -614,7 +617,7 @@ namespace OctoshiftCLI.Tests
             await githubClient.PutAsync("http://example.com", "hello"); // normal call
 
             // Assert
-            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 10 seconds before continuing"), Times.Once);
+            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 1 seconds before continuing"), Times.Once);
         }
 
         [Fact]
@@ -760,7 +763,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             var now = DateTimeOffset.Now.ToUnixTimeSeconds();
-            var retryAt = now + 10;
+            var retryAt = now + 1;
 
             _dateTimeProvider.Setup(m => m.CurrentUnixTimeSeconds()).Returns(now);
 
@@ -802,7 +805,7 @@ namespace OctoshiftCLI.Tests
             await githubClient.PatchAsync("http://example.com", "hello"); // normal call
 
             // Assert
-            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 10 seconds before continuing"), Times.Once);
+            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 1 seconds before continuing"), Times.Once);
         }
 
         [Fact]
@@ -934,7 +937,7 @@ namespace OctoshiftCLI.Tests
         {
             // Arrange
             var now = DateTimeOffset.Now.ToUnixTimeSeconds();
-            var retryAt = now + 10;
+            var retryAt = now + 1;
 
             _dateTimeProvider.Setup(m => m.CurrentUnixTimeSeconds()).Returns(now);
 
@@ -976,7 +979,7 @@ namespace OctoshiftCLI.Tests
             await githubClient.DeleteAsync("http://example.com"); // normal call
 
             // Assert
-            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 10 seconds before continuing"), Times.Once);
+            _mockOctoLogger.Verify(m => m.LogWarning("GitHub rate limit exceeded. Waiting 1 seconds before continuing"), Times.Once);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/Octoshift/Handlers/WaitForMigrationCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Handlers/WaitForMigrationCommandHandlerTests.cs
@@ -20,7 +20,7 @@ public class WaitForMigrationCommandHandlerTests
     private const string REPO_MIGRATION_ID = "RM_MIGRATION_ID";
     private const string ORG_MIGRATION_ID = "OM_MIGRATION_ID";
     private const string TARGET_REPO = "TARGET_REPO";
-    private const int WAIT_INTERVAL = 1;
+    private const int WAIT_INTERVAL = 0;
 
     public WaitForMigrationCommandHandlerTests()
     {


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Improved unit test performance from 2.4 minutes to 26 seconds.

We had a bunch of unit tests that we're doing retries with up to 10 seconds wait times between retries. I changed it to be 0 wait time where possible, and 1 second wait in a couple places where 0 wouldn't work.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->