### PR TITLE
Added BBS environment reset code for e2e tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -204,7 +204,7 @@ jobs:
         AZURE_STORAGE_CONNECTION_STRING_MACOS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_MACOS }}
         AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}
         GEI_DEBUG_MODE: 'true'
-        LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:/home/runner/work/gh-gei/gh-gei/src/OctoshiftCLI.IntegrationTests/bin/Debug/net6.0/runtimes/ubuntu.18.04-x64/native'
+        LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:${{ github.workspace }}/src/OctoshiftCLI.IntegrationTests/bin/Debug/net6.0/runtimes/ubuntu.18.04-x64/native'
       run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
 
     - name: Publish Integration Test Results

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -204,7 +204,7 @@ jobs:
         AZURE_STORAGE_CONNECTION_STRING_MACOS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_MACOS }}
         AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}
         GEI_DEBUG_MODE: 'true'
-      run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --runtime linux-x64 --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
+      run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --runtime linux-x64 --no-self-contained --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
 
     - name: Publish Integration Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -204,7 +204,7 @@ jobs:
         AZURE_STORAGE_CONNECTION_STRING_MACOS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_MACOS }}
         AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}
         GEI_DEBUG_MODE: 'true'
-      run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
+      run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --runtime linux-x64 --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
 
     - name: Publish Integration Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -204,6 +204,7 @@ jobs:
         AZURE_STORAGE_CONNECTION_STRING_MACOS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_MACOS }}
         AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}
         GEI_DEBUG_MODE: 'true'
+        LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:/home/runner/work/gh-gei/gh-gei/src/OctoshiftCLI.IntegrationTests/bin/Debug/net6.0/runtimes/ubuntu.18.04-x64/native'
       run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --runtime linux-x64 --no-self-contained --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
 
     - name: Publish Integration Test Results

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -205,7 +205,7 @@ jobs:
         AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}
         GEI_DEBUG_MODE: 'true'
         LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:/home/runner/work/gh-gei/gh-gei/src/OctoshiftCLI.IntegrationTests/bin/Debug/net6.0/runtimes/ubuntu.18.04-x64/native'
-      run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --runtime linux-x64 --no-self-contained --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
+      run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
 
     - name: Publish Integration Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -132,6 +132,7 @@ jobs:
         AZURE_STORAGE_CONNECTION_STRING_MACOS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_MACOS }}
         AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}
         GEI_DEBUG_MODE: 'true'
+        LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:${{ github.workspace }}/src/OctoshiftCLI.IntegrationTests/bin/Debug/net6.0/runtimes/ubuntu.18.04-x64/native'
       run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
 
     - name: Publish Integration Test Results

--- a/src/Octoshift/BbsClient.cs
+++ b/src/Octoshift/BbsClient.cs
@@ -48,6 +48,8 @@ public class BbsClient
 
     public virtual async Task<string> PostAsync(string url, object body) => await SendAsync(HttpMethod.Post, url, body);
 
