### PR TITLE
Output information about the progress of org-to-org migrations as repos are migrated

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-- Added logging to `gh gei wait-for-migration`, showing the number of repos that have been migrated so far
+- Added logging to `gh gei wait-for-migration` and `gh gei migrate-org --wait`, showing the number of repos that have been migrated so far

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Added logging to `gh gei wait-for-migration`, showing the number of repos that have been migrated so far

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -375,12 +375,12 @@ namespace OctoshiftCLI
             return (string)data["data"]["startOrganizationMigration"]["orgMigration"]["id"];
         }
 
-        public virtual async Task<(string State, string SourceOrgUrl, string TargetOrgName, string FailureReason)> GetOrganizationMigration(string migrationId)
+        public virtual async Task<(string State, string SourceOrgUrl, string TargetOrgName, string FailureReason, int? RemainingRepositoriesCount, int? TotalRepositoriesCount)> GetOrganizationMigration(string migrationId)
         {
             var url = $"{_apiUrl}/graphql";
 
             var query = "query($id: ID!)";
-            var gql = "node(id: $id) { ... on OrganizationMigration { state, sourceOrgUrl, targetOrgName, failureReason } }";
+            var gql = "node(id: $id) { ... on OrganizationMigration { state, sourceOrgUrl, targetOrgName, failureReason, remainingRepositoriesCount, totalRepositoriesCount } }";
 
             var payload = new { query = $"{query} {{ {gql} }}", variables = new { id = migrationId } };
 
@@ -395,7 +395,9 @@ namespace OctoshiftCLI
                     State: (string)data["data"]["node"]["state"],
                     SourceOrgUrl: (string)data["data"]["node"]["sourceOrgUrl"],
                     TargetOrgName: (string)data["data"]["node"]["targetOrgName"],
-                    FailureReason: (string)data["data"]["node"]["failureReason"]);
+                    FailureReason: (string)data["data"]["node"]["failureReason"],
+                    RemainingRepositoriesCount: (int?)data["data"]["node"]["remainingRepositoriesCount"],
+                    TotalRepositoriesCount: (int?)data["data"]["node"]["totalRepositoriesCount"]);
             });
 
             return response.Outcome == OutcomeType.Failure

--- a/src/Octoshift/Handlers/WaitForMigrationCommandHandler.cs
+++ b/src/Octoshift/Handlers/WaitForMigrationCommandHandler.cs
@@ -76,15 +76,14 @@ public class WaitForMigrationCommandHandler : ICommandHandler<WaitForMigrationCo
                 throw new OctoshiftCliException($"Migration {migrationId} failed for {sourceOrgUrl} -> {targetOrgName}. Failure reason: {failureReason}");
             }
 
-            // TODO: Remove `== 0` condition once GraphQL API bug is fixed and we return `null` when count not computed
-            if (totalRepositoriesCount is 0 or null)
-            {
-                _log.LogInformation($"Migration {migrationId} is {state}");
-            }
-            else
+            if (OrganizationMigrationStatus.IsRepoMigration(state))
             {
                 var completedRepositoriesCount = (int)totalRepositoriesCount - (int)remainingRepositoriesCount;
                 _log.LogInformation($"Migration {migrationId} is {state} - {completedRepositoriesCount}/{totalRepositoriesCount} repositories completed");
+            }
+            else
+            {
+                _log.LogInformation($"Migration {migrationId} is {state}");
             }
             _log.LogInformation($"Waiting {WaitIntervalInSeconds} seconds...");
             await Task.Delay(WaitIntervalInSeconds * 1000);

--- a/src/Octoshift/OrganizationMigrationStatus.cs
+++ b/src/Octoshift/OrganizationMigrationStatus.cs
@@ -14,5 +14,6 @@ namespace OctoshiftCLI
         public static bool IsSucceeded(string migrationState) => migrationState?.Trim().ToUpper() is Succeeded;
         public static bool IsPending(string migrationState) => migrationState?.Trim().ToUpper() is Queued or InProgress or NotStarted or PostRepoMigration or PreRepoMigration or RepoMigration;
         public static bool IsFailed(string migrationState) => !(IsPending(migrationState) || IsSucceeded(migrationState));
