### PR TITLE
Add api for GHES version

### DIFF
--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -729,6 +729,16 @@ namespace OctoshiftCLI
             await _client.PatchAsync(url, payload);
         }
 
+        public virtual async Task<string> GetEnterpriseServerVersion()
+        {
+            var url = $"{_apiUrl}/meta";
+
+            var response = await _client.GetAsync(url);
+            var data = JObject.Parse(response);
+
+            return (string)data["installed_version"];
+        }
+
         private static object GetMannequinsPayload(string orgId)
         {
             var query = "query($id: ID!, $first: Int, $after: String)";

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -2600,7 +2600,6 @@ namespace OctoshiftCLI.Tests
             // Act
             var version = await _githubApi.GetEnterpriseServerVersion();
 
-
             // Assert
             version.Should().Be("3.7.0");
         }

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -2552,6 +2552,61 @@ namespace OctoshiftCLI.Tests
             _githubClientMock.Verify(m => m.PatchAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null));
         }
 
+        [Fact]
+        public async Task GetEnterpriseServerVersion_Returns_Null_If_Not_Enterprise_Server()
+        {
+            // Arrange
+            var url = "https://api.github.com/meta";
+            var response = $@"
+            {{
+                ""verifiable_password_authentication"": true,
+                ""packages"": [
+                ],
+                ""dependabot"": [
+                ]
+            }}
+        ";
+
+
+            _githubClientMock
+                .Setup(m => m.GetAsync(url, null))
+                .ReturnsAsync(response);
+
+            // Act
+            var version = await _githubApi.GetEnterpriseServerVersion();
+
+            // Assert
+            version.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task GetEnterpriseServerVersion_Returns_Version()
+        {
+            // Arrange
+            var url = "https://api.github.com/meta";
+            var response = $@"
+            {{
+                ""verifiable_password_authentication"": true,
+                ""packages"": [
+                ],
+                ""dependabot"": [
+                ],
+                ""installed_version"": ""3.7.0""
+            }}
+        ";
+
+            _githubClientMock
+                .Setup(m => m.GetAsync(url, null))
+                .ReturnsAsync(response);
+
+            // Act
+            var version = await _githubApi.GetEnterpriseServerVersion();
+
+
+            // Assert
+            version.Should().Be("3.7.0");
+        }
+
         private string Compact(string source) =>
             source
                 .Replace("\r", "")

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -2591,8 +2591,7 @@ namespace OctoshiftCLI.Tests
                 ""dependabot"": [
                 ],
                 ""installed_version"": ""3.7.0""
-            }}
-        ";
+            }}";
 
             _githubClientMock
                 .Setup(m => m.GetAsync(url, null))

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -2564,8 +2564,7 @@ namespace OctoshiftCLI.Tests
                 ],
                 ""dependabot"": [
                 ]
-            }}
-        ";
+            }}";
 
 
             _githubClientMock


### PR DESCRIPTION
Fixes #753 
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->