+    public virtual async Task<string> DeleteAsync(string url) => await SendAsync(HttpMethod.Delete, url);
+
     private async Task<string> SendAsync(HttpMethod httpMethod, string url, object body = null)
     {
         _log.LogVerbose($"HTTP {httpMethod}: {url}");

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -70,7 +70,7 @@ public sealed class BbsToGithub : IDisposable
     [Fact]
     public async Task Basic()
     {
-        var bbsProjectKey = "E2E-L";
+        var bbsProjectKey = $"E2E-{TestHelper.GetOsName().ToUpper()}";
         var githubTargetOrg = $"e2e-testing-{TestHelper.GetOsName()}";
         var repo1 = $"{bbsProjectKey}-repo-1";
         var repo2 = $"{bbsProjectKey}-repo-2";

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -65,7 +65,7 @@ public sealed class BbsToGithub : IDisposable
     }
 
     [Theory]
-    [InlineData("http://e2e-bbs-8-5-0-linux-2204.eastus.cloudapp.azure.com:7990")]
+    //[InlineData("http://e2e-bbs-8-5-0-linux-2204.eastus.cloudapp.azure.com:7990")]
     [InlineData("http://e2e-bbs-5-14-0-linux-2004.eastus.cloudapp.azure.com:7990")]
     public async Task Basic(string bbsServer)
     {

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -64,10 +64,10 @@ public sealed class BbsToGithub : IDisposable
         _targetHelper = new TestHelper(_output, _targetGithubApi, _targetGithubClient, _blobServiceClient);
     }
 
-    [Fact]
-    public async Task Basic_Version_8_5_0()
+    [Theory]
+    [InlineData("http://e2e-bbs-8-5-0-linux-2204.eastus.cloudapp.azure.com:7990")]
+    public async Task Basic(string bbsServer)
     {
-        var bbsServer = "http://e2e-bbs-8-5-0-linux-2204.eastus.cloudapp.azure.com:7990";
         var bbsProjectKey = $"E2E-{TestHelper.GetOsName().ToUpper()}";
         var githubTargetOrg = $"e2e-testing-{TestHelper.GetOsName()}";
         var repo1 = $"{bbsProjectKey}-repo-1";

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -65,8 +65,7 @@ public sealed class BbsToGithub : IDisposable
     }
 
     [Theory]
-    //[InlineData("http://e2e-bbs-8-5-0-linux-2204.eastus.cloudapp.azure.com:7990")]
-    [InlineData("http://e2e-bbs-5-14-0-linux-2004.eastus.cloudapp.azure.com:7990")]
+    [InlineData("http://e2e-bbs-8-5-0-linux-2204.eastus.cloudapp.azure.com:7990")]
     public async Task Basic(string bbsServer)
     {
         var bbsProjectKey = $"E2E-{TestHelper.GetOsName().ToUpper()}";

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -85,8 +85,6 @@ public sealed class BbsToGithub : IDisposable
         await _sourceHelper.CreateBbsRepo(BBS_URL, bbsProjectKey, "repo-2");
         _sourceHelper.InitializeBbsRepo(BBS_URL, bbsProjectKey, "repo-2");
 
-        // TODO: Generate BBS test data
-
         await _targetHelper.RunBbsCliMigration(
             $"generate-script --github-org {githubTargetOrg} --bbs-server-url {BBS_URL} --bbs-project-key {bbsProjectKey} --ssh-user octoshift --ssh-private-key {SSH_KEY_FILE}", _tokens);
 

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -70,19 +70,25 @@ public sealed class BbsToGithub : IDisposable
     [Fact]
     public async Task Basic()
     {
+        var bbsProjectKey = "E2E-L";
         var githubTargetOrg = $"e2e-testing-{TestHelper.GetOsName()}";
-        const string repo1 = "EEL-repo-1";
-        const string repo2 = "EEL-repo-2";
+        var repo1 = $"{bbsProjectKey}-repo-1";
+        var repo2 = $"{bbsProjectKey}-repo-2";
 
         await _targetHelper.ResetBlobContainers();
-
-        // TODO: Reset BBS test environment
+        await _sourceHelper.ResetBbsTestEnvironment(BBS_URL, bbsProjectKey);
         await _targetHelper.ResetGithubTestEnvironment(githubTargetOrg);
+
+        await _sourceHelper.CreateBbsProject(BBS_URL, bbsProjectKey);
+        await _sourceHelper.CreateBbsRepo(BBS_URL, bbsProjectKey, "repo-1");
+        _sourceHelper.InitializeBbsRepo(BBS_URL, bbsProjectKey, "repo-1");
+        await _sourceHelper.CreateBbsRepo(BBS_URL, bbsProjectKey, "repo-2");
+        _sourceHelper.InitializeBbsRepo(BBS_URL, bbsProjectKey, "repo-2");
 
         // TODO: Generate BBS test data
 
         await _targetHelper.RunBbsCliMigration(
-            $"generate-script --github-org {githubTargetOrg} --bbs-server-url {BBS_URL} --ssh-user octoshift --ssh-private-key {SSH_KEY_FILE}", _tokens);
+            $"generate-script --github-org {githubTargetOrg} --bbs-server-url {BBS_URL} --bbs-project-key {bbsProjectKey} --ssh-user octoshift --ssh-private-key {SSH_KEY_FILE}", _tokens);
 
         _targetHelper.AssertNoErrorInLogs(_startTime);
 

--- a/src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj
+++ b/src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -159,6 +159,12 @@ namespace OctoshiftCLI.IntegrationTests
         public void InitializeBbsRepo(string bbsProjectKey, string repoName)
         {
             var repoPath = Path.Combine(Path.GetTempPath(), repoName);
+
+            if (Directory.Exists(repoPath))
+            {
+                Directory.Delete(repoPath, true);
+            }
+
             Directory.CreateDirectory(repoPath);
 
             Repository.Init(repoPath);

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -172,6 +172,7 @@ namespace OctoshiftCLI.IntegrationTests
             Directory.CreateDirectory(repoPath);
 
             Environment.SetEnvironmentVariable("LD_LIBRARY_PATH", "$LD_LIBRARY_PATH:./runtimes/ubuntu.18.04-x64/native");
+            Environment.SetEnvironmentVariable("LD_DEBUG", "all");
 
             Repository.Init(repoPath);
             using var repo = new Repository(repoPath);

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -171,9 +171,6 @@ namespace OctoshiftCLI.IntegrationTests
             var repoPath = Path.Combine(Path.GetTempPath(), repoName);
             Directory.CreateDirectory(repoPath);
 
-            Environment.SetEnvironmentVariable("LD_LIBRARY_PATH", "$LD_LIBRARY_PATH:./runtimes/ubuntu.18.04-x64/native");
-            Environment.SetEnvironmentVariable("LD_DEBUG", "all");
-
             Repository.Init(repoPath);
             using var repo = new Repository(repoPath);
             File.WriteAllText(Path.Join(repo.Info.WorkingDirectory, "README.md"), "# Test Repo");

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -171,6 +171,8 @@ namespace OctoshiftCLI.IntegrationTests
             var repoPath = Path.Combine(Path.GetTempPath(), repoName);
             Directory.CreateDirectory(repoPath);
 
+            Environment.SetEnvironmentVariable("LD_LIBRARY_PATH", "$LD_LIBRARY_PATH:./runtimes/ubuntu.18.04-x64/native");
+
             Repository.Init(repoPath);
             using var repo = new Repository(repoPath);
             File.WriteAllText(Path.Join(repo.Info.WorkingDirectory, "README.md"), "# Test Repo");

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using FluentAssertions;
+using LibGit2Sharp;
 using Newtonsoft.Json.Linq;
 using Xunit.Abstractions;
 
@@ -96,6 +97,38 @@ namespace OctoshiftCLI.IntegrationTests
             await CreateRepo(githubOrg, repo, true, true);
         }
 
+        public async Task ResetBbsTestEnvironment(string bbsServer, string bbsProjectKey)
+        {
+            var retryPolicy = new RetryPolicy(null);
+
+            await retryPolicy.Retry(async () =>
+            {
+                var bbsRepos = (await _bbsApi.GetRepos(bbsProjectKey)).Select(x => x.Slug);
+
+                foreach (var repo in bbsRepos)
+                {
+                    _output.WriteLine($"Deleting BBS repo: {bbsProjectKey}\\{repo}...");
+                    await DeleteBbsRepo(bbsServer, bbsProjectKey, repo);
+                }
+
+                await DeleteBbsProject(bbsServer, bbsProjectKey);
+            });
+        }
+
+        private async Task DeleteBbsRepo(string bbsServer, string bbsProjectKey, string slug)
+        {
+            var url = $"{bbsServer}/rest/api/1.0/projects/{bbsProjectKey}/repos/{slug}";
+
+            await _bbsClient.DeleteAsync(url);
+        }
+
+        private async Task DeleteBbsProject(string bbsServer, string bbsProjectKey)
+        {
+            var url = $"{bbsServer}/rest/api/1.0/projects/{bbsProjectKey}";
+
+            await _bbsClient.DeleteAsync(url);
+        }
+
         public async Task ResetGithubTestEnvironment(string githubOrg)
         {
             var retryPolicy = new RetryPolicy(null);
@@ -121,6 +154,54 @@ namespace OctoshiftCLI.IntegrationTests
                     await DeleteTeam(githubOrg, teamSlug);
                 }
             });