+        public static bool IsRepoMigration(string migrationState) => migrationState?.Trim().ToUpper() is RepoMigration;
     }
 }

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -1170,7 +1170,7 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task GetOrganizationMigration_Returns_The_Migration_State_And_Org_URL_And_Name()
+        public async Task GetOrganizationMigration_Returns_The_Migration_State_And_Org_URL_And_Name_And_Progress_Information()
         {
             // Arrange
             const string migrationId = "MIGRATION_ID";
@@ -1178,9 +1178,11 @@ namespace OctoshiftCLI.Tests
             const string sourceOrgUrl = "https://github.com/import-testing";
 
             var payload =
-                "{\"query\":\"query($id: ID!) { node(id: $id) { ... on OrganizationMigration { state, sourceOrgUrl, targetOrgName, failureReason } } }\"" +
+                "{\"query\":\"query($id: ID!) { node(id: $id) { ... on OrganizationMigration { state, sourceOrgUrl, targetOrgName, failureReason, remainingRepositoriesCount, totalRepositoriesCount } } }\"" +
                 $",\"variables\":{{\"id\":\"{migrationId}\"}}}}";
             const string actualMigrationState = "SUCCEEDED";
+            const int actualRemainingRepositoriesCount = 0;
+            const int actualTotalRepositoriesCount = 9000;
             var response = $@"
             {{
                 ""data"": {{
@@ -1188,7 +1190,9 @@ namespace OctoshiftCLI.Tests
                         ""sourceOrgUrl"": ""{sourceOrgUrl}"",
                         ""state"": ""{actualMigrationState}"",
                         ""failureReason"": """",
-                        ""targetOrgName"": ""{TARGET_ORG}""
+                        ""targetOrgName"": ""{TARGET_ORG}"",
+                        ""remainingRepositoriesCount"": {actualRemainingRepositoriesCount},
+                        ""totalRepositoriesCount"": {actualTotalRepositoriesCount}
                     }}
                 }}
             }}";
@@ -1198,13 +1202,15 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var (expectedMigrationState, expectedSourceOrgUrl, expectedTargetOrgName, expectedFailureReason) = await _githubApi.GetOrganizationMigration(migrationId);
+            var (expectedMigrationState, expectedSourceOrgUrl, expectedTargetOrgName, expectedFailureReason, expectedRemainingRepositoriesCount, expectedTotalRepositoriesCount) = await _githubApi.GetOrganizationMigration(migrationId);
 
             // Assert
             expectedMigrationState.Should().Be(actualMigrationState);
             expectedSourceOrgUrl.Should().Be(sourceOrgUrl);
             expectedTargetOrgName.Should().Be(TARGET_ORG);
             expectedFailureReason.Should().BeEmpty();
+            expectedRemainingRepositoriesCount.Should().Be(actualRemainingRepositoriesCount);
+            expectedTotalRepositoriesCount.Should().Be(actualTotalRepositoriesCount);
         }
 
         [Fact]
@@ -1216,9 +1222,11 @@ namespace OctoshiftCLI.Tests
             const string sourceOrgUrl = "https://github.com/import-testing";
 
             var payload =
-                "{\"query\":\"query($id: ID!) { node(id: $id) { ... on OrganizationMigration { state, sourceOrgUrl, targetOrgName, failureReason } } }\"" +
+                "{\"query\":\"query($id: ID!) { node(id: $id) { ... on OrganizationMigration { state, sourceOrgUrl, targetOrgName, failureReason, remainingRepositoriesCount, totalRepositoriesCount } } }\"" +
                 $",\"variables\":{{\"id\":\"{migrationId}\"}}}}";
             const string actualMigrationState = "SUCCEEDED";
+            const int actualRemainingRepositoriesCount = 0;
+            const int actualTotalRepositoriesCount = 9000;
             var response = $@"
             {{
                 ""data"": {{
@@ -1226,7 +1234,9 @@ namespace OctoshiftCLI.Tests
                         ""sourceOrgUrl"": ""{sourceOrgUrl}"",
                         ""state"": ""{actualMigrationState}"",
                         ""failureReason"": """",
-                        ""targetOrgName"": ""{TARGET_ORG}""
+                        ""targetOrgName"": ""{TARGET_ORG}"",
+                        ""remainingRepositoriesCount"": {actualRemainingRepositoriesCount},
+                        ""totalRepositoriesCount"": {actualTotalRepositoriesCount}
                     }}
                 }}
             }}";
