### PR TITLE
Add GHES support to Grant/Revoke Migrator Role commands

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,3 +3,4 @@
 - If `create-team` fails when linking an IdP group with an HTTP 400, we will retry
 - If `create-team` fails when removing the initial team member, it will retry
 - In v0.25 we started publishing `ado2gh` as an extension to the `gh` CLI. However, we didn't update `ado2gh generate-script` to use the new syntax in the generated migration script. Now it will, and you will need the `gh ado2gh` extension installed in order to run the generated migration script.
+- Added `-ghes-api-url` as an optional arg to the `grant-migrator-role` and `revoke-migrator-role` commands.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,4 +3,4 @@
 - If `create-team` fails when linking an IdP group with an HTTP 400, we will retry
 - If `create-team` fails when removing the initial team member, it will retry
 - In v0.25 we started publishing `ado2gh` as an extension to the `gh` CLI. However, we didn't update `ado2gh generate-script` to use the new syntax in the generated migration script. Now it will, and you will need the `gh ado2gh` extension installed in order to run the generated migration script.
-- Added `-ghes-api-url` as an optional arg to the `grant-migrator-role` and `revoke-migrator-role` commands.
+- Added `--ghes-api-url` as an optional arg to the `grant-migrator-role` and `revoke-migrator-role` commands for both `ado2gh` and `gei`.

--- a/src/Octoshift/Commands/GrantMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/GrantMigratorRoleCommandBase.cs
@@ -25,7 +25,7 @@ public class GrantMigratorRoleCommandBase : Command
 
     protected virtual Option<bool> Verbose { get; } = new("--verbose") { IsRequired = false };
 
-    protected virtual Option<string> GhesApiUrl { get; } = new("--ghes-api-url") { IsRequired = false};
+    protected virtual Option<string> GhesApiUrl { get; } = new("--ghes-api-url") { IsRequired = false };
 
     protected void AddOptions()
     {

--- a/src/Octoshift/Commands/GrantMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/GrantMigratorRoleCommandBase.cs
@@ -25,6 +25,8 @@ public class GrantMigratorRoleCommandBase : Command
 
     protected virtual Option<bool> Verbose { get; } = new("--verbose") { IsRequired = false };
 
+    protected virtual Option<string> GhesApiUrl { get; } = new("--ghes-api-url") { IsRequired = false};
+
     protected void AddOptions()
     {
         AddOption(GithubOrg);
@@ -32,6 +34,7 @@ public class GrantMigratorRoleCommandBase : Command
         AddOption(ActorType);
         AddOption(GithubPat);
         AddOption(Verbose);
+        AddOption(GhesApiUrl);
     }
 }
 
@@ -42,4 +45,5 @@ public class GrantMigratorRoleCommandArgs
     public string ActorType { get; set; }
     public string GithubPat { get; set; }
     public bool Verbose { get; set; }
+    public string GhesApiUrl { get; set; }
 }

--- a/src/Octoshift/Commands/RevokeMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/RevokeMigratorRoleCommandBase.cs
@@ -45,5 +45,5 @@ public class RevokeMigratorRoleArgs
     public string ActorType { get; set; }
     public string GithubPat { get; set; }
     public bool Verbose { get; set; }
-    public string GhesApiUrl{ get; set; }
+    public string GhesApiUrl { get; set; }
 }

--- a/src/Octoshift/Commands/RevokeMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/RevokeMigratorRoleCommandBase.cs
@@ -25,6 +25,8 @@ public class RevokeMigratorRoleCommandBase : Command
 
     protected virtual Option<bool> Verbose { get; } = new("--verbose") { IsRequired = false };
 
+    protected virtual Option<string> GhesApiUrl { get; } = new("--ghes-api-url") { IsRequired = false };
+
     protected void AddOptions()
     {
         AddOption(GithubOrg);
@@ -32,6 +34,7 @@ public class RevokeMigratorRoleCommandBase : Command
         AddOption(ActorType);
         AddOption(GithubPat);
         AddOption(Verbose);
+        AddOption(GhesApiUrl);
     }
 }
 
@@ -42,4 +45,5 @@ public class RevokeMigratorRoleArgs
     public string ActorType { get; set; }
     public string GithubPat { get; set; }
     public bool Verbose { get; set; }
+    public string GhesApiUrl{ get; set; }
 }