+        }
+
+        public void InitializeBbsRepo(string bbsServer, string bbsProjectKey, string repoName)
+        {
+            var repoPath = Path.Combine(Path.GetTempPath(), repoName);
+            Directory.CreateDirectory(repoPath);
+
+            Repository.Init(repoPath);
+            using var repo = new Repository(repoPath);
+            File.WriteAllText(Path.Join(repo.Info.WorkingDirectory, "README.md"), "# Test Repo");
+            repo.Index.Add("README.md");
+            repo.Index.Write();
+            var author = new Signature("Octoshift", "octoshift@github.com", DateTime.Now);
+            var commit = repo.Commit("Here's a commit i made!", author, author);
+            var origin = repo.Network.Remotes.Add("origin", $"{bbsServer}/scm/{bbsProjectKey}/{repoName}.git");
+            var options = new PushOptions
+            {
+                CredentialsProvider = (url, user, cred) => new UsernamePasswordCredentials
+                {
+                    Username = Environment.GetEnvironmentVariable("BBS_USERNAME"),
+                    Password = Environment.GetEnvironmentVariable("BBS_PASSWORD")
+                }
+            };
+            repo.Network.Push(origin, @"refs/heads/master", options);
+        }
+
+        public async Task CreateBbsRepo(string bbsServer, string bbsProjectKey, string repoName)
+        {
+            var url = $"{bbsServer}/rest/api/1.0/projects/{bbsProjectKey}/repos";
+            var payload = new
+            {
+                name = repoName,
+                scmId = "git",
+                slug = repoName
+            };
+
+            await _bbsClient.PostAsync(url, payload);
+        }
+
+        public async Task CreateBbsProject(string bbsServer, string bbsProjectKey)
+        {
+            var url = $"{bbsServer}/rest/api/1.0/projects";
+            var payload = new
+            {
+                key = bbsProjectKey
+            };
+
+            await _bbsClient.PostAsync(url, payload);
         }
 
         public async Task CreateTeamProject(string adoOrg, string teamProject)