@@ -1238,7 +1248,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var (expectedMigrationState, _, _, _) = await _githubApi.GetOrganizationMigration(migrationId);
+            var (expectedMigrationState, _, _, _, _, _) = await _githubApi.GetOrganizationMigration(migrationId);
 
             // Assert
             expectedMigrationState.Should().Be(actualMigrationState);
@@ -1253,7 +1263,7 @@ namespace OctoshiftCLI.Tests
             const string sourceOrgUrl = "https://github.com/import-testing";
 
             var payload =
-                "{\"query\":\"query($id: ID!) { node(id: $id) { ... on OrganizationMigration { state, sourceOrgUrl, targetOrgName, failureReason } } }\"" +
+                "{\"query\":\"query($id: ID!) { node(id: $id) { ... on OrganizationMigration { state, sourceOrgUrl, targetOrgName, failureReason, remainingRepositoriesCount, totalRepositoriesCount } } }\"" +
                 $",\"variables\":{{\"id\":\"{migrationId}\"}}}}";
             const string actualMigrationState = "SUCCEEDED";
             var response = $@"
@@ -1275,7 +1285,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var (expectedMigrationState, _, _, _) = await _githubApi.GetOrganizationMigration(migrationId);
+            var (expectedMigrationState, _, _, _, _, _) = await _githubApi.GetOrganizationMigration(migrationId);
 
             // Assert
             expectedMigrationState.Should().Be(actualMigrationState);
@@ -1290,9 +1300,11 @@ namespace OctoshiftCLI.Tests
             const string sourceOrgUrl = "https://github.com/import-testing";
 
             var payload =
-                "{\"query\":\"query($id: ID!) { node(id: $id) { ... on OrganizationMigration { state, sourceOrgUrl, targetOrgName, failureReason } } }\"" +
+                "{\"query\":\"query($id: ID!) { node(id: $id) { ... on OrganizationMigration { state, sourceOrgUrl, targetOrgName, failureReason, remainingRepositoriesCount, totalRepositoriesCount } } }\"" +
                 $",\"variables\":{{\"id\":\"{migrationId}\"}}}}";
             const string actualFailureReason = "FAILURE_REASON";
+            const int actualRemainingRepositoriesCount = 9000;
+            const int actualTotalRepositoriesCount = 9000;
             var response = $@"
             {{
                 ""data"": {{
@@ -1300,7 +1312,9 @@ namespace OctoshiftCLI.Tests
                         ""sourceOrgUrl"": ""{sourceOrgUrl}"",
                         ""state"": ""FAILED"",
                         ""failureReason"": ""{actualFailureReason}"",
-                        ""targetOrgName"": ""{TARGET_ORG}""
+                        ""targetOrgName"": ""{TARGET_ORG}"",
+                        ""remainingRepositoriesCount"": {actualRemainingRepositoriesCount},
+                        ""totalRepositoriesCount"": {actualTotalRepositoriesCount}
                     }}
                 }}
             }}";
