### PR TITLE
Adding in absent PAT log and tests

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,3 +3,4 @@
 - Fix log output so we don't say we've finished upload to Azure Blob Storage when you're actually using Amazon S3
 - Extend the expiration of blob storage signed URLs from 24hrs to 48hrs so migration can still be successful even if there is a long queue of migrations
 - Skip the upload to Azure/AWS blob storage when migrating from GHES 3.8+, as GHES will now handle putting the archives into blob storage
+- Fixes bug to ensure useful message is returned if empty string passed as PAT arg when no PAT is set in the environment

--- a/src/Octoshift/AdoClient.cs
+++ b/src/Octoshift/AdoClient.cs
@@ -35,6 +35,12 @@ namespace OctoshiftCLI
                 {
                     _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(comments));
                 }
+
+                if (personalAccessToken.IsNullOrWhiteSpace())
+                {
+                    var failureReason = "No PAT provided, please provide a valid PAT as an argument or add a PAT as a environmental variable";
+                    throw new OctoshiftCliException(failureReason);
+                }
             }
         }
 

--- a/src/Octoshift/BbsClient.cs
+++ b/src/Octoshift/BbsClient.cs
@@ -21,6 +21,12 @@ public class BbsClient
         {
             var authCredentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{username}:{password}"));
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", authCredentials);
+
+            if (password.IsNullOrWhiteSpace())
+            {
+                var failureReason = "No password provided, please provide a valid password as an argument or add a password as a environmental variable";
+                throw new OctoshiftCliException(failureReason);
+            }
         }
     }
 

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -41,6 +41,13 @@ namespace OctoshiftCLI
                     _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(comments));
                 }
             }
+
+            if (personalAccessToken.IsNullOrWhiteSpace())
+            {
+                var failureReason = "No PAT provided, please provide a valid PAT as an argument or add a PAT as a environmental variable";
+                throw new OctoshiftCliException(failureReason);
+            }
+
         }
 
         public virtual async Task<string> GetNonSuccessAsync(string url, HttpStatusCode status) => (await SendAsync(HttpMethod.Get, url, expectedStatus: status)).Content;

--- a/src/OctoshiftCLI.Tests/AdoClientTests.cs
+++ b/src/OctoshiftCLI.Tests/AdoClientTests.cs
@@ -42,6 +42,20 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public void Error_Thrown_If_PAT_Not_Provided()
+        {
+            // Arrange
+            using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
+            var failureReason = "No PAT provided, please provide a valid PAT as an argument or add a PAT as a environmental variable";
+
+            // Act
+            var ex = Assert.Throws<OctoshiftCliException>(() => new AdoClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, null));
+
+            // Assert
+            Assert.Equal(failureReason, ex.Message);
+        }
+
+        [Fact]
         public void It_Adds_The_Authorization_Header()
         {
             // Arrange

--- a/src/OctoshiftCLI.Tests/BbsClientTests.cs
+++ b/src/OctoshiftCLI.Tests/BbsClientTests.cs
@@ -36,6 +36,20 @@ public sealed class BbsClientTests : IDisposable
     }
 
     [Fact]
+    public void Error_Thrown_If_Password_Not_Provided()
+    {
+        // Arrange
+        using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
+        var failureReason = "No password provided, please provide a valid password as an argument or add a password as a environmental variable";
+
+        // Act
+        var ex = Assert.Throws<OctoshiftCliException>(() => new BbsClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, USERNAME, ""));
+
+        // Assert
+        Assert.Equal(failureReason, ex.Message);
+    }
+
+    [Fact]
     public void It_Adds_The_Authorization_Header()
     {
         // Arrange

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -47,12 +47,27 @@ namespace OctoshiftCLI.Tests
             _httpResponse?.Dispose();
         }
 
+
+        [Fact]
+        public void Error_Thrown_If_PAT_Not_Provided()
+        {
+            // Arrange
+            using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
+            var failureReason = "No PAT provided, please provide a valid PAT as an argument or add a PAT as a environmental variable";
+
+            // Act
+            var ex = Assert.Throws<OctoshiftCliException>(() => new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, null));
+
+            // Assert
+            Assert.Equal(failureReason, ex.Message);
+        }
+
         [Fact]
         public async Task GetAsync_Returns_String_Response()
         {
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForGet().Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, null);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var actualContent = await githubClient.GetAsync("http://example.com");
@@ -69,7 +84,7 @@ namespace OctoshiftCLI.Tests
             const string graphQLSchemaHeaderValue = "internal";
             var handlerMock = MockHttpHandlerForGet();
             using var httpClient = new HttpClient(handlerMock.Object);
-            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, null);
+            var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
             // Act
             var internalSchemaHeader = new Dictionary<string, string>() { { graphQLSchemaHeaderName, graphQLSchemaHeaderValue } };


### PR DESCRIPTION
Closes #694 

Added in checks within GitHub, Ado, and BBS clients to ensure a useful and appropriate message is returned if an empty string is passed as the PAT arg when no PAT is set in the environment.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)