### PR TITLE
Allow blob credentials to be optional after GHES 3.8

### DIFF
--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -586,14 +586,9 @@ namespace OctoshiftCLI
                 var data = JObject.Parse(response);
                 return (int)data["id"];
             }
-            catch (HttpRequestException ex)
+            catch (HttpRequestException ex) when (ex.Message.Contains("configure blob storage"))
             {
-                if (ex.Message.Contains("configure blob storage"))
-                {
-                    throw new OctoshiftCliException(ex.Message, ex);
-                }
-
-                throw;
+                throw new OctoshiftCliException(ex.Message, ex);
             }
         }
 

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -580,9 +580,21 @@ namespace OctoshiftCLI
                 exclude_metadata = true
             };
 
-            var response = await _client.PostAsync(url, options);
-            var data = JObject.Parse(response);
-            return (int)data["id"];
+            try
+            {
+                var response = await _client.PostAsync(url, options);
+                var data = JObject.Parse(response);
+                return (int)data["id"];
+            }
+            catch (HttpRequestException ex)
+            {
+                if (ex.Message.Contains("configure blob storage"))
+                {
+                    throw new OctoshiftCliException(ex.Message, ex);
+                }
+
+                throw;
+            }
         }
 
         public virtual async Task<int> StartMetadataArchiveGeneration(string org, string repo, bool skipReleases, bool lockSource)

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -170,14 +170,20 @@ namespace OctoshiftCLI
             {
                 (content, headers) = await SendAsync(httpMethod, url, body, expectedStatus, customHeaders);
             }
-            else if (response.StatusCode == HttpStatusCode.OK)
+            else if (expectedStatus == HttpStatusCode.OK)
             {
-                response.EnsureSuccessStatusCode();
+                try
+                {
+                    response.EnsureSuccessStatusCode();
+                }
+                catch (HttpRequestException ex)
+                {
+                    throw new HttpRequestException($"GitHub API error: {content}", ex, response.StatusCode);
+                }
             }
             else if (response.StatusCode != expectedStatus)
             {
-
-                throw new HttpRequestException(content, null, response.StatusCode);
+                throw new HttpRequestException($"Expected status code {expectedStatus} but got {response.StatusCode}", null, response.StatusCode);
             }
 
             return (content, headers);

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -170,13 +170,14 @@ namespace OctoshiftCLI
             {
                 (content, headers) = await SendAsync(httpMethod, url, body, expectedStatus, customHeaders);
             }
-            else if (expectedStatus == HttpStatusCode.OK)
+            else if (response.StatusCode == HttpStatusCode.OK)
             {
                 response.EnsureSuccessStatusCode();
             }
             else if (response.StatusCode != expectedStatus)
             {
-                throw new HttpRequestException($"Expected status code {expectedStatus} but got {response.StatusCode}", null, response.StatusCode);
+
+                throw new HttpRequestException(content, null, response.StatusCode);
             }
 
             return (content, headers);

