### PR TITLE
Update docs url for CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,27 @@
 ## Contributing
+
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 
-Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.md).
+Contributions to this project are [released](https://docs.github.com/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.md).
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
 Here's some helpful notes on how to contribute to this project, including details on how to get started working the codebase.
 
 ## How to submit a bug or request a feature
+
 If you think you've found a bug or have a great idea for new functionality please create an Issue in this repo. We have Issue Templates for both Bugs and Feature Requests.
 
 ## How to provide feedback or ask for help
-Use the [Discussions](https://github.com/github/OctoshiftCLI/discussions) tab in this repo for more general feedback or any questions/comments on this tooling.
+
+Use the [Discussions](https://github.com/github/gh-gei/discussions) tab in this repo for more general feedback or any questions/comments on this tooling.
 
 ## Product Backlog
-All work done by the maintainers of this repo is tracked in this repo using Issues. We have a hierarchical backlog with Epics at the top, broken down into Batches then broken down to Tasks (epic/batch/task is indicated via labels on the issues). You can see an example Epic and navigate down from there [here](https://github.com/github/OctoshiftCLI/issues/101).
+
+All work done by the maintainers of this repo is tracked in this repo using Issues. We have a hierarchical backlog with Epics at the top, broken down into Batches then broken down to Tasks (epic/batch/task is indicated via labels on the issues). You can see an example Epic and navigate down from there [here](https://github.com/github/gh-gei/issues/101).
 
 ## Submitting a Pull Request
+
 Before submitting a Pull Request please first open an issue to get feedback on the change you intend to submit.
 
 When creating a PR the template will prompt you to confirm that you have done a few required steps (or at least considered them and determined they are not necessary on this PR):


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests -> no needed
- [x] Release notes updated (if appropriate) -> no needed
- [x] Appropriate logging output -> no needed
- [x] Issue linked -> no needed
- [x] Docs updated (or issue created) -> no needed

Hello 👋 

This is a tiny update but it would be good to keep links in our docs up to date 😄 

Thanks!


<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->