### PR TITLE
Support non default bbs shared home directory

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,4 +4,4 @@
 - If `create-team` fails when removing the initial team member, it will retry
 - In v0.25 we started publishing `ado2gh` as an extension to the `gh` CLI. However, we didn't update `ado2gh generate-script` to use the new syntax in the generated migration script. Now it will, and you will need the `gh ado2gh` extension installed in order to run the generated migration script.
 - Added `--ghes-api-url` as an optional arg to the `grant-migrator-role` and `revoke-migrator-role` commands for both `ado2gh` and `gei`.
-- Added `--bbs-shared-home` option to `migrate-repo` and `generate-script` commands for `bbs2gh`.
+- Added `--bbs-shared-home` option to `migrate-repo` and `generate-script` commands for `bbs2gh`. This provides support for BBS servers with a non default directory path.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,3 +4,4 @@
 - If `create-team` fails when removing the initial team member, it will retry
 - In v0.25 we started publishing `ado2gh` as an extension to the `gh` CLI. However, we didn't update `ado2gh generate-script` to use the new syntax in the generated migration script. Now it will, and you will need the `gh ado2gh` extension installed in order to run the generated migration script.
 - Added `--ghes-api-url` as an optional arg to the `grant-migrator-role` and `revoke-migrator-role` commands for both `ado2gh` and `gei`.
+- Added `--bbs-shared-home` option to `migrate-repo` and `generate-script` commands for `bbs2gh`.

--- a/src/.idea/.idea.OctoshiftCLI/.idea/vcs.xml
+++ b/src/.idea/.idea.OctoshiftCLI/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/src/Octoshift/Commands/CommandBase.cs
+++ b/src/Octoshift/Commands/CommandBase.cs
@@ -1,5 +1,5 @@
+using System;
 using System.CommandLine;
-using Microsoft.Extensions.DependencyInjection;
 using OctoshiftCLI.Handlers;
 
 namespace OctoshiftCLI.Commands;
@@ -8,5 +8,5 @@ public abstract class CommandBase<TArgs, THandler> : Command where TArgs : class
 {
     protected CommandBase(string name, string description = null) : base(name, description) { }
 
-    public abstract THandler BuildHandler(TArgs args, ServiceProvider sp);
+    public abstract THandler BuildHandler(TArgs args, IServiceProvider sp);
 }

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
@@ -2,7 +2,6 @@ using FluentAssertions;
 using OctoshiftCLI.BbsToGithub.Commands;
 using Xunit;
 
-
 namespace OctoshiftCLI.Tests.BbsToGithub.Commands;
 
 public class GenerateScriptCommandTests
@@ -13,12 +12,13 @@ public class GenerateScriptCommandTests
         var command = new GenerateScriptCommand();
         command.Should().NotBeNull();
         command.Name.Should().Be("generate-script");
-        command.Options.Count.Should().Be(9);
+        command.Options.Count.Should().Be(10);
 
         TestHelpers.VerifyCommandOption(command.Options, "bbs-server-url", true);
         TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "bbs-username", false);
         TestHelpers.VerifyCommandOption(command.Options, "bbs-password", false);
+        TestHelpers.VerifyCommandOption(command.Options, "bbs-shared-home", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-user", true);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-private-key", true);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-port", false);

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
@@ -1,37 +1,171 @@
+using System;
 using FluentAssertions;
+using Moq;
+using OctoshiftCLI.BbsToGithub;
 using OctoshiftCLI.BbsToGithub.Commands;
 using Xunit;
 
