### PR TITLE
Including the repo name in Bitbucket Server migration archive filenames

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,3 +2,4 @@
 - Added logic to check if a target repo exists before generating GHES archives
 - Fixed reclaiming a single mannequin using `reclaim-mannequin` with the `--mannequin-user` and `--target-user` parameters
 - Added logic to ensure target org exists before generating GHES archives
+- Updated filenames for Bitbucket Server migration archives to include the repo name

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -110,7 +110,7 @@ namespace OctoshiftCLI.Tests.bbs2gh.Handlers
             await _handler.Handle(args);
 
             // Assert
-            _mockBbsArchiveDownloader.Verify(m => m.Download(BBS_EXPORT_ID, It.IsAny<string>()));
+            _mockBbsArchiveDownloader.Verify(m => m.Download(BBS_EXPORT_ID, BBS_REPO, It.IsAny<string>()));
         }
 
         [Fact]
@@ -147,7 +147,7 @@ namespace OctoshiftCLI.Tests.bbs2gh.Handlers
             // Arrange
             _mockBbsApi.Setup(x => x.StartExport(BBS_PROJECT, BBS_REPO)).ReturnsAsync(BBS_EXPORT_ID);
             _mockBbsApi.Setup(x => x.GetExport(BBS_EXPORT_ID)).ReturnsAsync(("COMPLETED", "The export is complete", 100));
-            _mockBbsArchiveDownloader.Setup(x => x.Download(BBS_EXPORT_ID, It.IsAny<string>())).ReturnsAsync(ARCHIVE_PATH);
+            _mockBbsArchiveDownloader.Setup(x => x.Download(BBS_EXPORT_ID, BBS_REPO, It.IsAny<string>())).ReturnsAsync(ARCHIVE_PATH);
             _mockFileSystemProvider.Setup(x => x.ReadAllBytesAsync(ARCHIVE_PATH)).ReturnsAsync(ARCHIVE_DATA);
             _mockAzureApi.Setup(x => x.UploadToBlob(It.IsAny<string>(), ARCHIVE_DATA)).ReturnsAsync(new Uri(ARCHIVE_URL));
             _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
@@ -186,7 +186,7 @@ namespace OctoshiftCLI.Tests.bbs2gh.Handlers
             // Arrange
             _mockBbsApi.Setup(x => x.StartExport(BBS_PROJECT, BBS_REPO)).ReturnsAsync(BBS_EXPORT_ID);
             _mockBbsApi.Setup(x => x.GetExport(BBS_EXPORT_ID)).ReturnsAsync(("COMPLETED", "The export is complete", 100));
-            _mockBbsArchiveDownloader.Setup(x => x.Download(BBS_EXPORT_ID, It.IsAny<string>())).ReturnsAsync(ARCHIVE_PATH);
+            _mockBbsArchiveDownloader.Setup(x => x.Download(BBS_EXPORT_ID, BBS_REPO, It.IsAny<string>())).ReturnsAsync(ARCHIVE_PATH);
             _mockAwsApi.Setup(x => x.UploadToBucket(AWS_BUCKET_NAME, ARCHIVE_PATH, It.IsAny<string>())).ReturnsAsync(ARCHIVE_URL);
             _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
             _mockGithubApi.Setup(x => x.CreateBbsMigrationSource(GITHUB_ORG_ID).Result).Returns(MIGRATION_SOURCE_ID);
@@ -226,7 +226,7 @@ namespace OctoshiftCLI.Tests.bbs2gh.Handlers
             // Arrange
             _mockBbsApi.Setup(x => x.StartExport(BBS_PROJECT, BBS_REPO)).ReturnsAsync(BBS_EXPORT_ID);
             _mockBbsApi.Setup(x => x.GetExport(BBS_EXPORT_ID)).ReturnsAsync(("COMPLETED", "The export is complete", 100));
-            _mockBbsArchiveDownloader.Setup(x => x.GetSourceExportArchiveAbsolutePath(BBS_EXPORT_ID)).Returns(ARCHIVE_PATH);
+            _mockBbsArchiveDownloader.Setup(x => x.GetSourceExportArchiveAbsolutePath(BBS_EXPORT_ID, BBS_REPO)).Returns(ARCHIVE_PATH);
             _mockFileSystemProvider.Setup(x => x.ReadAllBytesAsync(ARCHIVE_PATH)).ReturnsAsync(ARCHIVE_DATA);
             _mockAzureApi.Setup(x => x.UploadToBlob(It.IsAny<string>(), ARCHIVE_DATA)).ReturnsAsync(new Uri(ARCHIVE_URL));
             _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