--- a/src/Octoshift/Handlers/GrantMigratorRoleCommandHandler.cs
+++ b/src/Octoshift/Handlers/GrantMigratorRoleCommandHandler.cs
@@ -42,6 +42,11 @@ public class GrantMigratorRoleCommandHandler
             return;
         }
 
+        if (args.GhesApiUrl is not null)
+        {
+            _log.LogInformation($"GHES API URL: {args.GhesApiUrl}");
+        }
+
         if (args.GithubPat is not null)
         {
             _log.LogInformation($"GITHUB PAT: ***");

--- a/src/Octoshift/Handlers/GrantMigratorRoleCommandHandler.cs
+++ b/src/Octoshift/Handlers/GrantMigratorRoleCommandHandler.cs
@@ -49,7 +49,7 @@ public class GrantMigratorRoleCommandHandler
 
         _log.RegisterSecret(args.GithubPat);
 
-        var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: args.GithubPat);
+        var githubApi = _githubApiFactory.Create(args.GhesApiUrl, args.GithubPat);
         var githubOrgId = await githubApi.GetOrganizationId(args.GithubOrg);
         var success = await githubApi.GrantMigratorRole(githubOrgId, args.Actor, args.ActorType);
 

--- a/src/Octoshift/Handlers/RevokeMigratorRoleCommandHandler.cs
+++ b/src/Octoshift/Handlers/RevokeMigratorRoleCommandHandler.cs
@@ -29,6 +29,11 @@ public class RevokeMigratorRoleCommandHandler
         _log.LogInformation($"GITHUB ORG: {args.GithubOrg}");
         _log.LogInformation($"ACTOR: {args.Actor}");
 
+        if (args.GhesApiUrl is not null)
+        {
+            _log.LogInformation($"GHES API URL: {args.GhesApiUrl}");
+        }
+
         if (args.GithubPat is not null)
         {
             _log.LogInformation($"GITHUB PAT: ***");

--- a/src/Octoshift/Handlers/RevokeMigratorRoleCommandHandler.cs
+++ b/src/Octoshift/Handlers/RevokeMigratorRoleCommandHandler.cs
@@ -51,7 +51,7 @@ public class RevokeMigratorRoleCommandHandler
 
         _log.RegisterSecret(args.GithubPat);
 
-        var githubApi = _githubApiFactory.Create(targetPersonalAccessToken: args.GithubPat);
+        var githubApi = _githubApiFactory.Create(args.GhesApiUrl, args.GithubPat);
         var githubOrgId = await githubApi.GetOrganizationId(args.GithubOrg);
         var success = await githubApi.RevokeMigratorRole(githubOrgId, args.Actor, args.ActorType);
 

--- a/src/OctoshiftCLI.Tests/Octoshift/Handlers/GrantMigratorRoleCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Handlers/GrantMigratorRoleCommandHandlerTests.cs
@@ -74,4 +74,23 @@ public class GrantMigratorRoleCommandHandlerTests
         };
         await _handler.Handle(args);
     }
+
+    [Fact]
+    public async Task It_Uses_The_GhesApiUrl_When_Provided()
+    {
+        const string ghesApiUrl = "GHES-API-URL";
+
+        _mockGithubApiFactory.Setup(x => x.Create(ghesApiUrl, It.IsAny<string>())).Returns(_mockGithubApi.Object);
+
+        var args = new GrantMigratorRoleCommandArgs
+        {
+            GithubOrg = GITHUB_ORG,
+            Actor = ACTOR,
+            ActorType = ACTOR_TYPE,
+            GhesApiUrl = ghesApiUrl
+        };
+        await _handler.Handle(args);
+
+        _mockGithubApiFactory.Verify(m => m.Create(ghesApiUrl, null));
+    }
 }

--- a/src/OctoshiftCLI.Tests/Octoshift/Handlers/RevokeMigratorRoleCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Handlers/RevokeMigratorRoleCommandHandlerTests.cs
@@ -74,4 +74,24 @@ public class RevokeMigratorRoleCommandHandlerTests
         };
         await _handler.Handle(args);
     }
+
+    [Fact]
+    public async Task It_Uses_The_GhesApiUrl_When_Provided()
+    {
+        const string ghesApiUrl = "GhesApiUrl";
+
+        _mockGithubApiFactory.Setup(m => m.Create(ghesApiUrl, It.IsAny<string>())).Returns(_mockGithubApi.Object);
+
+        var args = new RevokeMigratorRoleArgs
+        {
+            GithubOrg = GITHUB_ORG,
+            Actor = ACTOR,
+            ActorType = ACTOR_TYPE,
+            GhesApiUrl = ghesApiUrl,
+        };
+        await _handler.Handle(args);
+
+        _mockGithubApiFactory.Verify(m => m.Create(ghesApiUrl, null));
+    }
+
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRoleCommandTests.cs
@@ -11,12 +11,13 @@ public class GrantMigratorRoleCommandTests
         var command = new GrantMigratorRoleCommand(null, null);
         Assert.NotNull(command);
         Assert.Equal("grant-migrator-role", command.Name);