-namespace OctoshiftCLI.Tests.BbsToGithub.Commands
-{
-    public class MigrateRepoCommandTests
-    {
-        [Fact]
-        public void Should_Have_Options()
-        {
-            var command = new MigrateRepoCommand();
-            command.Should().NotBeNull();
-            command.Name.Should().Be("migrate-repo");
-            command.Options.Count.Should().Be(18);
+namespace OctoshiftCLI.Tests.BbsToGithub.Commands;
 
-            TestHelpers.VerifyCommandOption(command.Options, "bbs-server-url", false);
-            TestHelpers.VerifyCommandOption(command.Options, "bbs-project", false);
-            TestHelpers.VerifyCommandOption(command.Options, "bbs-repo", false);
-            TestHelpers.VerifyCommandOption(command.Options, "bbs-username", false);
-            TestHelpers.VerifyCommandOption(command.Options, "bbs-password", false);
-            TestHelpers.VerifyCommandOption(command.Options, "archive-url", false);
-            TestHelpers.VerifyCommandOption(command.Options, "archive-path", false);
-            TestHelpers.VerifyCommandOption(command.Options, "azure-storage-connection-string", false);
-            TestHelpers.VerifyCommandOption(command.Options, "github-org", false);
-            TestHelpers.VerifyCommandOption(command.Options, "github-repo", false);
-            TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
-            TestHelpers.VerifyCommandOption(command.Options, "ssh-user", false);
-            TestHelpers.VerifyCommandOption(command.Options, "ssh-private-key", false);
-            TestHelpers.VerifyCommandOption(command.Options, "ssh-port", false);
-            TestHelpers.VerifyCommandOption(command.Options, "smb-user", false, true);
-            TestHelpers.VerifyCommandOption(command.Options, "smb-password", false, true);
-            TestHelpers.VerifyCommandOption(command.Options, "wait", false);
-            TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
-        }
+public class MigrateRepoCommandTests
+{
+    private const string SSH_USER = "ssh-user";
+    private const string SSH_PRIVATE_KEY = "ssh-private-key";
+    private const int SSH_PORT = 1234;
+    private const string BBS_SHARED_HOME = "shared-home";
+    private const string BBS_HOST = "bbs-host";
+    private const string BBS_SERVER_URL = $"https://{BBS_HOST}";
+    private const string GITHUB_ORG = "github-org";
+    private const string GITHUB_PAT = "github-pat";
+    private const string BBS_USERNAME = "bbs-username";
+    private const string BBS_PASSWORD = "bbs-password";
+    private const string AZURE_STORAGE_CONNECTION_STRING = "azure-storage-connection-string";
+
+    private Mock<IServiceProvider> _mockServiceProvider = new();
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+    private readonly Mock<EnvironmentVariableProvider> _mockEnvironmentVariableProvider = TestHelpers.CreateMock<EnvironmentVariableProvider>();
+    private readonly Mock<FileSystemProvider> _mockFileSystemProvider = TestHelpers.CreateMock<FileSystemProvider>();
+    private readonly Mock<GithubApiFactory> _mockGithubApiFactory = TestHelpers.CreateMock<GithubApiFactory>();
+    private readonly Mock<BbsApiFactory> _mockBbsApiFactory = TestHelpers.CreateMock<BbsApiFactory>();
+    private readonly Mock<BbsArchiveDownloaderFactory> _mockBbsArchiveDownloaderFactory = TestHelpers.CreateMock<BbsArchiveDownloaderFactory>();
+    private readonly Mock<IAzureApiFactory> _mockAzureApiFactory = new();
+
+    private readonly MigrateRepoCommand _command = new();
+
+    public MigrateRepoCommandTests()
+    {
+        _mockServiceProvider.Setup(m => m.GetService(typeof(OctoLogger))).Returns(_mockOctoLogger.Object);
+        _mockServiceProvider.Setup(m => m.GetService(typeof(EnvironmentVariableProvider))).Returns(_mockEnvironmentVariableProvider.Object);
+        _mockServiceProvider.Setup(m => m.GetService(typeof(FileSystemProvider))).Returns(_mockFileSystemProvider.Object);
+        _mockServiceProvider.Setup(m => m.GetService(typeof(GithubApiFactory))).Returns(_mockGithubApiFactory.Object);
+        _mockServiceProvider.Setup(m => m.GetService(typeof(BbsApiFactory))).Returns(_mockBbsApiFactory.Object);
+        _mockServiceProvider.Setup(m => m.GetService(typeof(BbsArchiveDownloaderFactory))).Returns(_mockBbsArchiveDownloaderFactory.Object);
+        _mockServiceProvider.Setup(m => m.GetService(typeof(IAzureApiFactory))).Returns(_mockAzureApiFactory.Object);
+    }
+    
+    [Fact]
+    public void Should_Have_Options()
+    {
+        _command.Should().NotBeNull();
+        _command.Name.Should().Be("migrate-repo");
+        _command.Options.Count.Should().Be(19);
+
+        TestHelpers.VerifyCommandOption(_command.Options, "bbs-server-url", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "bbs-project", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "bbs-repo", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "bbs-username", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "bbs-password", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "bbs-shared-home", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "archive-url", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "archive-path", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "azure-storage-connection-string", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "github-org", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "github-repo", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "github-pat", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "ssh-user", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "ssh-private-key", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "ssh-port", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "smb-user", false, true);
+        TestHelpers.VerifyCommandOption(_command.Options, "smb-password", false, true);
+        TestHelpers.VerifyCommandOption(_command.Options, "wait", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
+    }
+
+    [Fact]
+    public void BuildHandler_Creates_Bbs_Ssh_Archive_Downloader_When_Ssh_User_Is_Provided()
+    {
+        // Arrange
+        var args = new MigrateRepoCommandArgs
+        {
+            SshUser = SSH_USER,
+            SshPrivateKey = SSH_PRIVATE_KEY,
+            SshPort = SSH_PORT,
+            BbsSharedHome = BBS_SHARED_HOME,
+            BbsServerUrl = BBS_SERVER_URL
+        };
+        
+        // Act
+        var handler = _command.BuildHandler(args, _mockServiceProvider.Object);
+        
+        // Assert
+        handler.Should().NotBeNull();
+        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSshDownloader(BBS_HOST, SSH_USER, SSH_PRIVATE_KEY, SSH_PORT, BBS_SHARED_HOME));
+    }
+
+    [Fact]
+    public void BuildHandler_Creates_The_Handler()
+    {
+        // Arrange
+        var args = new MigrateRepoCommandArgs();
+        
+        // Act
+        var handler = _command.BuildHandler(args, _mockServiceProvider.Object);
+        
+        // Assert
+        handler.Should().NotBeNull();
+
+        _mockGithubApiFactory.Verify(m => m.Create(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _mockBbsApiFactory.Verify(m => m.Create(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSshDownloader(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSmbDownloader(), Times.Never);
+        _mockAzureApiFactory.Verify(m => m.Create(It.IsAny<string>()), Times.Never);
+        _mockAzureApiFactory.Verify(m => m.CreateClientNoSsl(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void BuildHandler_Creates_GitHub_Api_When_Github_Org_Is_Provided()
+    {
+        // Arrange
+        var args = new MigrateRepoCommandArgs
+        {
+            GithubOrg = GITHUB_ORG,
+            GithubPat = GITHUB_PAT 
+        };
+        
+        // Act
+        var handler = _command.BuildHandler(args, _mockServiceProvider.Object);
+        
+        // Assert
+        handler.Should().NotBeNull();
+
+        _mockGithubApiFactory.Verify(m => m.Create(null, GITHUB_PAT));
+    }
+
+    [Fact]
+    public void BuildHandler_Creates_Bbs_Api_When_Github_Org_Is_Provided()
+    {
+        // Arrange
+        var args = new MigrateRepoCommandArgs
+        {
+            BbsServerUrl = BBS_SERVER_URL,
+            BbsUsername = BBS_USERNAME,
+            BbsPassword = BBS_PASSWORD
+        };
+        
+        // Act
+        var handler = _command.BuildHandler(args, _mockServiceProvider.Object);
+        
+        // Assert
+        handler.Should().NotBeNull();
+
+        _mockBbsApiFactory.Verify(m => m.Create(BBS_SERVER_URL, BBS_USERNAME, BBS_PASSWORD));
+    }
+
+    [Fact]
+    public void BuildHandler_Creates_Azure_Api_Factory_When_Azure_Storage_Connection_String_Is_Provided()
+    {
+        // Arrange
+        var args = new MigrateRepoCommandArgs
+        {
+            AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING
+        };
+        
+        // Act
+        var handler = _command.BuildHandler(args, _mockServiceProvider.Object);
+        
+        // Assert
+        handler.Should().NotBeNull();
+
+        _mockAzureApiFactory.Verify(m => m.Create(AZURE_STORAGE_CONNECTION_STRING));
     }
 }

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
@@ -21,7 +21,7 @@ public class MigrateRepoCommandTests
     private const string BBS_PASSWORD = "bbs-password";
     private const string AZURE_STORAGE_CONNECTION_STRING = "azure-storage-connection-string";
 
-    private Mock<IServiceProvider> _mockServiceProvider = new();
+    private readonly Mock<IServiceProvider> _mockServiceProvider = new();
     private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
     private readonly Mock<EnvironmentVariableProvider> _mockEnvironmentVariableProvider = TestHelpers.CreateMock<EnvironmentVariableProvider>();
     private readonly Mock<FileSystemProvider> _mockFileSystemProvider = TestHelpers.CreateMock<FileSystemProvider>();
@@ -42,7 +42,7 @@ public class MigrateRepoCommandTests
         _mockServiceProvider.Setup(m => m.GetService(typeof(BbsArchiveDownloaderFactory))).Returns(_mockBbsArchiveDownloaderFactory.Object);
         _mockServiceProvider.Setup(m => m.GetService(typeof(IAzureApiFactory))).Returns(_mockAzureApiFactory.Object);
     }
-    
+
     [Fact]
     public void Should_Have_Options()
     {
@@ -83,10 +83,10 @@ public class MigrateRepoCommandTests
             BbsSharedHome = BBS_SHARED_HOME,
             BbsServerUrl = BBS_SERVER_URL
         };
-        
+
         // Act
         var handler = _command.BuildHandler(args, _mockServiceProvider.Object);
-        
+
         // Assert
         handler.Should().NotBeNull();
         _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSshDownloader(BBS_HOST, SSH_USER, SSH_PRIVATE_KEY, SSH_PORT, BBS_SHARED_HOME));
@@ -97,10 +97,10 @@ public class MigrateRepoCommandTests
     {
         // Arrange
         var args = new MigrateRepoCommandArgs();
-        
+
         // Act
         var handler = _command.BuildHandler(args, _mockServiceProvider.Object);
-        
+
         // Assert
         handler.Should().NotBeNull();
 
@@ -119,12 +119,12 @@ public class MigrateRepoCommandTests
         var args = new MigrateRepoCommandArgs
         {
             GithubOrg = GITHUB_ORG,
-            GithubPat = GITHUB_PAT 
+            GithubPat = GITHUB_PAT
         };
-        
+
         // Act
         var handler = _command.BuildHandler(args, _mockServiceProvider.Object);
-        
+
         // Assert
         handler.Should().NotBeNull();
 
@@ -141,10 +141,10 @@ public class MigrateRepoCommandTests
             BbsUsername = BBS_USERNAME,
             BbsPassword = BBS_PASSWORD
         };
-        
+
         // Act
         var handler = _command.BuildHandler(args, _mockServiceProvider.Object);
-        
+
         // Assert
         handler.Should().NotBeNull();
 
@@ -159,10 +159,10 @@ public class MigrateRepoCommandTests
         {
             AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING
         };
-        
+
         // Act
         var handler = _command.BuildHandler(args, _mockServiceProvider.Object);
-        
+
         // Assert
         handler.Should().NotBeNull();
 

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
@@ -44,6 +44,7 @@ public class GenerateScriptCommandHandlerTests
     private const string BBS_BAR_REPO_1_NAME = "BBS-BAR-REPO-1-NAME";
     private const string BBS_BAR_REPO_2_SLUG = "barrepo2";
     private const string BBS_BAR_REPO_2_NAME = "BBS-BAR-REPO-2-NAME";
+    private const string BBS_SHARED_HOME = "BBS-SHARED-HOME";
 
     public GenerateScriptCommandHandlerTests()
     {
@@ -121,10 +122,10 @@ public class GenerateScriptCommandHandlerTests
             (Id: 4, Slug: BBS_BAR_REPO_2_SLUG, Name: BBS_BAR_REPO_2_NAME)
         });
 
-        const string migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait }}";
-        const string migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait }}";
-        const string migrateRepoCommand3 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_1_SLUG}\" --verbose --wait }}";
-        const string migrateRepoCommand4 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_2_SLUG}\" --verbose --wait }}";
+        const string migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait }}";
+        const string migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait }}";
+        const string migrateRepoCommand3 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_1_SLUG}\" --verbose --wait }}";
+        const string migrateRepoCommand4 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_2_SLUG}\" --verbose --wait }}";
 
         // Act
         var args = new GenerateScriptCommandArgs