--- a/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
@@ -74,41 +74,11 @@ public sealed class GhesToGithub : IDisposable
         {
             await _targetHelper.ResetBlobContainers();
 
-            try
-            {
-                await _sourceHelper.ResetGithubTestEnvironment(githubSourceOrg);
-            }
-            catch (HttpRequestException)
-            {
-                // ignore
-            }
+            await _sourceHelper.ResetGithubTestEnvironment(githubSourceOrg);
+            await _targetHelper.ResetGithubTestEnvironment(githubTargetOrg);
 
-            try
-            {
-                await _targetHelper.ResetGithubTestEnvironment(githubTargetOrg);
-            }
-            catch (HttpRequestException)
-            {
-                // ignore
-            }
-
-            try
-            {
-                await _sourceHelper.CreateGithubRepo(githubSourceOrg, repo1);
-            }
-            catch (HttpRequestException)
-            {
-                // ignore
-            }
-
-            try
-            {
-                await _sourceHelper.CreateGithubRepo(githubSourceOrg, repo2);
-            }
-            catch (HttpRequestException)
-            {
-                // ignore
-            }
+            await _sourceHelper.CreateGithubRepo(githubSourceOrg, repo1);
+            await _sourceHelper.CreateGithubRepo(githubSourceOrg, repo2);
         });
 
         await _targetHelper.RunGeiCliMigration(

--- a/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
@@ -74,11 +74,41 @@ public sealed class GhesToGithub : IDisposable
         {
             await _targetHelper.ResetBlobContainers();
 
-            await _sourceHelper.ResetGithubTestEnvironment(githubSourceOrg);
-            await _targetHelper.ResetGithubTestEnvironment(githubTargetOrg);
+            try
+            {
+                await _sourceHelper.ResetGithubTestEnvironment(githubSourceOrg);
+            }
+            catch (HttpRequestException)
+            {
+                // ignore
+            }
 
-            await _sourceHelper.CreateGithubRepo(githubSourceOrg, repo1);
-            await _sourceHelper.CreateGithubRepo(githubSourceOrg, repo2);
+            try
+            {
+                await _targetHelper.ResetGithubTestEnvironment(githubTargetOrg);
+            }
+            catch (HttpRequestException)
+            {
+                // ignore
+            }
+
+            try
+            {
+                await _sourceHelper.CreateGithubRepo(githubSourceOrg, repo1);
+            }
+            catch (HttpRequestException)
+            {
+                // ignore
+            }
+
+            try
+            {
+                await _sourceHelper.CreateGithubRepo(githubSourceOrg, repo2);
+            }
+            catch (HttpRequestException)
+            {
+                // ignore
+            }
         });
 
         await _targetHelper.RunGeiCliMigration(

--- a/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
@@ -58,12 +58,6 @@ namespace OctoshiftCLI.IntegrationTests
                 await _helper.CreateGithubRepo(githubSourceOrg, repo2);
             });
 
-            await _helper.ResetGithubTestEnvironment(githubSourceOrg);
-            await _helper.ResetGithubTestEnvironment(githubTargetOrg);
-
-            await _helper.CreateGithubRepo(githubSourceOrg, repo1);
-            await _helper.CreateGithubRepo(githubSourceOrg, repo2);
-
             await _helper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --download-migration-logs", _tokens);
 
             _helper.AssertNoErrorInLogs(_startTime);

--- a/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
@@ -51,18 +51,26 @@ namespace OctoshiftCLI.IntegrationTests
 
             await retryPolicy.Retry(async () =>
             {
-                await _helper.ResetGithubTestEnvironment(githubSourceOrg);
-                await _helper.ResetGithubTestEnvironment(githubTargetOrg);
+                try
+                {
+                    await _helper.ResetGithubTestEnvironment(githubSourceOrg);
+                }
+                catch (HttpRequestException)
+                {
+                    // ignore
+                }
+                try
+                {
+                    await _helper.ResetGithubTestEnvironment(githubTargetOrg);
+                }
+                catch (HttpRequestException)
+                {
+                    // ignore
+                }
 
                 await _helper.CreateGithubRepo(githubSourceOrg, repo1);
                 await _helper.CreateGithubRepo(githubSourceOrg, repo2);
             });
-
-            await _helper.ResetGithubTestEnvironment(githubSourceOrg);
-            await _helper.ResetGithubTestEnvironment(githubTargetOrg);
-
-            await _helper.CreateGithubRepo(githubSourceOrg, repo1);
-            await _helper.CreateGithubRepo(githubSourceOrg, repo2);
 
             await _helper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --download-migration-logs", _tokens);
 

--- a/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
@@ -51,41 +51,18 @@ namespace OctoshiftCLI.IntegrationTests
 
             await retryPolicy.Retry(async () =>
             {
-                try
-                {
-                    await _helper.ResetGithubTestEnvironment(githubSourceOrg);
-                }
-                catch (HttpRequestException)
-                {
-                    // ignore
-                }
-                try
-                {
-                    await _helper.ResetGithubTestEnvironment(githubTargetOrg);
-                }
-                catch (HttpRequestException)
-                {
-                    // ignore
-                }
+                await _helper.ResetGithubTestEnvironment(githubSourceOrg);
+                await _helper.ResetGithubTestEnvironment(githubTargetOrg);
 
-                try
-                {
-                    await _helper.CreateGithubRepo(githubSourceOrg, repo1);
-                }
-                catch (HttpRequestException)
-                {
-                    // ignore
-                }
-
-                try
-                {
-                    await _helper.CreateGithubRepo(githubSourceOrg, repo2);
-                }
-                catch (HttpRequestException)
-                {
-                    // ignore
-                }
+                await _helper.CreateGithubRepo(githubSourceOrg, repo1);
+                await _helper.CreateGithubRepo(githubSourceOrg, repo2);
             });
