### PR TITLE
Mask the `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` in the output

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Mask the value for `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` parameters in the output for blobs storages.

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -328,12 +328,12 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         if (args.AwsAccessKey.HasValue())
         {
-            _log.LogInformation($"AWS ACCESS KEY: {args.AwsAccessKey}");
+            _log.LogInformation("AWS ACCESS KEY: ***");
         }
 
         if (args.AwsSecretKey.HasValue())
         {
-            _log.LogInformation($"AWS SECRET KEY: {args.AwsSecretKey}");
+            _log.LogInformation("AWS SECRET KEY: ***");
         }
     }
 


### PR DESCRIPTION
Hello 👋 

Currently, the values for `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` parameters are included in the output of the `gh gei` command for migration from GHES, and octoshift.log. As they're credential, this PR will mask the values.

Thanks!

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests -> No, this PR only hide the AWS ACCESS KEY ID/SECRET and no impact on the current test logic
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked -> No, this is a simple update
- [x] Docs updated (or issue created) -> No needed.

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->