@@ -133,6 +134,7 @@ public class GenerateScriptCommandHandlerTests
             GithubOrg = GITHUB_ORG,
             BbsUsername = BBS_USERNAME,
             BbsPassword = BBS_PASSWORD,
+            BbsSharedHome = BBS_SHARED_HOME,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,

--- a/src/bbs2gh/BbsArchiveDownloaderFactory.cs
+++ b/src/bbs2gh/BbsArchiveDownloaderFactory.cs
@@ -1,6 +1,5 @@
 using System;
 using OctoshiftCLI.BbsToGithub.Services;
-using OctoshiftCLI.Extensions;
 
 namespace OctoshiftCLI.BbsToGithub;
 

--- a/src/bbs2gh/BbsArchiveDownloaderFactory.cs
+++ b/src/bbs2gh/BbsArchiveDownloaderFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using OctoshiftCLI.BbsToGithub.Services;
+using OctoshiftCLI.Extensions;
 
 namespace OctoshiftCLI.BbsToGithub;
 
@@ -14,8 +15,11 @@ public class BbsArchiveDownloaderFactory
         _fileSystemProvider = fileSystemProvider;
     }
 
-    public virtual IBbsArchiveDownloader CreateSshDownloader(string host, string sshUser, string privateKeyFileFullPath, int sshPort = 22) =>
-        new BbsSshArchiveDownloader(_log, _fileSystemProvider, host, sshUser, privateKeyFileFullPath, sshPort);
+    public virtual IBbsArchiveDownloader CreateSshDownloader(string host, string sshUser, string privateKeyFileFullPath, int sshPort = 22, string bbsSharedHomeDirectory = null) =>
+        new BbsSshArchiveDownloader(_log, _fileSystemProvider, host, sshUser, privateKeyFileFullPath, sshPort)
+        {
+            BbsSharedHomeDirectory = bbsSharedHomeDirectory ?? IBbsArchiveDownloader.DEFAULT_BBS_SHARED_HOME_DIRECTORY
+        };
 
     public virtual IBbsArchiveDownloader CreateSmbDownloader() => throw new NotImplementedException();
 }