@@ -265,7 +265,7 @@ namespace OctoshiftCLI.Tests.bbs2gh.Handlers
             _mockEnvironmentVariableProvider.Setup(m => m.BbsPassword(It.IsAny<bool>())).Returns(BBS_PASSWORD);
             _mockBbsApi.Setup(x => x.StartExport(BBS_PROJECT, BBS_REPO)).ReturnsAsync(BBS_EXPORT_ID);
             _mockBbsApi.Setup(x => x.GetExport(BBS_EXPORT_ID)).ReturnsAsync(("COMPLETED", "The export is complete", 100));
-            _mockBbsArchiveDownloader.Setup(x => x.Download(BBS_EXPORT_ID, It.IsAny<string>())).ReturnsAsync(ARCHIVE_PATH);
+            _mockBbsArchiveDownloader.Setup(x => x.Download(BBS_EXPORT_ID, BBS_REPO, It.IsAny<string>())).ReturnsAsync(ARCHIVE_PATH);
             _mockFileSystemProvider.Setup(x => x.ReadAllBytesAsync(ARCHIVE_PATH)).ReturnsAsync(ARCHIVE_DATA);
             _mockAzureApi.Setup(x => x.UploadToBlob(It.IsAny<string>(), ARCHIVE_DATA)).ReturnsAsync(new Uri(ARCHIVE_URL));
             _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
@@ -618,7 +618,7 @@ namespace OctoshiftCLI.Tests.bbs2gh.Handlers
             _mockBbsApi.Setup(x => x.StartExport(BBS_PROJECT, BBS_REPO)).ReturnsAsync(BBS_EXPORT_ID);
             _mockBbsApi.Setup(x => x.GetExport(BBS_EXPORT_ID)).ReturnsAsync(("COMPLETED", "The export is complete", 100));
             _mockAzureApi.Setup(x => x.UploadToBlob(It.IsAny<string>(), It.IsAny<byte[]>())).ReturnsAsync(new Uri(ARCHIVE_URL));
-            _mockBbsArchiveDownloader.Setup(x => x.GetSourceExportArchiveAbsolutePath(BBS_EXPORT_ID)).Returns(ARCHIVE_PATH);
+            _mockBbsArchiveDownloader.Setup(x => x.GetSourceExportArchiveAbsolutePath(BBS_EXPORT_ID, BBS_REPO)).Returns(ARCHIVE_PATH);
 
             // Act
             var args = new MigrateRepoCommandArgs

--- a/src/OctoshiftCLI.Tests/bbs2gh/Services/BbsSmbArchiveDownloaderTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Services/BbsSmbArchiveDownloaderTests.cs
@@ -19,12 +19,13 @@ public class BbsSmbArchiveDownloaderTests
     private const string BBS_HOME_DIRECTORY_FROM_SHARE = "PATH\\TO\\BBS\\HOME\\DIRECTORY";
     private const string BBS_HOME_DIRECTORY = $"{SHARE_ROOT}\\{BBS_HOME_DIRECTORY_FROM_SHARE}";
     private const string TARGET_DIRECTORY = "TARGET";
+    private const string REPO_NAME = "REPO_NAME";
     private const string HOST = "HOST";
     private const string SMB_USER = "SMB_USER";
     private const string SMB_PASSWORD = "SMB_PASSWORD";
     private const string DOMAIN = "DOMAIN";
 
-    private readonly string _exportArchiveFilename = $"Bitbucket_export_{EXPORT_JOB_ID}.tar";
+    private readonly string _exportArchiveFilename = $"Bitbucket_export_{REPO_NAME}_{EXPORT_JOB_ID}.tar";
     private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
     private readonly Mock<FileSystemProvider> _mockFileSystemProvider = TestHelpers.CreateMock<FileSystemProvider>();
     private readonly Mock<ISMBClient> _mockSmbClient = new();
@@ -86,7 +87,7 @@ public class BbsSmbArchiveDownloaderTests
             .Returns(NTStatus.STATUS_END_OF_FILE);
 
         // Act
-        var actualTargetArchiveFullName = await _bbsArchiveDownloader.Download(EXPORT_JOB_ID, TARGET_DIRECTORY);
+        var actualTargetArchiveFullName = await _bbsArchiveDownloader.Download(EXPORT_JOB_ID, REPO_NAME, TARGET_DIRECTORY);
 
         // Assert
         _mockSmbClient.Verify(m => m.Connect(HOST, SMBTransportType.DirectTCPTransport), Times.Once);
@@ -120,7 +121,7 @@ public class BbsSmbArchiveDownloaderTests
 
         // Act, Assert
         await _bbsArchiveDownloader