@@ -1310,7 +1324,7 @@ namespace OctoshiftCLI.Tests
                 .ReturnsAsync(response);
 
             // Act
-            var (_, _, _, expectedFailureReason) = await _githubApi.GetOrganizationMigration(migrationId);
+            var (_, _, _, expectedFailureReason, _, _) = await _githubApi.GetOrganizationMigration(migrationId);
 
             // Assert
             expectedFailureReason.Should().Be(actualFailureReason);

--- a/src/OctoshiftCLI.Tests/Octoshift/Handlers/WaitForMigrationCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Handlers/WaitForMigrationCommandHandlerTests.cs
@@ -171,9 +171,9 @@ public class WaitForMigrationCommandHandlerTests
         const string sourceOrgUrl = "some_url";
         const string targetOrgName = "TARGET_ORG";
         _mockGithubApi.SetupSequence(x => x.GetOrganizationMigration(ORG_MIGRATION_ID).Result)
-            .Returns((State: OrganizationMigrationStatus.InProgress, sourceOrgUrl, targetOrgName, FailureReason: null))
-            .Returns((State: OrganizationMigrationStatus.InProgress, sourceOrgUrl, targetOrgName, FailureReason: null))
-            .Returns((State: OrganizationMigrationStatus.Succeeded, sourceOrgUrl, targetOrgName, FailureReason: null));
+            .Returns((State: OrganizationMigrationStatus.InProgress, sourceOrgUrl, targetOrgName, FailureReason: null, 0, 0))
+            .Returns((State: OrganizationMigrationStatus.InProgress, sourceOrgUrl, targetOrgName, FailureReason: null, 1, 1))
+            .Returns((State: OrganizationMigrationStatus.Succeeded, sourceOrgUrl, targetOrgName, FailureReason: null, 0, 1));
 
         var actualLogOutput = new List<string>();
         _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
@@ -184,7 +184,7 @@ public class WaitForMigrationCommandHandlerTests
                 $"Waiting for {sourceOrgUrl} -> {targetOrgName} migration (ID: {ORG_MIGRATION_ID}) to finish...",
                 $"Migration {ORG_MIGRATION_ID} is {RepositoryMigrationStatus.InProgress}",
                 $"Waiting {WAIT_INTERVAL} seconds...",
-                $"Migration {ORG_MIGRATION_ID} is {RepositoryMigrationStatus.InProgress}",
+                $"Migration {ORG_MIGRATION_ID} is {RepositoryMigrationStatus.InProgress} - 0/1 repositories completed",
                 $"Waiting {WAIT_INTERVAL} seconds...",
                 $"Migration {ORG_MIGRATION_ID} succeeded"
             };
@@ -215,9 +215,9 @@ public class WaitForMigrationCommandHandlerTests
         const string sourceOrgUrl = "some_url";
         const string targetOrgName = "TARGET_ORG";
         _mockGithubApi.SetupSequence(x => x.GetOrganizationMigration(ORG_MIGRATION_ID).Result)
-            .Returns((State: OrganizationMigrationStatus.InProgress, sourceOrgUrl, targetOrgName, FailureReason: null))
-            .Returns((State: OrganizationMigrationStatus.InProgress, sourceOrgUrl, targetOrgName, FailureReason: null))
-            .Returns((State: OrganizationMigrationStatus.Failed, sourceOrgUrl, targetOrgName, failureReason));
+            .Returns((State: OrganizationMigrationStatus.InProgress, sourceOrgUrl, targetOrgName, FailureReason: null, 0, 0))
+            .Returns((State: OrganizationMigrationStatus.InProgress, sourceOrgUrl, targetOrgName, FailureReason: null, 1, 1))
+            .Returns((State: OrganizationMigrationStatus.Failed, sourceOrgUrl, targetOrgName, failureReason, 0, 1));
 
         var actualLogOutput = new List<string>();
         _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
