### PR TITLE
Fix reclaim mannequin command without CSV

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - Added logic to check if a target repo exists before generating GHES archives
+- Fixed a bug when reclaiming a single mannequin with --mannequin-user and --target-user parameters. They were were not being passed to the reclaim command
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,3 @@
 - Added logic to check if a target repo exists before generating GHES archives
-- Fixed a bug when reclaiming a single mannequin with --mannequin-user and --target-user parameters. They were were not being passed to the reclaim command
+- Fixed a bug when reclaiming a single mannequin with --mannequin-user and --target-user parameters. They were not being passed to the reclaim command
 - Added logic to ensure target org exists before generating GHES archives

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,3 @@
 - Added logic to check if a target repo exists before generating GHES archives
-- Fixed a bug when reclaiming a single mannequin with --mannequin-user and --target-user parameters. They were not being passed to the reclaim command
+- Fixed reclaiming a single mannequin using `reclaim-mannequin` with the `--mannequin-user` and `--target-user` parameters
 - Added logic to ensure target org exists before generating GHES archives

--- a/src/Octoshift/Commands/ReclaimMannequinCommandBase.cs
+++ b/src/Octoshift/Commands/ReclaimMannequinCommandBase.cs
@@ -33,7 +33,7 @@ public class ReclaimMannequinCommandBase : CommandBase<ReclaimMannequinCommandAr
         Description = "CSV file path with list of mannequins to be reclaimed."
     };
 
-    public virtual Option<string> MannequinUsername { get; } = new("--mannequin-user")
+    public virtual Option<string> MannequinUser { get; } = new("--mannequin-user")
     {
         Description = "The login of the mannequin to be remapped."
     };
@@ -43,7 +43,7 @@ public class ReclaimMannequinCommandBase : CommandBase<ReclaimMannequinCommandAr
         Description = "The Id of the mannequin, in case there are multiple mannequins with the same login you can specify the id to reclaim one of the mannequins."
     };
 
-    public virtual Option<string> TargetUsername { get; } = new("--target-user")
+    public virtual Option<string> TargetUser { get; } = new("--target-user")
     {
         Description = "The login of the target user to be mapped."
     };
@@ -84,9 +84,9 @@ public class ReclaimMannequinCommandBase : CommandBase<ReclaimMannequinCommandAr
     {
         AddOption(GithubOrg);
         AddOption(Csv);
-        AddOption(MannequinUsername);
+        AddOption(MannequinUser);
         AddOption(MannequinId);
-        AddOption(TargetUsername);
+        AddOption(TargetUser);
         AddOption(Force);
         AddOption(GithubPat);
         AddOption(Verbose);


### PR DESCRIPTION
Individual reclaiming of a mannequin wasn't working. mannequin and target user were not being passed.

closes #760 
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->