### PR TITLE
Update the error message for getting an org id 

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Improved error messages for handling the result of GitHub API requests.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-- Improved error messages for handling the result of GitHub API requests.
+- Improved error messages when the specified organization or enterprise cannot be found

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -148,7 +148,7 @@ namespace OctoshiftCLI
             });
 
             return response.Outcome == OutcomeType.Failure
-                ? throw new OctoshiftCliException($"Failed to lookup the Organization ID for {org}", response.FinalException)
+                ? throw new OctoshiftCliException($"Failed to lookup the Organization ID for organization '{org}'", response.FinalException)
                 : response.Result;
         }
 

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -148,7 +148,7 @@ namespace OctoshiftCLI
             });
 
             return response.Outcome == OutcomeType.Failure
-                ? throw new OctoshiftCliException("Failed to lookup the Organization ID", response.FinalException)
+                ? throw new OctoshiftCliException($"Failed to lookup the Organization ID for {org}", response.FinalException)
                 : response.Result;
         }
 

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -173,7 +173,7 @@ namespace OctoshiftCLI
             });
 
             return response.Outcome == OutcomeType.Failure
-                ? throw new OctoshiftCliException($"Failed to lookup the Enterprise ID '{enterpriseName}'", response.FinalException)
+                ? throw new OctoshiftCliException($"Failed to lookup the Enterprise ID for enterprise '{enterpriseName}'", response.FinalException)
                 : response.Result;
         }
 

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -173,7 +173,7 @@ namespace OctoshiftCLI
             });
 
             return response.Outcome == OutcomeType.Failure
-                ? throw new OctoshiftCliException("Failed to lookup the Enterprise ID", response.FinalException)
+                ? throw new OctoshiftCliException($"Failed to lookup the Enterprise ID '{enterpriseName}'", response.FinalException)
                 : response.Result;
         }
 


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests  -> no because it's only small update and no test currently
- [x] Release notes updated (if appropriate) -> no
- [x] Appropriate logging output -> yes?
- [x] Issue linked -> no because it's a small update
- [x] Docs updated (or issue created) -> no I don't think we need it

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->

Hello 👋 

This PR will update an error message when failing to get an org id during the migration process a bit. It's a small change but would be helpful for debugging.

Currently, when the migration failed in the process of getting an organization id, we can see the following error:

```
[11:41 AM] [INFO] You are running the latest version of the gei CLI [v0.31]
[11:41 AM] [INFO] Migrating Repo...
[11:41 AM] [INFO] GITHUB SOURCE ORG: <org>
[11:41 AM] [INFO] SOURCE REPO: <repo>
[11:41 AM] [INFO] GITHUB TARGET ORG: <org2>
[11:41 AM] [INFO] TARGET REPO:<repo2>
[11:41 AM] [INFO] WAIT: true
[11:41 AM] [INFO] Target repo name not provided, defaulting to same as source repo (k8s)
[11:42 AM] [ERROR] Failed to lookup the Organization ID
```

However, it doesn't let us know which org has the error, source or target org 💭 

So I'm adding the organization name in the error message.

Thanks!