-            .Invoking(async x => await x.Download(EXPORT_JOB_ID, TARGET_DIRECTORY))
+            .Invoking(async x => await x.Download(EXPORT_JOB_ID, REPO_NAME, TARGET_DIRECTORY))
             .Should()
             .ThrowExactlyAsync<OctoshiftCliException>();
     }
@@ -134,7 +135,7 @@ public class BbsSmbArchiveDownloaderTests
 
         // Act, Assert
         await _bbsArchiveDownloader
-            .Invoking(x => x.Download(EXPORT_JOB_ID, TARGET_DIRECTORY))
+            .Invoking(x => x.Download(EXPORT_JOB_ID, REPO_NAME, TARGET_DIRECTORY))
             .Should()
             .ThrowExactlyAsync<OctoshiftCliException>()
             .WithMessage($"*{NTStatus.STATUS_LOGON_FAILURE}*");
@@ -151,7 +152,7 @@ public class BbsSmbArchiveDownloaderTests
 
         // Act, Assert
         await _bbsArchiveDownloader
-            .Invoking(x => x.Download(EXPORT_JOB_ID, TARGET_DIRECTORY))
+            .Invoking(x => x.Download(EXPORT_JOB_ID, REPO_NAME, TARGET_DIRECTORY))
             .Should()
             .ThrowExactlyAsync<OctoshiftCliException>()
             .WithMessage($"*{NTStatus.STATUS_BAD_NETWORK_NAME}*");
@@ -182,7 +183,7 @@ public class BbsSmbArchiveDownloaderTests
 
         // Act, Assert
         await _bbsArchiveDownloader
-            .Invoking(x => x.Download(EXPORT_JOB_ID, TARGET_DIRECTORY))
+            .Invoking(x => x.Download(EXPORT_JOB_ID, REPO_NAME, TARGET_DIRECTORY))
             .Should()
             .ThrowExactlyAsync<OctoshiftCliException>()
             .WithMessage($"*{NTStatus.STATUS_OBJECT_NAME_NOT_FOUND}*");
@@ -197,7 +198,7 @@ public class BbsSmbArchiveDownloaderTests
 
         // Act, Assert
         await _bbsArchiveDownloader
-            .Invoking(x => x.Download(EXPORT_JOB_ID, TARGET_DIRECTORY))
+            .Invoking(x => x.Download(EXPORT_JOB_ID, REPO_NAME, TARGET_DIRECTORY))
             .Should()
             .ThrowExactlyAsync<OctoshiftCliException>()
             .WithMessage($"*{targetArchiveFullName}*");

--- a/src/OctoshiftCLI.Tests/bbs2gh/Services/BbsSshArchiveDownloaderTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Services/BbsSshArchiveDownloaderTests.cs
@@ -15,7 +15,9 @@ public sealed class BbsSshArchiveDownloaderTests : IDisposable
     private const string BBS_HOME_DIRECTORY = "BBS_HOME";
     private const string TARGET_DIRECTORY = "TARGET";
 
-    private readonly string _exportArchiveFilename = $"Bitbucket_export_{EXPORT_JOB_ID}.tar";
+    private const string REPO_NAME = "REPO_NAME";
+
+    private readonly string _exportArchiveFilename = $"Bitbucket_export_{REPO_NAME}_{EXPORT_JOB_ID}.tar";
     private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
     private readonly Mock<FileSystemProvider> _mockFileSystemProvider = TestHelpers.CreateMock<FileSystemProvider>();
     private readonly Mock<ISftpClient> _mockSftpClient = new();
@@ -45,7 +47,7 @@ public sealed class BbsSshArchiveDownloaderTests : IDisposable
         var expectedTargetArchiveFullName = Path.Join(TARGET_DIRECTORY, _exportArchiveFilename).Replace('\\', '/');
 
         // Act
-        var actualDownloadedArchiveFullName = await _bbsArchiveDownloader.Download(EXPORT_JOB_ID, TARGET_DIRECTORY);
+        var actualDownloadedArchiveFullName = await _bbsArchiveDownloader.Download(EXPORT_JOB_ID, REPO_NAME, TARGET_DIRECTORY);
 
         // Assert
         _mockSftpClient.Verify(m =>
@@ -67,7 +69,7 @@ public sealed class BbsSshArchiveDownloaderTests : IDisposable
         _mockFileSystemProvider.Setup(m => m.FileExists(It.Is<string>(x => x.Contains(_exportArchiveFilename)))).Returns(true);
 
         // Act, Assert
-        await _bbsArchiveDownloader.Invoking(x => x.Download(EXPORT_JOB_ID)).Should().ThrowExactlyAsync<OctoshiftCliException>();
+        await _bbsArchiveDownloader.Invoking(x => x.Download(EXPORT_JOB_ID, REPO_NAME)).Should().ThrowExactlyAsync<OctoshiftCliException>();
     }
 
     [Fact]