-        Assert.Equal(5, command.Options.Count);
+        Assert.Equal(6, command.Options.Count);
 
         TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "actor", true);
         TestHelpers.VerifyCommandOption(command.Options, "actor-type", true);
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
         TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+        TestHelpers.VerifyCommandOption(command.Options, "ghes-api-url", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/RevokeMigratorRoleCommandTests.cs
@@ -11,12 +11,13 @@ public class RevokeMigratorRoleCommandTests
         var command = new RevokeMigratorRoleCommand(null, null);
         Assert.NotNull(command);
         Assert.Equal("revoke-migrator-role", command.Name);
-        Assert.Equal(5, command.Options.Count);
+        Assert.Equal(6, command.Options.Count);
 
         TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "actor", true);
         TestHelpers.VerifyCommandOption(command.Options, "actor-type", true);
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
         TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+        TestHelpers.VerifyCommandOption(command.Options, "ghes-api-url", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRoleCommandTests.cs
@@ -11,12 +11,13 @@ public class GrantMigratorRoleCommandTests
         var command = new GrantMigratorRoleCommand(null, null);
         Assert.NotNull(command);
         Assert.Equal("grant-migrator-role", command.Name);
-        Assert.Equal(5, command.Options.Count);
+        Assert.Equal(6, command.Options.Count);
 
         TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "actor", true);
         TestHelpers.VerifyCommandOption(command.Options, "actor-type", true);
         TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
         TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+        TestHelpers.VerifyCommandOption(command.Options, "ghes-api-url", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/RevokeMigratorRoleCommandTests.cs
@@ -11,12 +11,13 @@ public class RevokeMigratorRoleCommandTests
         var command = new RevokeMigratorRoleCommand(null, null);
         Assert.NotNull(command);
         Assert.Equal("revoke-migrator-role", command.Name);
-        Assert.Equal(5, command.Options.Count);
+        Assert.Equal(6, command.Options.Count);
 
         TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "actor", true);
         TestHelpers.VerifyCommandOption(command.Options, "actor-type", true);
         TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
         TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+        TestHelpers.VerifyCommandOption(command.Options, "ghes-api-url", false);
     }
 }

--- a/src/gei/Commands/GrantMigratorRoleCommand.cs
+++ b/src/gei/Commands/GrantMigratorRoleCommand.cs
@@ -27,7 +27,8 @@ public sealed class GrantMigratorRoleCommand : GrantMigratorRoleCommandBase
             Actor = args.Actor,
             ActorType = args.ActorType,
             GithubPat = args.GithubTargetPat,
-            Verbose = args.Verbose
+            Verbose = args.Verbose,
+            GhesApiUrl = args.GhesApiUrl
         });
 }
 
@@ -38,4 +39,5 @@ public class GrantMigratorRoleCommandArgs
     public string ActorType { get; set; }
     public string GithubTargetPat { get; set; }
     public bool Verbose { get; set; }
+    public string GhesApiUrl { get; set; }
 }

--- a/src/gei/Commands/RevokeMigratorRoleCommand.cs
+++ b/src/gei/Commands/RevokeMigratorRoleCommand.cs
@@ -27,7 +27,8 @@ public sealed class RevokeMigratorRoleCommand : RevokeMigratorRoleCommandBase
         Actor = args.Actor,
         ActorType = args.ActorType,
         GithubPat = args.GithubTargetPat,
-        Verbose = args.Verbose
+        Verbose = args.Verbose,
+        GhesApiUrl = args.GhesApiUrl
     });
 }
 
@@ -38,4 +39,5 @@ public class RevokeMigratorRoleArgs
     public string ActorType { get; set; }
     public string GithubTargetPat { get; set; }
     public bool Verbose { get; set; }
+    public string GhesApiUrl { get; set; }
 }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->
Closes #600 

This PR adds the ability to specify a GHES API Url to the `GrantMigratorRole` and `RevokeMigratorRole` commands via the `--ghes-api-url` flag.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->