+
+            await _helper.ResetGithubTestEnvironment(githubSourceOrg);
+            await _helper.ResetGithubTestEnvironment(githubTargetOrg);
+
+            await _helper.CreateGithubRepo(githubSourceOrg, repo1);
+            await _helper.CreateGithubRepo(githubSourceOrg, repo2);
 
             await _helper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --download-migration-logs", _tokens);
 

--- a/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
@@ -68,8 +68,23 @@ namespace OctoshiftCLI.IntegrationTests
                     // ignore
                 }
 
-                await _helper.CreateGithubRepo(githubSourceOrg, repo1);
-                await _helper.CreateGithubRepo(githubSourceOrg, repo2);
+                try
+                {
+                    await _helper.CreateGithubRepo(githubSourceOrg, repo1);
+                }
+                catch (HttpRequestException)
+                {
+                    // ignore
+                }
+
+                try
+                {
+                    await _helper.CreateGithubRepo(githubSourceOrg, repo2);
+                }
+                catch (HttpRequestException)
+                {
+                    // ignore
+                }
             });
 
             await _helper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --download-migration-logs", _tokens);

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -2256,6 +2256,31 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task StartGitArchiveGeneration_Throws_Octoshift_CLI_Exception_When_Blob_Storage_Settings_Are_Not_Set()
+        {
+            // Arrange
+            const string url = $"https://api.github.com/orgs/{GITHUB_ORG}/migrations";
+            var payload = new
+            {
+                repositories = new[] { GITHUB_REPO },
+                exclude_metadata = true
+            };
+            var exception_message = "Before you can start a migration, you must configure blob storage settings in your management console.";
+
+            _githubClientMock
+                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
+                    .ThrowsAsync(new HttpRequestException(exception_message, null, HttpStatusCode.BadGateway));
+
+            // Act
+            Func<Task> act = async () => await _githubApi.StartGitArchiveGeneration(GITHUB_ORG, GITHUB_REPO);
+
+            // Assert
+            await act.Should().ThrowExactlyAsync<OctoshiftCliException>()
+                .WithMessage(exception_message);
+        }
+
+
+        [Fact]
         public async Task GetSecretScanningAlertsData()
         {
             // Arrange

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -2272,10 +2272,9 @@ namespace OctoshiftCLI.Tests
                     .ThrowsAsync(new HttpRequestException(exception_message, null, HttpStatusCode.BadGateway));
 
             // Act
-            Func<Task> act = async () => await _githubApi.StartGitArchiveGeneration(GITHUB_ORG, GITHUB_REPO);
-
-            // Assert
-            await act.Should().ThrowExactlyAsync<OctoshiftCliException>()
+            await _githubApi.Invoking(api => api.StartGitArchiveGeneration(GITHUB_ORG, GITHUB_REPO))
+                .Should()
+                .ThrowExactlyAsync<OctoshiftCliException>()
                 .WithMessage(exception_message);
         }
 

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -557,7 +557,7 @@ namespace OctoshiftCLI.Tests
                 })
                 .Should()
                 .ThrowExactlyAsync<HttpRequestException>()
-                .WithMessage(EXPECTED_RESPONSE_CONTENT);
+                .WithMessage($"GitHub API error: {EXPECTED_RESPONSE_CONTENT}");
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -530,7 +530,10 @@ namespace OctoshiftCLI.Tests
         public async Task PostAsync_Throws_HttpRequestException_On_Non_Success_Response()
         {
             // Arrange
-            using var httpResponse = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            using var httpResponse = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent(EXPECTED_RESPONSE_CONTENT)
+            };
             var handlerMock = new Mock<HttpMessageHandler>();
             handlerMock
                 .Protected()
@@ -553,7 +556,8 @@ namespace OctoshiftCLI.Tests
                     return githubClient.PostAsync("http://example.com", _rawRequestBody);
                 })
                 .Should()
