### PR TITLE
Add an INT test covering BBS S3 archive upload

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -205,6 +205,8 @@ jobs:
         AZURE_STORAGE_CONNECTION_STRING_LINUX: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_LINUX }}
         AZURE_STORAGE_CONNECTION_STRING_MACOS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_MACOS }}
         AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}
+        AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
         GEI_DEBUG_MODE: 'true'
         LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:${{ github.workspace }}/src/OctoshiftCLI.IntegrationTests/bin/Debug/net6.0/runtimes/ubuntu.18.04-x64/native'
       run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -133,6 +133,8 @@ jobs:
         AZURE_STORAGE_CONNECTION_STRING_LINUX: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_LINUX }}
         AZURE_STORAGE_CONNECTION_STRING_MACOS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_MACOS }}
         AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}
+        AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
         GEI_DEBUG_MODE: 'true'
         LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:${{ github.workspace }}/src/OctoshiftCLI.IntegrationTests/bin/Debug/net6.0/runtimes/ubuntu.18.04-x64/native'
       run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -112,8 +112,8 @@ public sealed class BbsToGithub : IDisposable
         }
         else
         {
-            _tokens.Add("--aws-access-key", Environment.GetEnvironmentVariable("AWS_ACCESS_KEY"));
-            _tokens.Add("--aws-secret-key", Environment.GetEnvironmentVariable("AWS_SECRET_KEY"));
+            _tokens.Add("AWS_ACCESS_KEY", Environment.GetEnvironmentVariable("AWS_ACCESS_KEY"));
+            _tokens.Add("AWS_SECRET_KEY", Environment.GetEnvironmentVariable("AWS_SECRET_KEY"));
             archiveUploadOptions = $" --aws-bucket-name {AWS_BUCKET_NAME}";
         }
 


### PR DESCRIPTION
Closes #815 

This test adds a new end to end INT test for BBS that migrates an export archive using AWS S3 instead of Azure blob storage. 
We have an AWS S3 bucket just for dev testing under the name of `github-dev`. Unfortunately there is no straight forward paved path for internal AWS usage so I wasn't able to do full bucket provisioning (deleting all contents before each test) but I understand that for dev purposes it's ok not to. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)