--- a/src/bbs2gh/Commands/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScriptCommand.cs
@@ -64,7 +64,7 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
 
     public Option<bool> Verbose { get; } = new("--verbose");
 
-    public override GenerateScriptCommandHandler BuildHandler(GenerateScriptCommandArgs args, ServiceProvider sp)
+    public override GenerateScriptCommandHandler BuildHandler(GenerateScriptCommandArgs args, IServiceProvider sp)
     {
         if (args is null)
         {

--- a/src/bbs2gh/Commands/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScriptCommand.cs
@@ -47,7 +47,7 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
     public Option<string> BbsSharedHome { get; } = new(
         name: "--bbs-shared-home",
         description: "Bitbucket server's shared home directory. If not provided \"/var/atlassian/application-data/bitbucket/shared\" will be used.");
-    
+
     public Option<string> SshUser { get; } = new(
         name: "--ssh-user",
         description: "The SSH user to be used for downloading the export archive off of the Bitbucket server.")

--- a/src/bbs2gh/Commands/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScriptCommand.cs
@@ -18,6 +18,7 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
         AddOption(GithubOrg);
         AddOption(BbsUsername);
         AddOption(BbsPassword);
+        AddOption(BbsSharedHome);
         AddOption(SshUser);
         AddOption(SshPrivateKey);
         AddOption(SshPort);
@@ -43,6 +44,10 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
                       $"{Environment.NewLine}" +
                       "Note: The password will not get included in the generated script and it has to be set as an env variable before running the script.");
 
+    public Option<string> BbsSharedHome { get; } = new(
+        name: "--bbs-shared-home",
+        description: "Bitbucket server's shared home directory. If not provided \"/var/atlassian/application-data/bitbucket/shared\" will be used.");
+    
     public Option<string> SshUser { get; } = new(
         name: "--ssh-user",
         description: "The SSH user to be used for downloading the export archive off of the Bitbucket server.")
@@ -94,6 +99,7 @@ public class GenerateScriptCommandArgs
     public string GithubOrg { get; set; }
     public string BbsUsername { get; set; }
     public string BbsPassword { get; set; }
+    public string BbsSharedHome { get; set; }
     public string SshUser { get; set; }
     public string SshPrivateKey { get; set; }
     public string SshPort { get; set; }

--- a/src/bbs2gh/Commands/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepoCommand.cs
@@ -25,6 +25,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         AddOption(BbsRepo);
         AddOption(BbsUsername);
         AddOption(BbsPassword);
+        AddOption(BbsSharedHome);
         AddOption(SshUser);
         AddOption(SshPrivateKey);
         AddOption(SshPort);
@@ -34,7 +35,6 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         AddOption(AzureStorageConnectionString);
         AddOption(Wait);
         AddOption(Verbose);
-        AddOption(SharedHome);
     }
 
     public Option<string> BbsServerUrl { get; } = new(
@@ -56,6 +56,10 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
     public Option<string> BbsPassword { get; } = new(
         name: "--bbs-password",
         description: "The Bitbucket password of the user specified by --bbs-username. If not set will be read from BBS_PASSWORD environment variable.");
+
+    public Option<string> BbsSharedHome { get; } = new(
+        name: "--bbs-shared-home",
+        description: "Bitbucket server's shared home directory. If not provided \"/var/atlassian/application-data/bitbucket/shared\" will be used.");
 
     public Option<string> ArchiveUrl { get; } = new(
         name: "--archive-url",
@@ -117,11 +121,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
 
     public Option<bool> Verbose { get; } = new("--verbose");
 
-    public Option<string> SharedHome { get; } = new(
-        name: "--shared-home",
-        description: "Bitbucket server's shared home directory. If not provided \"/var/atlassian/application-data/bitbucket/shared\" will be used.");
-
-    public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, ServiceProvider sp)
+    public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, IServiceProvider sp)
     {
         if (args is null)
         {
@@ -157,7 +157,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         {
             var bbsArchiveDownloaderFactory = sp.GetRequiredService<BbsArchiveDownloaderFactory>();
             var bbsHost = new Uri(args.BbsServerUrl).Host;
-            bbsArchiveDownloader = bbsArchiveDownloaderFactory.CreateSshDownloader(bbsHost, args.SshUser, args.SshPrivateKey, args.SshPort, args.SharedHome);
+            bbsArchiveDownloader = bbsArchiveDownloaderFactory.CreateSshDownloader(bbsHost, args.SshUser, args.SshPrivateKey, args.SshPort, args.BbsSharedHome);
         }
 
         if (args.AzureStorageConnectionString.HasValue())
@@ -182,13 +182,13 @@ public class MigrateRepoCommandArgs
     public string GithubPat { get; set; }
     public bool Wait { get; set; }
     public bool Verbose { get; set; }
-    public string SharedHome { get; set; }
 
     public string BbsServerUrl { get; set; }
     public string BbsProject { get; set; }
     public string BbsRepo { get; set; }
     public string BbsUsername { get; set; }
     public string BbsPassword { get; set; }
+    public string BbsSharedHome { get; set; }
 
     public string SshUser { get; set; }
     public string SshPrivateKey { get; set; }

--- a/src/bbs2gh/Commands/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepoCommand.cs
@@ -34,6 +34,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         AddOption(AzureStorageConnectionString);
         AddOption(Wait);
         AddOption(Verbose);
+        AddOption(SharedHome);
     }
 
     public Option<string> BbsServerUrl { get; } = new(
@@ -116,6 +117,10 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
 
     public Option<bool> Verbose { get; } = new("--verbose");
 
+    public Option<string> SharedHome { get; } = new(
+        name: "--shared-home",
+        description: "Bitbucket server's shared home directory. If not provided \"/var/atlassian/application-data/bitbucket/shared\" will be used.");
+
     public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, ServiceProvider sp)
     {
         if (args is null)
@@ -152,7 +157,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         {
             var bbsArchiveDownloaderFactory = sp.GetRequiredService<BbsArchiveDownloaderFactory>();
             var bbsHost = new Uri(args.BbsServerUrl).Host;
-            bbsArchiveDownloader = bbsArchiveDownloaderFactory.CreateSshDownloader(bbsHost, args.SshUser, args.SshPrivateKey, args.SshPort);
+            bbsArchiveDownloader = bbsArchiveDownloaderFactory.CreateSshDownloader(bbsHost, args.SshUser, args.SshPrivateKey, args.SshPort, args.SharedHome);
         }
 
         if (args.AzureStorageConnectionString.HasValue())
@@ -177,6 +182,7 @@ public class MigrateRepoCommandArgs
     public string GithubPat { get; set; }
     public bool Wait { get; set; }
     public bool Verbose { get; set; }
+    public string SharedHome { get; set; }
 
     public string BbsServerUrl { get; set; }
     public string BbsProject { get; set; }

--- a/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
+++ b/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
@@ -104,8 +104,9 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         var archiveDownloadOptions = args.SshUser.HasValue()
             ? $" --ssh-user \"{args.SshUser}\" --ssh-private-key \"{args.SshPrivateKey}\"{(args.SshPort.HasValue() ? $" --ssh-port {args.SshPort}" : "")}"
             : "";
+        var bbsSharedHomeOption = args.BbsSharedHome.HasValue() ? $" --bbs-shared-home \"{args.BbsSharedHome}\"" : "";
 
-        return $"gh bbs2gh migrate-repo{bbsServerUrlOption}{bbsUsernameOption}{bbsProjectOption}{bbsRepoOption}{archiveDownloadOptions}{githubOrgOption}{githubRepoOption}{verboseOption}{waitOption}";
+        return $"gh bbs2gh migrate-repo{bbsServerUrlOption}{bbsUsernameOption}{bbsSharedHomeOption}{bbsProjectOption}{bbsRepoOption}{archiveDownloadOptions}{githubOrgOption}{githubRepoOption}{verboseOption}{waitOption}";
     }
 
     private string Exec(string script) => Wrap(script, "Exec");

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -254,6 +254,11 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         {
             _log.LogInformation("WAIT: true");
         }
+
+        if (args.SharedHome.HasValue())
+        {
+            _log.LogInformation($"SHARED HOME: {args.SharedHome}");
+        }
     }
 
     private void ValidateOptions(MigrateRepoCommandArgs args)

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -255,9 +255,9 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             _log.LogInformation("WAIT: true");
         }
 