-                .ThrowExactlyAsync<HttpRequestException>();
+                .ThrowExactlyAsync<HttpRequestException>()
+                .WithMessage(EXPECTED_RESPONSE_CONTENT);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommanHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommanHandlerTests.cs
@@ -714,7 +714,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 TargetRepo = TARGET_REPO,
                 TargetApiUrl = TARGET_API_URL,
                 GhesApiUrl = GHES_API_URL,
-                AzureStorageConnectionString = AZURE_CONNECTION_STRING,
                 NoSslVerify = true,
                 Wait = true
             };

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -86,19 +86,19 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         };
         public Option<string> AzureStorageConnectionString { get; } = new("--azure-storage-connection-string")
         {
-            Description = "Required if migrating from GHES. The connection string for the Azure storage account, used to upload data archives pre-migration. For example: \"DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net\""
+            Description = "Required if migrating from GHES (Not required for GHES 3.8.0 and later). The connection string for the Azure storage account, used to upload data archives pre-migration. For example: \"DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net\""
         };
         public Option<string> AwsBucketName { get; } = new("--aws-bucket-name")
         {
-            Description = "If using AWS, the name of the S3 bucket to upload the BBS archive to."
+            Description = "If using AWS, the name of the S3 bucket to upload the BBS archive to (Not required for GHES 3.8.0 and later)."
         };
         public Option<string> AwsAccessKey { get; } = new("--aws-access-key")
         {
-            Description = "If uploading to S3, the AWS access key. If not provided, it will be read from AWS_ACCESS_KEY environment variable."
+            Description = "If uploading to S3, the AWS access key. If not provided, it will be read from AWS_ACCESS_KEY environment variable (Not required for GHES 3.8.0 and later)."
         };
         public Option<string> AwsSecretKey { get; } = new("--aws-secret-key")
         {
-            Description = "If uploading to S3, the AWS secret key. If not provided, it will be read from AWS_SECRET_KEY environment variable."
+            Description = "If uploading to S3, the AWS secret key. If not provided, it will be read from AWS_SECRET_KEY environment variable (Not required for GHES 3.8.0 and later)."
         };
         public Option<bool> NoSslVerify { get; } = new("--no-ssl-verify")
         {

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -48,7 +48,10 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         _log.RegisterSecret(args.AzureStorageConnectionString);
 
         LogOptions(args);
-        ValidateOptions(args);
+
+        var blobCredentialsRequired = await DetermineIfBlobCredentialsRequired(args);
+
+        ValidateOptions(args, blobCredentialsRequired);
 
         if (args.GhesApiUrl.HasValue())
         {
@@ -57,10 +60,14 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
               args.SourceRepo,
               args.AwsBucketName,
               args.SkipReleases,
-              args.LockSourceRepo
+              args.LockSourceRepo,
+              blobCredentialsRequired
             );
 
-            _log.LogInformation("Archives uploaded to Azure Blob Storage, now starting migration...");
+            if (blobCredentialsRequired)
+            {
+                _log.LogInformation("Archives uploaded to Azure Blob Storage, now starting migration...");
+            }
         }
 
         var githubOrgId = await _targetGithubApi.GetOrganizationId(args.GithubTargetOrg);
@@ -155,7 +162,8 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
       string sourceRepo,
       string awsBucketName,
       bool skipReleases,
-      bool lockSourceRepo)
+      bool lockSourceRepo,
+      bool blobCredentialsRequired)
     {
         var gitDataArchiveId = await _sourceGithubApi.StartGitArchiveGeneration(githubSourceOrg, sourceRepo);
         _log.LogInformation($"Archive generation of git data started with id: {gitDataArchiveId}");
@@ -172,9 +180,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         var metadataArchiveUrl = await WaitForArchiveGeneration(_sourceGithubApi, githubSourceOrg, metadataArchiveId);
         _log.LogInformation($"Archive (metadata) download url: {metadataArchiveUrl}");
 
-        // if GetEnterpriseServerVersion is 3.8.0 or higher, we can skip downloading/uploading and return the archive urls directly
-        var ghesVersion = await _sourceGithubApi.GetEnterpriseServerVersion();
-        if (ghesVersion != null && new Version(ghesVersion) >= new Version(3, 8, 0))
+        if (!blobCredentialsRequired)
         {
             return (gitArchiveUrl, metadataArchiveUrl);
         }
@@ -228,6 +234,26 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             await Task.Delay(CHECK_STATUS_DELAY_IN_MILLISECONDS);
         }
         throw new TimeoutException($"Archive generation timed out after {ARCHIVE_GENERATION_TIMEOUT_IN_HOURS} hours");