@@ -77,14 +79,14 @@ public sealed class BbsSshArchiveDownloaderTests : IDisposable
         _mockSftpClient.Setup(m => m.Exists(It.IsAny<string>())).Returns(false);
 
         // Act, Assert
-        await _bbsArchiveDownloader.Invoking(x => x.Download(EXPORT_JOB_ID)).Should().ThrowExactlyAsync<OctoshiftCliException>();
+        await _bbsArchiveDownloader.Invoking(x => x.Download(EXPORT_JOB_ID, REPO_NAME)).Should().ThrowExactlyAsync<OctoshiftCliException>();
     }
 
     [Fact]
     public async Task Download_Creates_Target_Directory()
     {
         // Arrange, Act
-        await _bbsArchiveDownloader.Download(EXPORT_JOB_ID, TARGET_DIRECTORY);
+        await _bbsArchiveDownloader.Download(EXPORT_JOB_ID, REPO_NAME, TARGET_DIRECTORY);
 
         // Assert
         _mockFileSystemProvider.Verify(m => m.CreateDirectory(TARGET_DIRECTORY), Times.Once);

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -65,7 +65,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
             if (ShouldDownloadArchive(args))
             {
-                args.ArchivePath = await DownloadArchive(exportId);
+                args.ArchivePath = await DownloadArchive(exportId, args.BbsRepo);
             }
         }
 
@@ -74,7 +74,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             // This is for the case where the CLI is being run on the BBS server itself
             if (args.ArchivePath.IsNullOrWhiteSpace())
             {
-                args.ArchivePath = _bbsArchiveDownloader.GetSourceExportArchiveAbsolutePath(exportId);
+                args.ArchivePath = _bbsArchiveDownloader.GetSourceExportArchiveAbsolutePath(exportId, args.BbsRepo);
             }
 
             args.ArchiveUrl = args.AwsBucketName.HasValue()
@@ -108,10 +108,10 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         return args.ArchiveUrl.HasValue();
     }
 