-        if (args.SharedHome.HasValue())
+        if (args.BbsSharedHome.HasValue())
         {
-            _log.LogInformation($"SHARED HOME: {args.SharedHome}");
+            _log.LogInformation($"SHARED HOME: {args.BbsSharedHome}");
         }
     }
 

--- a/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
+++ b/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
@@ -8,7 +8,6 @@ namespace OctoshiftCLI.BbsToGithub.Services;
 public sealed class BbsSshArchiveDownloader : IBbsArchiveDownloader, IDisposable
 {
     private const int DOWNLOAD_PROGRESS_REPORT_INTERVAL_IN_SECONDS = 10;
-    private const string DEFAULT_BBS_SHARED_HOME_DIRECTORY = "/var/atlassian/application-data/bitbucket/shared";
     private const string EXPORT_ARCHIVE_SOURCE_DIRECTORY = "data/migration/export";
 
     private readonly ISftpClient _sftpClient;
@@ -31,7 +30,7 @@ public sealed class BbsSshArchiveDownloader : IBbsArchiveDownloader, IDisposable
         _sftpClient = sftpClient;
     }
 
-    public string BbsSharedHomeDirectory { get; init; } = DEFAULT_BBS_SHARED_HOME_DIRECTORY;
+    public string BbsSharedHomeDirectory { get; init; } = IBbsArchiveDownloader.DEFAULT_BBS_SHARED_HOME_DIRECTORY;
 
     public async Task<string> Download(long exportJobId, string targetDirectory = IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY)
     {

--- a/src/bbs2gh/Services/IBbsArchiveDownloader.cs
+++ b/src/bbs2gh/Services/IBbsArchiveDownloader.cs
@@ -4,6 +4,8 @@ namespace OctoshiftCLI.BbsToGithub.Services;
 
 public interface IBbsArchiveDownloader
 {
+    const string DEFAULT_BBS_SHARED_HOME_DIRECTORY = "/var/atlassian/application-data/bitbucket/shared";
+
     const string DEFAULT_TARGET_DIRECTORY = "bbs_archive_downloads";
 
     Task<string> Download(long exportJobId, string targetDirectory = DEFAULT_TARGET_DIRECTORY);


### PR DESCRIPTION
Closes https://github.com/github/octoshift/issues/5664

This PR adds `--bbs-shared-home` option to `bbs2gh migrate-repo` and `bbs2gh generate-script` commands. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)