@@ -228,7 +228,7 @@ public class WaitForMigrationCommandHandlerTests
                 $"Waiting for {sourceOrgUrl} -> {targetOrgName} migration (ID: {ORG_MIGRATION_ID}) to finish...",
                 $"Migration {ORG_MIGRATION_ID} is {RepositoryMigrationStatus.InProgress}",
                 $"Waiting {WAIT_INTERVAL} seconds...",
-                $"Migration {ORG_MIGRATION_ID} is {RepositoryMigrationStatus.InProgress}",
+                $"Migration {ORG_MIGRATION_ID} is {RepositoryMigrationStatus.InProgress} - 0/1 repositories completed",
                 $"Waiting {WAIT_INTERVAL} seconds..."
             };
 

--- a/src/OctoshiftCLI.Tests/Octoshift/Handlers/WaitForMigrationCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Handlers/WaitForMigrationCommandHandlerTests.cs
@@ -172,7 +172,7 @@ public class WaitForMigrationCommandHandlerTests
         const string targetOrgName = "TARGET_ORG";
         _mockGithubApi.SetupSequence(x => x.GetOrganizationMigration(ORG_MIGRATION_ID).Result)
             .Returns((State: OrganizationMigrationStatus.InProgress, sourceOrgUrl, targetOrgName, FailureReason: null, 0, 0))
-            .Returns((State: OrganizationMigrationStatus.InProgress, sourceOrgUrl, targetOrgName, FailureReason: null, 1, 1))
+            .Returns((State: OrganizationMigrationStatus.RepoMigration, sourceOrgUrl, targetOrgName, FailureReason: null, 1, 1))
             .Returns((State: OrganizationMigrationStatus.Succeeded, sourceOrgUrl, targetOrgName, FailureReason: null, 0, 1));
 
         var actualLogOutput = new List<string>();
@@ -182,9 +182,9 @@ public class WaitForMigrationCommandHandlerTests
         var expectedLogOutput = new List<string>
             {
                 $"Waiting for {sourceOrgUrl} -> {targetOrgName} migration (ID: {ORG_MIGRATION_ID}) to finish...",
-                $"Migration {ORG_MIGRATION_ID} is {RepositoryMigrationStatus.InProgress}",
+                $"Migration {ORG_MIGRATION_ID} is {OrganizationMigrationStatus.InProgress}",
                 $"Waiting {WAIT_INTERVAL} seconds...",
-                $"Migration {ORG_MIGRATION_ID} is {RepositoryMigrationStatus.InProgress} - 0/1 repositories completed",
+                $"Migration {ORG_MIGRATION_ID} is {OrganizationMigrationStatus.RepoMigration} - 0/1 repositories completed",
                 $"Waiting {WAIT_INTERVAL} seconds...",
                 $"Migration {ORG_MIGRATION_ID} succeeded"
             };
@@ -216,7 +216,7 @@ public class WaitForMigrationCommandHandlerTests
         const string targetOrgName = "TARGET_ORG";
         _mockGithubApi.SetupSequence(x => x.GetOrganizationMigration(ORG_MIGRATION_ID).Result)
             .Returns((State: OrganizationMigrationStatus.InProgress, sourceOrgUrl, targetOrgName, FailureReason: null, 0, 0))
-            .Returns((State: OrganizationMigrationStatus.InProgress, sourceOrgUrl, targetOrgName, FailureReason: null, 1, 1))
+            .Returns((State: OrganizationMigrationStatus.RepoMigration, sourceOrgUrl, targetOrgName, FailureReason: null, 1, 1))
             .Returns((State: OrganizationMigrationStatus.Failed, sourceOrgUrl, targetOrgName, failureReason, 0, 1));
 
         var actualLogOutput = new List<string>();