+    }
+
+    private async Task<bool> DetermineIfBlobCredentialsRequired(MigrateRepoCommandArgs args)
+    {
+        var blobCredentialsRequired = true;
+        if (args.GhesApiUrl.HasValue())
+        {
+            _log.LogInformation("Using GitHub Enterprise Server - verifying server version");
+            var ghesVersion = await _sourceGithubApi.GetEnterpriseServerVersion();
+            if (ghesVersion != null)
+            {
+                _log.LogInformation($"GitHub Enterprise Server version {ghesVersion} detected");
+                if (new Version(ghesVersion) >= new Version(3, 8, 0))
+                {
+                    blobCredentialsRequired = false;
+                }
+            }
+        }
+
+        return blobCredentialsRequired;
     }
 
     private string GetGithubRepoUrl(string org, string repo, string baseUrl) => $"{baseUrl ?? DEFAULT_GITHUB_BASE_URL}/{org}/{repo}".Replace(" ", "%20");
@@ -343,8 +369,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             _log.LogInformation("AWS SECRET KEY: ***");
         }
     }
-
-    private void ValidateOptions(MigrateRepoCommandArgs args)
+    private void ValidateOptions(MigrateRepoCommandArgs args, bool cloudCredentialsRequired)
     {
         if (args.GithubTargetPat.HasValue() && args.GithubSourcePat.IsNullOrWhiteSpace())
         {
@@ -383,6 +408,15 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         {
             var shouldUseAzureStorage = GetAzureStorageConnectionString(args).HasValue();
             var shouldUseAwsS3 = args.AwsBucketName.HasValue();
+
+            if (!cloudCredentialsRequired)
+            {
+                if (shouldUseAzureStorage || shouldUseAwsS3)
+                {
+                    _log.LogInformation("GHES version is 3.8.0 or later, no need to set cloud storage options here, please set in GHES admin UI.");
+                }
+                return;
+            }
 
             if (!shouldUseAzureStorage && !shouldUseAwsS3)
             {

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -403,6 +403,11 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             throw new OctoshiftCliException("When using archive urls, you must provide both --git-archive-url --metadata-archive-url");
         }
 
+        ValidateGHESOptions(args, cloudCredentialsRequired);
+    }
+
+    private void ValidateGHESOptions(MigrateRepoCommandArgs args, bool cloudCredentialsRequired)
+    {
         // GHES migration path
         if (args.GhesApiUrl.HasValue())
         {


### PR DESCRIPTION
Fixes #755 

I didn't want to move around too much logic so just pulled out the GHES version check to happen earlier to we can properly validate args and then pass that along to the migrations API logic so we don't call the meta API twice.
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated - created https://github.com/github/gh-gei/issues/770

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->

Functionally tested as shown below. Real integration tests will be added in https://github.com/github/gh-gei/issues/756.

#### Tested BAU behavior with older GHES version (3.6.0)
![image](https://user-images.githubusercontent.com/2413532/211442096-98a3439d-f5a7-4d33-b22e-860a7b9566b4.png)

#### Tested new behavior with new GHES version (3.8.0) - no credentials set in UI
![image](https://user-images.githubusercontent.com/2413532/211897540-bfcf7ae8-b6e0-40b3-98e2-1dc0e18e3585.png)

Error message in cli (moved out of verbose log) since this is an expected error we should surface.

#### Tested new behavior with new GHES version (3.8.0) - credentials set in UI
![image](https://user-images.githubusercontent.com/2413532/211442344-1d3dc5ac-576d-480c-8453-db388817310f.png)
![image](https://user-images.githubusercontent.com/2413532/211442379-7ebdfd92-199a-4e16-8b08-f38a3129e123.png)

#### Tested new behavior with new GHES version (3.8.0) - credentials set in UI and in cli 
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/2413532/211442465-dffe5b79-bf64-4942-ad82-ac92fa1ac98f.png">
Can see the note that the user does not need to set in cli anymore. 