### PR TITLE
Update log message after successful blob storage upload to not refer to a specific blob storage provider

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - Improve error messages when the specified target organization or enterprise cannot be found
 - Mask the value for `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` parameters in log output
+- Fix log output so we don't say we've finished upload to Azure Blob Storage when you're actually using Amazon S3

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,2 @@
-- Improved error messages when the specified organization or enterprise cannot be found
-- Mask the value for `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` parameters in the output for blobs storages.
+- Improve error messages when the specified target organization or enterprise cannot be found
+- Mask the value for `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` parameters in log output

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -60,7 +60,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
               args.LockSourceRepo
             );
 
-            _log.LogInformation("Archives uploaded to Azure Blob Storage, now starting migration...");
+            _log.LogInformation("Archives uploaded to blob storage, now starting migration...");
         }
 
         var githubOrgId = await _targetGithubApi.GetOrganizationId(args.GithubTargetOrg);


### PR DESCRIPTION
When running an indirect migration, after finishing the upload of
the archives to blob storage, the CLI outputs the following line
to the logs:

> Archives uploaded to Azure Blob Storage, now starting migration...

It's great to tell the user that the blob storage upload is done,
but we now support Amazon S3 as well as Azure Blob Storage, but
this log line *always* mentions Azure.

This updates the log output to just refer to "blob storage" rather
than a specific provider. Previous lines in the logs will make it
clear which provider was used, e.g.:

> Uploading archive 2022-11-16_22-24-14-10-metadata_archive.tar.gz to AWS S3

Fixes https://github.com/github/gh-gei/issues/740.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)