@@ -226,9 +226,9 @@ public class WaitForMigrationCommandHandlerTests
         var expectedLogOutput = new List<string>
             {
                 $"Waiting for {sourceOrgUrl} -> {targetOrgName} migration (ID: {ORG_MIGRATION_ID}) to finish...",
-                $"Migration {ORG_MIGRATION_ID} is {RepositoryMigrationStatus.InProgress}",
+                $"Migration {ORG_MIGRATION_ID} is {OrganizationMigrationStatus.InProgress}",
                 $"Waiting {WAIT_INTERVAL} seconds...",
-                $"Migration {ORG_MIGRATION_ID} is {RepositoryMigrationStatus.InProgress} - 0/1 repositories completed",
+                $"Migration {ORG_MIGRATION_ID} is {OrganizationMigrationStatus.RepoMigration} - 0/1 repositories completed",
                 $"Waiting {WAIT_INTERVAL} seconds..."
             };
 

--- a/src/OctoshiftCLI.Tests/gei/Handlers/MigrateOrgCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Handlers/MigrateOrgCommandHandlerTests.cs
@@ -46,7 +46,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             _mockGithubApi.Setup(x => x.GetEnterpriseId(TARGET_ENTERPRISE).Result).Returns(githubEntpriseId);
             _mockGithubApi.Setup(x => x.StartOrganizationMigration(githubOrgUrl, TARGET_ORG, githubEntpriseId, sourceGithubPat).Result).Returns(migrationId);
             _mockGithubApi.Setup(x => x.GetOrganizationMigration(migrationId).Result)
-                .Returns((State: migrationState, SourceOrgUrl: githubOrgUrl, TargetOrgName: TARGET_ORG, FailureReason: null));
+                .Returns((State: migrationState, SourceOrgUrl: githubOrgUrl, TargetOrgName: TARGET_ORG, FailureReason: null, RemainingRepositoriesCount: 0, TotalRepositoriesCount: 9000));
 
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken()).Returns(sourceGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
@@ -105,7 +105,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             _mockGithubApi.Setup(x => x.GetEnterpriseId(TARGET_ENTERPRISE).Result).Returns(githubEntpriseId);
             _mockGithubApi.Setup(x => x.StartOrganizationMigration(githubOrgUrl, TARGET_ORG, githubEntpriseId, targetGithubPat).Result).Returns(migrationId);
-            _mockGithubApi.Setup(x => x.GetOrganizationMigration(migrationId).Result).Returns((State: migrationState, SourceOrgUrl: githubOrgUrl, TargetOrgName: TARGET_ORG, FailureReason: null));
+            _mockGithubApi.Setup(x => x.GetOrganizationMigration(migrationId).Result).Returns((State: migrationState, SourceOrgUrl: githubOrgUrl, TargetOrgName: TARGET_ORG, FailureReason: null, RemainingRepositoriesCount: 0, TotalRepositoriesCount: 9000));
 
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken()).Returns(sourceGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);
@@ -163,7 +163,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
             _mockGithubApi.Setup(x => x.GetEnterpriseId(TARGET_ENTERPRISE).Result).Returns(githubEntpriseId);
             _mockGithubApi.Setup(x => x.StartOrganizationMigration(githubOrgUrl, TARGET_ORG, githubEntpriseId, sourceGithubPat).Result).Returns(migrationId);
-            _mockGithubApi.Setup(x => x.GetOrganizationMigration(migrationId).Result).Returns((State: migrationState, SourceOrgUrl: githubOrgUrl, TargetOrgName: TARGET_ORG, FailureReason: null));
+            _mockGithubApi.Setup(x => x.GetOrganizationMigration(migrationId).Result).Returns((State: migrationState, SourceOrgUrl: githubOrgUrl, TargetOrgName: TARGET_ORG, FailureReason: null, RemainingRepositoriesCount: 0, TotalRepositoriesCount: 9000));
 
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken()).Returns(sourceGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken()).Returns(targetGithubPat);