--- a/src/OctoshiftCLI.Tests/BbsClientTests.cs
+++ b/src/OctoshiftCLI.Tests/BbsClientTests.cs
@@ -248,7 +248,7 @@ public sealed class BbsClientTests : IDisposable
 
         const string actualUrl = "http://example.com/param with space";
         const string expectedUrl = "http://example.com/param%20with%20space";
-        
+
         // Act
         await bbsClient.DeleteAsync(actualUrl);
 

--- a/src/OctoshiftCLI.Tests/BbsClientTests.cs
+++ b/src/OctoshiftCLI.Tests/BbsClientTests.cs
@@ -239,6 +239,69 @@ public sealed class BbsClientTests : IDisposable
         _mockOctoLogger.Verify(m => m.LogVerbose($"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}"), Times.Once);
     }
 
+    [Fact]
+    public async Task DeleteAsync_Encodes_The_Url()
+    {
+        var handlerMock = MockHttpHandlerForDelete();
+        using var httpClient = new HttpClient(handlerMock.Object);
+        var bbsClient = new BbsClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, USERNAME, PASSWORD);
+
+        const string actualUrl = "http://example.com/param with space";
+        const string expectedUrl = "http://example.com/param%20with%20space";
+        
+        // Act
+        await bbsClient.DeleteAsync(actualUrl);
+
+        // Assert
+        handlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(msg => msg.RequestUri.AbsoluteUri == expectedUrl),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Logs_The_Url()
+    {
+        // Arrange
+        using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
+        var bbsClient = new BbsClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, USERNAME, PASSWORD);
+
+        // Act
+        await bbsClient.DeleteAsync(URL);
+
+        // Assert
+        _mockOctoLogger.Verify(m => m.LogVerbose($"HTTP DELETE: {URL}"), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Returns_String_Response()
+    {
+        // Arrange
+        using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
+        var bbsClient = new BbsClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, USERNAME, PASSWORD);
+
+        // Act
+        var actualContent = await bbsClient.DeleteAsync(URL);
+
+        // Assert
+        actualContent.Should().Be(EXPECTED_RESPONSE_CONTENT);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Logs_The_Response_Status_Code_And_Content()
+    {
+        // Arrange
+        using var httpClient = new HttpClient(MockHttpHandlerForDelete().Object);
+        var bbsClient = new BbsClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, USERNAME, PASSWORD);
+
+        // Act
+        await bbsClient.DeleteAsync(URL);
+
+        // Assert
+        _mockOctoLogger.Verify(m => m.LogVerbose($"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}"), Times.Once);
+    }
+
     private Mock<HttpMessageHandler> MockHttpHandlerForGet() =>
         MockHttpHandler(req => req.Method == HttpMethod.Get);
 
