### PR TITLE
Overwrite export archive if exists

### DIFF
--- a/src/OctoshiftCLI.Tests/bbs2gh/Services/BbsSmbArchiveDownloaderTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Services/BbsSmbArchiveDownloaderTests.cs
@@ -106,7 +106,7 @@ public class BbsSmbArchiveDownloaderTests
         _mockSmbFileStore.Verify(m => m.GetFileInformation(out fileStandardInformation, sharedFileHandle, FileInformationClass.FileStandardInformation), Times.Once);
         _mockSmbFileStore.Verify(m => m.ReadFile(out data, sharedFileHandle, It.IsAny<long>(), It.IsAny<int>()), Times.Exactly(3));
         _mockFileSystemProvider.Verify(m => m.CreateDirectory(TARGET_DIRECTORY), Times.Once);
-        _mockFileSystemProvider.Verify(m => m.Open(expectedTargetArchiveFullName, FileMode.CreateNew), Times.Once);
+        _mockFileSystemProvider.Verify(m => m.Open(expectedTargetArchiveFullName, FileMode.Create), Times.Once);
         _mockFileSystemProvider.Verify(m => m.WriteAsync(It.IsAny<FileStream>(), data, It.IsAny<CancellationToken>()), Times.Exactly(2));
 
         actualTargetArchiveFullName.Should().Be(expectedTargetArchiveFullName);
@@ -186,20 +186,5 @@ public class BbsSmbArchiveDownloaderTests
             .Should()
             .ThrowExactlyAsync<OctoshiftCliException>()
             .WithMessage($"*{NTStatus.STATUS_OBJECT_NAME_NOT_FOUND}*");
-    }
-
-    [Fact]
-    public async Task Download_Throws_When_Target_Export_Archive_Already_Exists()
-    {
-        // Arrange
-        var targetArchiveFullName = Path.Join(TARGET_DIRECTORY, _exportArchiveFilename).ToUnixPath();
-        _mockFileSystemProvider.Setup(m => m.FileExists(targetArchiveFullName)).Returns(true);
-
-        // Act, Assert
-        await _bbsArchiveDownloader
-            .Invoking(x => x.Download(EXPORT_JOB_ID, TARGET_DIRECTORY))
-            .Should()
-            .ThrowExactlyAsync<OctoshiftCliException>()
-            .WithMessage($"*{targetArchiveFullName}*");
     }
 }

--- a/src/OctoshiftCLI.Tests/bbs2gh/Services/BbsSshArchiveDownloaderTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Services/BbsSshArchiveDownloaderTests.cs
@@ -56,18 +56,8 @@ public sealed class BbsSshArchiveDownloaderTests : IDisposable
                 null,
                 It.IsAny<Action<ulong>>()));
 
-        _mockFileSystemProvider.Verify(m => m.Open(expectedTargetArchiveFullName, FileMode.CreateNew));
+        _mockFileSystemProvider.Verify(m => m.Open(expectedTargetArchiveFullName, FileMode.Create));
         actualDownloadedArchiveFullName.Should().Be(expectedTargetArchiveFullName);
-    }
-
-    [Fact]
-    public async Task Download_Throws_When_Target_Export_Archive_Already_Exists()
-    {
-        // Arrange
-        _mockFileSystemProvider.Setup(m => m.FileExists(It.Is<string>(x => x.Contains(_exportArchiveFilename)))).Returns(true);
-
-        // Act, Assert
-        await _bbsArchiveDownloader.Invoking(x => x.Download(EXPORT_JOB_ID)).Should().ThrowExactlyAsync<OctoshiftCliException>();
     }
 
     [Fact]

--- a/src/bbs2gh/Services/BbsSmbArchiveDownloader.cs
+++ b/src/bbs2gh/Services/BbsSmbArchiveDownloader.cs
@@ -155,13 +155,8 @@ public sealed class BbsSmbArchiveDownloader : IBbsArchiveDownloader
 
     private FileStream OpenWriteTargetExportArchive(string targetExportArchiveFullPath)
     {
-        if (_fileSystemProvider.FileExists(targetExportArchiveFullPath))
-        {
-            throw new OctoshiftCliException($"Target export archive ({targetExportArchiveFullPath}) already exists.");
-        }
-
         _fileSystemProvider.CreateDirectory(Path.GetDirectoryName(targetExportArchiveFullPath));
-        return _fileSystemProvider.Open(targetExportArchiveFullPath, FileMode.CreateNew);
+        return _fileSystemProvider.Open(targetExportArchiveFullPath, FileMode.Create);
     }
 
     private void ConnectToHost()

--- a/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
+++ b/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
@@ -87,11 +87,6 @@ public sealed class BbsSshArchiveDownloader : IBbsArchiveDownloader, IDisposable
         var targetExportArchiveFullPath =
             Path.Join(targetDirectory ?? IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY, IBbsArchiveDownloader.GetExportArchiveFileName(exportJobId)).ToUnixPath();
 
-        if (_fileSystemProvider.FileExists(targetExportArchiveFullPath))
-        {
-            throw new OctoshiftCliException($"Target export archive ({targetExportArchiveFullPath}) already exists.");
-        }
-
         if (_sftpClient is BaseClient { IsConnected: false } client)
         {
             client.Connect();
@@ -105,7 +100,7 @@ public sealed class BbsSshArchiveDownloader : IBbsArchiveDownloader, IDisposable
         _fileSystemProvider.CreateDirectory(targetDirectory);
 
         var sourceExportArchiveSize = _sftpClient.GetAttributes(sourceExportArchiveFullPath)?.Size ?? long.MaxValue;
-        await using var targetExportArchive = _fileSystemProvider.Open(targetExportArchiveFullPath, FileMode.CreateNew);
+        await using var targetExportArchive = _fileSystemProvider.Open(targetExportArchiveFullPath, FileMode.Create);
         await Task.Factory.FromAsync(
             _sftpClient.BeginDownloadFile(
                 sourceExportArchiveFullPath,


### PR DESCRIPTION
We used to throw an exception if the target export archive already exists during BBS archive download process. This is something that will probably never happen in real scenarios and may only happen in our test environment. So this PR just overwrite the target file. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)