--- a/src/gei/Handlers/MigrateOrgCommandHandler.cs
+++ b/src/gei/Handlers/MigrateOrgCommandHandler.cs
@@ -54,14 +54,14 @@ public class MigrateOrgCommandHandler : ICommandHandler<MigrateOrgCommandArgs>
 
         while (OrganizationMigrationStatus.IsPending(migrationState))
         {
-            if (totalRepositoriesCount is 0 or null)
-            {
-                _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. Waiting 10 seconds...");
-            }
-            else
+            if (OrganizationMigrationStatus.IsRepoMigration(migrationState))
             {
                 var remainingRepositoriesCount = (int)totalRepositoriesCount - (int)completedRepositoriesCount;
                 _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. {remainingRepositoriesCount}/{totalRepositoriesCount} repo(s) migrated. Waiting 10 seconds...");
+            }
+            else
+            {
+                _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. Waiting 10 seconds...");
             }
             await Task.Delay(10000);
             (migrationState, _, _, failureReason, completedRepositoriesCount, totalRepositoriesCount) = await _githubApi.GetOrganizationMigration(migrationId);

--- a/src/gei/Handlers/MigrateOrgCommandHandler.cs
+++ b/src/gei/Handlers/MigrateOrgCommandHandler.cs
@@ -50,21 +50,21 @@ public class MigrateOrgCommandHandler : ICommandHandler<MigrateOrgCommandArgs>
             return;
         }
 
-        var (migrationState, _, _, failureReason, completedRepositoriesCount, totalRepositoriesCount) = await _githubApi.GetOrganizationMigration(migrationId);
+        var (migrationState, _, _, failureReason, remainingRepositoriesCount, totalRepositoriesCount) = await _githubApi.GetOrganizationMigration(migrationId);
 
         while (OrganizationMigrationStatus.IsPending(migrationState))
         {
             if (OrganizationMigrationStatus.IsRepoMigration(migrationState))
             {
-                var remainingRepositoriesCount = (int)totalRepositoriesCount - (int)completedRepositoriesCount;
-                _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. {remainingRepositoriesCount}/{totalRepositoriesCount} repo(s) migrated. Waiting 10 seconds...");
+                var migratedRepositoriesCount = (int)totalRepositoriesCount - (int)remainingRepositoriesCount;
+                _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. {migratedRepositoriesCount}/{totalRepositoriesCount} repo(s) migrated. Waiting 10 seconds...");
             }
             else
             {
                 _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. Waiting 10 seconds...");
             }
             await Task.Delay(10000);
-            (migrationState, _, _, failureReason, completedRepositoriesCount, totalRepositoriesCount) = await _githubApi.GetOrganizationMigration(migrationId);
+            (migrationState, _, _, failureReason, remainingRepositoriesCount, totalRepositoriesCount) = await _githubApi.GetOrganizationMigration(migrationId);
         }
 
         if (OrganizationMigrationStatus.IsFailed(migrationState))


### PR DESCRIPTION
When waiting for an organization-to-organization migration with the `wait-for-migration` command, the only feedback that the CLI provides on the progress of the migration is its `state`.

Org-to-org migrations potentially stay in the `REPO_MIGRATION` `state` for a long time if there are many repos to be migrated, and this can be a worrying time - as a user, you are likely to wonder "is my migration actually moving forward"?.

The `node` query for `OrganizationMigration`s allows you to fetch the `remainingRepositoriesCount` and `totalRepositoriesCount` for the migration.

This commit starts grabbing that data and logging a progress indicator (`1/10 repos migrated`) to the console.

Note that the GraphQL API currently returns `0` for the two count fields if the number of repos has not yet been completed. There is an outstanding bug to fix this and return `null` instead. This code is future-proof, able to handle both values.

Fixes https://github.com/github/gh-gei/issues/699.

_I don't intend to make it a habit to make code changes, but I wanted to see this enhancement added before org-to-org ships, and I wanted to get familiar with the codebase 😊 _

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)