@@ -246,6 +309,9 @@ public sealed class BbsClientTests : IDisposable
         MockHttpHandler(req =>
             req.Content.ReadAsStringAsync().Result == EXPECTED_JSON_REQUEST_BODY
             && req.Method == HttpMethod.Post);
+
+    private Mock<HttpMessageHandler> MockHttpHandlerForDelete() =>
+        MockHttpHandler(req => req.Method == HttpMethod.Delete);
 
     private Mock<HttpMessageHandler> MockHttpHandler(
         Func<HttpRequestMessage, bool> requestMatcher,

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
@@ -183,7 +183,7 @@ public class GenerateScriptCommandHandlerTests
             GithubOrg = GITHUB_ORG,
             BbsUsername = BBS_USERNAME,
             BbsPassword = BBS_PASSWORD,
-            BbsProjectkey = BBS_FOO_PROJECT_KEY,
+            BbsProjectKey = BBS_FOO_PROJECT_KEY,
             BbsSharedHome = BBS_SHARED_HOME,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,

--- a/src/bbs2gh/Commands/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScriptCommand.cs
@@ -113,7 +113,7 @@ public class GenerateScriptCommandArgs
     public string GithubOrg { get; set; }
     public string BbsUsername { get; set; }
     public string BbsPassword { get; set; }
-    public string BbsProjectkey { get; set; }
+    public string BbsProjectKey { get; set; }
     public string BbsSharedHome { get; set; }
     public string SshUser { get; set; }
     public string SshPrivateKey { get; set; }

--- a/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
+++ b/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
@@ -63,8 +63,8 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         content.AppendLine(VersionComment);
         content.AppendLine(EXEC_FUNCTION_BLOCK);
 
-        var projects = args.BbsProjectkey.HasValue()
-            ? new List<string>() { args.BbsProjectkey }
+        var projects = args.BbsProjectKey.HasValue()
+            ? new List<string>() { args.BbsProjectKey }
             : (await _bbsApi.GetProjects()).Select(x => x.Key);
 
         foreach (var projectKey in projects)
@@ -141,9 +141,9 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
             _log.LogInformation("BBS PASSWORD: ***");
         }
 
-        if (args.BbsProjectkey.HasValue())
+        if (args.BbsProjectKey.HasValue())
         {
-            _log.LogInformation($"BBS PROJECT KEY: {args.BbsProjectkey}");
+            _log.LogInformation($"BBS PROJECT KEY: {args.BbsProjectKey}");
         }
 
         if (args.SshUser.HasValue())


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Added code to do a similar thing we do with our other e2e tests, where the test is responsible for resetting the test data that it expects in the test environment. This makes it easy to stand up new environments, and prevent accidentally breaking test environments by unintentional manual changes in the BBS server(s). It also makes it easy to add new data shapes to our test environments, as we just add them in one place (in the code) rather than having to manually touch each of our BBS test servers (and we will have several of them before we're done with the BBS work).

Right now these additions will check if the BBS project exists, and if so iterate and delete all repos in the project, then delete the project. Then create the project(s) and repo(s) from scratch.

It uses libgit2sharp to initialize the repos. This dependency only exists in our e2e test code, not in the CLI that we ship to customers. libgit2sharp comes with native binaries for various linux distro's, but only includes ubuntu 18.04 but our build servers use ubuntu 20.04 (or maybe 22.04). The workaround is to use the LD_LIBRARY_PATH env var when building our integration test project to force it to link to the ubuntu 18.04 binary (https://github.com/libgit2/libgit2sharp/issues/1703#issuecomment-619497921)

This has pretty much everything we need to support testing against BBS 5.14 also (#570 ) except for some reason the initialize repo code fails consistently when run against BBS 5.14. Once somebody figures out why that fails, you just need to add an extra [InlineData] attribute to the test case and it will run for both.

Closes #573 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->