-    private async Task<string> DownloadArchive(long exportId)
+    private async Task<string> DownloadArchive(long exportId, string repoName)
     {
         _log.LogInformation($"Download archive {exportId} started...");
-        var downloadedArchiveFullPath = await _bbsArchiveDownloader.Download(exportId);
+        var downloadedArchiveFullPath = await _bbsArchiveDownloader.Download(exportId, repoName);
         _log.LogInformation($"Archive was successfully downloaded at \"{downloadedArchiveFullPath}\".");
 
         return downloadedArchiveFullPath;

--- a/src/bbs2gh/Services/BbsSmbArchiveDownloader.cs
+++ b/src/bbs2gh/Services/BbsSmbArchiveDownloader.cs
@@ -48,22 +48,22 @@ public sealed class BbsSmbArchiveDownloader : IBbsArchiveDownloader
 
     public string BbsSharedHomeDirectory { get; init; } = DEFAULT_BBS_SHARED_HOME_DIRECTORY;
 
-    public string GetSourceExportArchiveAbsolutePath(long exportJobId) => Path.Join(BbsSharedHomeDirectory ?? DEFAULT_BBS_SHARED_HOME_DIRECTORY,
-        IBbsArchiveDownloader.GetSourceExportArchiveRelativePath(exportJobId)).ToWindowsPath();
+    public string GetSourceExportArchiveAbsolutePath(long exportJobId, string repoName) => Path.Join(BbsSharedHomeDirectory ?? DEFAULT_BBS_SHARED_HOME_DIRECTORY,
+        IBbsArchiveDownloader.GetSourceExportArchiveRelativePath(exportJobId, repoName)).ToWindowsPath();
 
-    public async Task<string> Download(long exportJobId, string targetDirectory = IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY)
+    public async Task<string> Download(long exportJobId, string repoName, string targetDirectory = IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY)
     {
         _nextProgressReport = DateTime.Now;
 
         ISMBFileStore fileStore = null;
         object sourceExportArchiveHandle = null;
 
-        var sourceExportArchiveFullPath = GetSourceExportArchiveAbsolutePath(exportJobId);
+        var sourceExportArchiveFullPath = GetSourceExportArchiveAbsolutePath(exportJobId, repoName);
         var share = sourceExportArchiveFullPath[..sourceExportArchiveFullPath.IndexOf("\\", StringComparison.Ordinal)];
         var sourceExportArchivePathAfterShare = sourceExportArchiveFullPath[(sourceExportArchiveFullPath.IndexOf("\\", StringComparison.Ordinal) + 1)..];
 
         var targetExportArchiveFullPath =
-            Path.Join(targetDirectory ?? IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY, IBbsArchiveDownloader.GetExportArchiveFileName(exportJobId)).ToUnixPath();
+            Path.Join(targetDirectory ?? IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY, IBbsArchiveDownloader.GetExportArchiveFileName(exportJobId, repoName)).ToUnixPath();
 
         await using var targetExportArchive = OpenWriteTargetExportArchive(targetExportArchiveFullPath);
 

--- a/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
+++ b/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
@@ -74,18 +74,18 @@ public sealed class BbsSshArchiveDownloader : IBbsArchiveDownloader, IDisposable
 
     public string BbsSharedHomeDirectory { get; init; } = DEFAULT_BBS_SHARED_HOME_DIRECTORY;
 
-    public string GetSourceExportArchiveAbsolutePath(long exportJobId)
+    public string GetSourceExportArchiveAbsolutePath(long exportJobId, string repoName)
     {
-        return Path.Join(BbsSharedHomeDirectory ?? DEFAULT_BBS_SHARED_HOME_DIRECTORY, IBbsArchiveDownloader.GetSourceExportArchiveRelativePath(exportJobId)).ToUnixPath();
+        return Path.Join(BbsSharedHomeDirectory ?? DEFAULT_BBS_SHARED_HOME_DIRECTORY, IBbsArchiveDownloader.GetSourceExportArchiveRelativePath(exportJobId, repoName)).ToUnixPath();
     }
 
-    public async Task<string> Download(long exportJobId, string targetDirectory = IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY)
+    public async Task<string> Download(long exportJobId, string repoName, string targetDirectory = IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY)
     {
         _nextProgressReport = DateTime.Now;
 
-        var sourceExportArchiveFullPath = GetSourceExportArchiveAbsolutePath(exportJobId);
+        var sourceExportArchiveFullPath = GetSourceExportArchiveAbsolutePath(exportJobId, repoName);
         var targetExportArchiveFullPath =
-            Path.Join(targetDirectory ?? IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY, IBbsArchiveDownloader.GetExportArchiveFileName(exportJobId)).ToUnixPath();
+            Path.Join(targetDirectory ?? IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY, IBbsArchiveDownloader.GetExportArchiveFileName(exportJobId, repoName)).ToUnixPath();
 
         if (_fileSystemProvider.FileExists(targetExportArchiveFullPath))
         {

--- a/src/bbs2gh/Services/IBbsArchiveDownloader.cs
+++ b/src/bbs2gh/Services/IBbsArchiveDownloader.cs
@@ -9,11 +9,11 @@ public interface IBbsArchiveDownloader
     const string EXPORT_ARCHIVE_SOURCE_DIRECTORY = "data/migration/export";
     const string DEFAULT_TARGET_DIRECTORY = "bbs_archive_downloads";
 
-    Task<string> Download(long exportJobId, string targetDirectory = DEFAULT_TARGET_DIRECTORY);
+    Task<string> Download(long exportJobId, string repoName, string targetDirectory = DEFAULT_TARGET_DIRECTORY);
 
-    string GetSourceExportArchiveAbsolutePath(long exportJobId);
+    string GetSourceExportArchiveAbsolutePath(long exportJobId, string repoName);
 
-    static string GetExportArchiveFileName(long exportJobId) => $"Bitbucket_export_{exportJobId}.tar";
+    static string GetExportArchiveFileName(long exportJobId, string repoName) => $"Bitbucket_export_{repoName}_{exportJobId}.tar";
 
-    static string GetSourceExportArchiveRelativePath(long exportJobId) => Path.Join(EXPORT_ARCHIVE_SOURCE_DIRECTORY, GetExportArchiveFileName(exportJobId)).ToUnixPath();
+    static string GetSourceExportArchiveRelativePath(long exportJobId, string repoName) => Path.Join(EXPORT_ARCHIVE_SOURCE_DIRECTORY, GetExportArchiveFileName(exportJobId, repoName)).ToUnixPath();
 }


### PR DESCRIPTION
When running a Bitbucket Server migration, the archive from the Bitbucket Server instance is stored in the `bbs_archive_downloads` directory. At the moment, the filename only contains the migration ID.

This makes it hard to identify which file is which, which makes life difficult when we want to ask a customer for a copy of their archive for debugging purposes.

This updates the download process so we include the migration ID and the BBS repo name in the filename of the downloaded TAR files.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->