### PR TITLE
Automatically build and release the CLI for the `windows-386` build target

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -277,9 +277,11 @@ jobs:
         body_path: ./RELEASENOTES.md
         files: |
           ./dist/ado2gh.*.win-x64.zip
+          ./dist/ado2gh.*.win-x86.zip
           ./dist/ado2gh.*.linux-x64.tar.gz
           ./dist/ado2gh.*.osx-x64.tar.gz
           ./dist/win-x64/gei-windows-amd64.exe
+          ./dist/win-x86/gei-windows-386.exe
           ./dist/linux-x64/gei-linux-amd64
           ./dist/osx-x64/gei-darwin-amd64
     
@@ -290,6 +292,7 @@ jobs:
         repository: github/gh-ado2gh
         token: ${{ secrets.PUBLISH_ADO2GH_TOKEN }}
         files: |
+          ./dist/win-x86/ado2gh-windows-386.exe
           ./dist/win-x64/ado2gh-windows-amd64.exe
           ./dist/linux-x64/ado2gh-linux-amd64
           ./dist/osx-x64/ado2gh-darwin-amd64
@@ -301,6 +304,7 @@ jobs:
         repository: github/gh-bbs2gh
         token: ${{ secrets.PUBLISH_BBS2GH_TOKEN }}
         files: |
+          ./dist/win-x86/bbs2gh-windows-386.exe
           ./dist/win-x64/bbs2gh-windows-amd64.exe
           ./dist/linux-x64/bbs2gh-linux-amd64
           ./dist/osx-x64/bbs2gh-darwin-amd64

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,3 @@
+- Added support for x86 Windows machines with new `windows-386` build
 - Added logic to check if a target repo exists before generating GHES archives
 - Added logic to ensure target org exists before generating GHES archives
-

--- a/publish.ps1
+++ b/publish.ps1
@@ -26,6 +26,20 @@ else {
     }
 
     Copy-Item ./dist/win-x64/ado2gh.exe ./dist/win-x64/ado2gh-windows-amd64.exe
+
+    dotnet publish src/ado2gh/ado2gh.csproj -c Release -o dist/win-x86/ -r win-x86 -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    Compress-Archive -Path ./dist/win-x86/ado2gh.exe -DestinationPath ./dist/ado2gh.$AssemblyVersion.win-x86.zip -Force
+    
+    if (Test-Path -Path ./dist/win-x86/ado2gh-windows-386.exe) {
+        Remove-Item ./dist/win-x86/ado2gh-windows-386.exe
+    }
+
+    Copy-Item ./dist/win-x86/ado2gh.exe ./dist/win-x86/ado2gh-windows-386.exe
 }
 
 if ((Test-Path env:SKIP_LINUX) -And $env:SKIP_LINUX.ToUpper() -eq "TRUE") {
@@ -83,6 +97,18 @@ else {
     }
 
     Rename-Item ./dist/win-x64/gei.exe gei-windows-amd64.exe
+
+    dotnet publish src/gei/gei.csproj -c Release -o dist/win-x86/ -r win-x86 -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    if (Test-Path -Path ./dist/win-x86/gei-windows-386.exe) {
+        Remove-Item ./dist/win-x86/gei-windows-386.exe
+    }
+
+    Rename-Item ./dist/win-x86/gei.exe gei-windows-386.exe
 }
 
 if ((Test-Path env:SKIP_LINUX) -And $env:SKIP_LINUX.ToUpper() -eq "TRUE") {
@@ -135,6 +161,18 @@ else {
     }
 
     Rename-Item ./dist/win-x64/bbs2gh.exe bbs2gh-windows-amd64.exe
+
+    dotnet publish src/bbs2gh/bbs2gh.csproj -c Release -o dist/win-x86/ -r win-x86 -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    if (Test-Path -Path ./dist/win-x86/bbs2gh-windows-386.exe) {
+        Remove-Item ./dist/win-x86/bbs2gh-windows-386.exe
+    }
+
+    Rename-Item ./dist/win-x86/bbs2gh.exe bbs2gh-windows-386.exe
 }
 
 if ((Test-Path env:SKIP_LINUX) -And $env:SKIP_LINUX.ToUpper() -eq "TRUE") {


### PR DESCRIPTION
This updates our release process to build each of our CLIs for x86 Windows devices (i.e. just about anything that isn't x64 or ARM!).

At this time, we don't have a way to test that these binaries work as part of our CI/CD process. Nevertheless, we think it's better to distribute a binary that should work than to offer nothing to users who want x86 support! If people run into any problems, they can create an issue and we will, of course, look into it.

Fixes https://github.com/github/gh-gei/issues/796.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)