### PR TITLE
Support implicit AWS SDK credential resolution

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 - Create shared access signature (SAS) with read-only permissions - not read-write - when generating Azure Blob Storage URL
+- Add support for Implicit Credentials Resolution for the S3 bucket: https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/creds-assign.html

--- a/src/Octoshift/AwsApi.cs
+++ b/src/Octoshift/AwsApi.cs
@@ -17,9 +17,9 @@ public class AwsApi : IDisposable
     private readonly ITransferUtility _transferUtility;
 
 #pragma warning disable CA2000
-    public AwsApi(AWSCredentials credentials) 
+    public AwsApi(AWSCredentials credentials)
         : this(new AmazonS3Client(credentials, RegionEndpoint))
-            
+
 #pragma warning restore CA2000
     {
     }

--- a/src/Octoshift/AwsApi.cs
+++ b/src/Octoshift/AwsApi.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using Amazon;
+using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Transfer;
@@ -16,11 +17,14 @@ public class AwsApi : IDisposable
     private readonly ITransferUtility _transferUtility;
 
 #pragma warning disable CA2000
-    public AwsApi(string awsAccessKey, string awsSecretKey) : this(new TransferUtility(new AmazonS3Client(awsAccessKey, awsSecretKey, RegionEndpoint)))
+    public AwsApi(AWSCredentials credentials) 
+        : this(new AmazonS3Client(credentials, RegionEndpoint))
+            
 #pragma warning restore CA2000
     {
     }
 
+    private AwsApi(IAmazonS3 s3Client) : this(new TransferUtility(s3Client)) { }
     internal AwsApi(ITransferUtility transferUtility) => _transferUtility = transferUtility;
 
     public virtual async Task<string> UploadToBucket(string bucketName, string fileName, string keyName)

--- a/src/Octoshift/EnvironmentVariableProvider.cs
+++ b/src/Octoshift/EnvironmentVariableProvider.cs
@@ -8,8 +8,6 @@ public class EnvironmentVariableProvider
     private const string TARGET_GH_PAT = "GH_PAT";
     private const string ADO_PAT = "ADO_PAT";
     private const string AZURE_STORAGE_CONNECTION_STRING = "AZURE_STORAGE_CONNECTION_STRING";
-    private const string AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
-    private const string AWS_SECRET_KEY = "AWS_SECRET_KEY";
     private const string BBS_USERNAME = "BBS_USERNAME";
     private const string BBS_PASSWORD = "BBS_PASSWORD";
     private const string SMB_PASSWORD = "SMB_PASSWORD";
@@ -32,12 +30,6 @@ public class EnvironmentVariableProvider
 
     public virtual string AzureStorageConnectionString(bool throwIfNotFound = true) =>
         GetSecret(AZURE_STORAGE_CONNECTION_STRING, throwIfNotFound);
-
-    public virtual string AwsSecretKey(bool throwIfNotFound = true) =>
-        GetSecret(AWS_SECRET_KEY, throwIfNotFound);
-
-    public virtual string AwsAccessKey(bool throwIfNotFound = true) =>
-        GetSecret(AWS_ACCESS_KEY, throwIfNotFound);
 
     public virtual string BbsUsername(bool throwIfNotFound = true) =>
         GetSecret(BBS_USERNAME, throwIfNotFound);

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -843,7 +843,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
-                .WithMessage("*--aws-access-key*AWS_ACCESS_KEY*");
+                .WithMessage("*--aws-access-key/--aws-secret-key*");
         }
 
         [Fact]
@@ -859,7 +859,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
-                .WithMessage("*--aws-secret-key*AWS_SECRET_KEY*");
+                .WithMessage("*--aws-access-key/--aws-secret-key*");
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommanHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommanHandlerTests.cs
@@ -1338,7 +1338,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
-                .WithMessage("*--aws-access-key*");
+                .WithMessage("*--aws-access-key/--aws-secret-key*");
         }
 
         [Fact]
@@ -1356,7 +1356,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
-                .WithMessage("*--aws-secret-key*");
+                .WithMessage("*--aws-access-key/--aws-secret-key*");
         }
 
         [Fact]

--- a/src/bbs2gh/AwsApiFactory.cs
+++ b/src/bbs2gh/AwsApiFactory.cs
@@ -1,19 +1,63 @@
+using System;
+using System.Text;
+using Amazon.Runtime;
+
 namespace OctoshiftCLI.BbsToGithub;
 
 public class AwsApiFactory
 {
-    private readonly EnvironmentVariableProvider _environmentVariableProvider;
-
-    public AwsApiFactory(EnvironmentVariableProvider environmentVariableProvider)
+    private const string AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
+    private const string AWS_SECRET_KEY = "AWS_SECRET_KEY";
+    
+    internal static AWSCredentials ResolveStaticCredentials()
     {
-        _environmentVariableProvider = environmentVariableProvider;
+        try
+        {
+            return FallbackCredentialsFactory.GetCredentials();
+        }
+        catch (AmazonServiceException)
+        {
+            Console.WriteLine($"Unable to load default AWS credentials, falling back to the legacy environment variables");
+            return ResolveLegacyCredentials();
+        }
     }
 
+    
+    /// <summary>
+    /// This is needed because the default resolution strategy has different variables names:
+    /// there's no mention of `AWS_ACCESS_KEY` in the code, just `AWS_SECRET_KEY`:
+    /// public const string LEGACY_ENVIRONMENT_VARIABLE_SECRETKEY = "AWS_SECRET_KEY";
+    /// </summary>
+    /// <returns>
+    /// BasicAWSCredentials
+    /// </returns>
+    private static AWSCredentials ResolveLegacyCredentials()
+    {
+        Console.WriteLine($"[DEPRECATED] Trying to use {AWS_ACCESS_KEY} and {AWS_SECRET_KEY} environment variables for authentication");
+        var ak = Environment.GetEnvironmentVariable(AWS_ACCESS_KEY);
+        var sk = Environment.GetEnvironmentVariable(AWS_SECRET_KEY);
+        
+        if (string.IsNullOrWhiteSpace(ak) || string.IsNullOrWhiteSpace(sk))
+        {
+            throw new OctoshiftCliException($"Both {AWS_SECRET_KEY} and {AWS_ACCESS_KEY} have to be set.");
+        }
+    
+        return new BasicAWSCredentials(ak, sk);
+    }
+    
     public virtual AwsApi Create(string awsAccessKey = null, string awsSecretKey = null)
     {
-        var accessKey = awsAccessKey ?? _environmentVariableProvider.AwsAccessKey();
-        var secretKey = awsSecretKey ?? _environmentVariableProvider.AwsSecretKey();
+        AWSCredentials credentials;
+        if (awsAccessKey == null
+            || awsSecretKey == null)
+        {
+            credentials = ResolveStaticCredentials();
+        }
+        else
+        {
+            credentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
+        }
 
-        return new AwsApi(accessKey, secretKey);
+        return new AwsApi(credentials);
     }
 }

--- a/src/bbs2gh/AwsApiFactory.cs
+++ b/src/bbs2gh/AwsApiFactory.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Text;
+using System.Net.Http;
 using Amazon.Runtime;
 
 namespace OctoshiftCLI.BbsToGithub;
@@ -8,21 +8,28 @@ public class AwsApiFactory
 {
     private const string AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
     private const string AWS_SECRET_KEY = "AWS_SECRET_KEY";
-    
+
     internal static AWSCredentials ResolveStaticCredentials()
     {
         try
         {
-            return FallbackCredentialsFactory.GetCredentials();
+            var crd = FallbackCredentialsFactory.GetCredentials();
+
+            // Ensure that the credentials are actually present by calling crd.GetCredentials()
+            crd.GetCredentials();
+
+            return crd;
         }
-        catch (AmazonServiceException)
+        catch (Exception e) when
+            (e is AmazonServiceException or
+             HttpRequestException) // HttpRequestException happens if there's a 400 on Amazon.Util.EC2InstanceMetadata.get_IAMSecurityCredentials()
         {
             Console.WriteLine($"Unable to load default AWS credentials, falling back to the legacy environment variables");
             return ResolveLegacyCredentials();
         }
     }
 
-    
+
     /// <summary>
     /// This is needed because the default resolution strategy has different variables names:
     /// there's no mention of `AWS_ACCESS_KEY` in the code, just `AWS_SECRET_KEY`:
@@ -36,28 +43,18 @@ public class AwsApiFactory
         Console.WriteLine($"[DEPRECATED] Trying to use {AWS_ACCESS_KEY} and {AWS_SECRET_KEY} environment variables for authentication");
         var ak = Environment.GetEnvironmentVariable(AWS_ACCESS_KEY);
         var sk = Environment.GetEnvironmentVariable(AWS_SECRET_KEY);
-        
-        if (string.IsNullOrWhiteSpace(ak) || string.IsNullOrWhiteSpace(sk))
-        {
-            throw new OctoshiftCliException($"Both {AWS_SECRET_KEY} and {AWS_ACCESS_KEY} have to be set.");
-        }
-    
-        return new BasicAWSCredentials(ak, sk);
+
+        return string.IsNullOrWhiteSpace(ak) || string.IsNullOrWhiteSpace(sk)
+            ? throw new OctoshiftCliException($"Both {AWS_SECRET_KEY} and {AWS_ACCESS_KEY} have to be set.")
+            : (AWSCredentials)new BasicAWSCredentials(ak, sk);
     }
-    
+
     public virtual AwsApi Create(string awsAccessKey = null, string awsSecretKey = null)
     {
-        AWSCredentials credentials;
-        if (awsAccessKey == null
-            || awsSecretKey == null)
-        {
-            credentials = ResolveStaticCredentials();
-        }
-        else
-        {
-            credentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
-        }
-
+        var credentials = awsAccessKey == null
+            || awsSecretKey == null
+            ? ResolveStaticCredentials()
+            : new BasicAWSCredentials(awsAccessKey, awsSecretKey);
         return new AwsApi(credentials);
     }
 }

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -500,7 +500,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
                 }
             }
         }
-        if (!shouldUseAwsS3 && (args.AwsAccessKey.HasValue() || args.AwsSecretKey.HasValue()))
+        else if (!shouldUseAwsS3 && (args.AwsAccessKey.HasValue() || args.AwsSecretKey.HasValue()))
         {
             throw new OctoshiftCliException("--aws-access-key and --aws-secret-key can only be provided with --aws-bucket-name.");
         }

--- a/src/gei/AwsApiFactory.cs
+++ b/src/gei/AwsApiFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using Amazon.Runtime;
 
 namespace OctoshiftCLI.GithubEnterpriseImporter;
@@ -7,21 +8,28 @@ public class AwsApiFactory
 {
     private const string AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
     private const string AWS_SECRET_KEY = "AWS_SECRET_KEY";
-    
+
     internal static AWSCredentials ResolveStaticCredentials()
     {
         try
         {
-            return FallbackCredentialsFactory.GetCredentials();
+            var crd = FallbackCredentialsFactory.GetCredentials();
+
+            // Ensure that the credentials are actually present by calling crd.GetCredentials()
+            crd.GetCredentials();
+
+            return crd;
         }
-        catch (AmazonServiceException)
+        catch (Exception e) when
+        (e is AmazonServiceException or
+         HttpRequestException) // HttpRequestException happens if there's a 400 on Amazon.Util.EC2InstanceMetadata.get_IAMSecurityCredentials()
         {
             Console.WriteLine($"Unable to load default AWS credentials, falling back to the legacy environment variables");
             return ResolveLegacyCredentials();
         }
     }
 
-    
+
     /// <summary>
     /// This is needed because the default resolution strategy has different variables names:
     /// there's no mention of `AWS_ACCESS_KEY` in the code, just `AWS_SECRET_KEY`:
@@ -35,28 +43,18 @@ public class AwsApiFactory
         Console.WriteLine($"[DEPRECATED] Trying to use {AWS_ACCESS_KEY} and {AWS_SECRET_KEY} environment variables for authentication");
         var ak = Environment.GetEnvironmentVariable(AWS_ACCESS_KEY);
         var sk = Environment.GetEnvironmentVariable(AWS_SECRET_KEY);
-        
-        if (string.IsNullOrWhiteSpace(ak) || string.IsNullOrWhiteSpace(sk))
-        {
-            throw new OctoshiftCliException($"Both {AWS_SECRET_KEY} and {AWS_ACCESS_KEY} have to be set.");
-        }
-    
-        return new BasicAWSCredentials(ak, sk);
+
+        return string.IsNullOrWhiteSpace(ak) || string.IsNullOrWhiteSpace(sk)
+            ? throw new OctoshiftCliException($"Both {AWS_SECRET_KEY} and {AWS_ACCESS_KEY} have to be set.")
+            : (AWSCredentials)new BasicAWSCredentials(ak, sk);
     }
-    
+
     public virtual AwsApi Create(string awsAccessKey = null, string awsSecretKey = null)
     {
-        AWSCredentials credentials;
-        if (awsAccessKey == null
-            || awsSecretKey == null)
-        {
-            credentials = ResolveStaticCredentials();
-        }
-        else
-        {
-            credentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
-        }
-
+        var credentials = awsAccessKey == null
+            || awsSecretKey == null
+            ? ResolveStaticCredentials()
+            : new BasicAWSCredentials(awsAccessKey, awsSecretKey);
         return new AwsApi(credentials);
     }
 }

--- a/src/gei/AwsApiFactory.cs
+++ b/src/gei/AwsApiFactory.cs
@@ -1,19 +1,62 @@
+using System;
+using Amazon.Runtime;
+
 namespace OctoshiftCLI.GithubEnterpriseImporter;
 
 public class AwsApiFactory
 {
-    private readonly EnvironmentVariableProvider _environmentVariableProvider;
-
-    public AwsApiFactory(EnvironmentVariableProvider environmentVariableProvider)
+    private const string AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
+    private const string AWS_SECRET_KEY = "AWS_SECRET_KEY";
+    
+    internal static AWSCredentials ResolveStaticCredentials()
     {
-        _environmentVariableProvider = environmentVariableProvider;
+        try
+        {
+            return FallbackCredentialsFactory.GetCredentials();
+        }
+        catch (AmazonServiceException)
+        {
+            Console.WriteLine($"Unable to load default AWS credentials, falling back to the legacy environment variables");
+            return ResolveLegacyCredentials();
+        }
     }
 
+    
+    /// <summary>
+    /// This is needed because the default resolution strategy has different variables names:
+    /// there's no mention of `AWS_ACCESS_KEY` in the code, just `AWS_SECRET_KEY`:
+    /// public const string LEGACY_ENVIRONMENT_VARIABLE_SECRETKEY = "AWS_SECRET_KEY";
+    /// </summary>
+    /// <returns>
+    /// BasicAWSCredentials
+    /// </returns>
+    private static AWSCredentials ResolveLegacyCredentials()
+    {
+        Console.WriteLine($"[DEPRECATED] Trying to use {AWS_ACCESS_KEY} and {AWS_SECRET_KEY} environment variables for authentication");
+        var ak = Environment.GetEnvironmentVariable(AWS_ACCESS_KEY);
+        var sk = Environment.GetEnvironmentVariable(AWS_SECRET_KEY);
+        
+        if (string.IsNullOrWhiteSpace(ak) || string.IsNullOrWhiteSpace(sk))
+        {
+            throw new OctoshiftCliException($"Both {AWS_SECRET_KEY} and {AWS_ACCESS_KEY} have to be set.");
+        }
+    
+        return new BasicAWSCredentials(ak, sk);
+    }
+    
     public virtual AwsApi Create(string awsAccessKey = null, string awsSecretKey = null)
     {
-        var accessKey = awsAccessKey ?? _environmentVariableProvider.AwsAccessKey();
-        var secretKey = awsSecretKey ?? _environmentVariableProvider.AwsSecretKey();
+        AWSCredentials credentials;
+        if (awsAccessKey == null
+            || awsSecretKey == null)
+        {
+            credentials = ResolveStaticCredentials();
+        }
+        else
+        {
+            credentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
+        }
 
-        return new AwsApi(accessKey, secretKey);
+        return new AwsApi(credentials);
     }
 }

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -453,19 +453,24 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
                     "specified together.");
             }
 
+            
             if (shouldUseAwsS3)
             {
-                if (!GetAwsAccessKey(args).HasValue())
+                if (!args.AwsSecretKey.HasValue() || !args.AwsAccessKey.HasValue())
                 {
-                    throw new OctoshiftCliException("Either --aws-access-key or AWS_ACCESS_KEY environment variable must be set.");
-                }
-
-                if (!GetAwsSecretKey(args).HasValue())
-                {
-                    throw new OctoshiftCliException("Either --aws-secret-key or AWS_SECRET_KEY environment variable must be set.");
+                    try
+                    {
+                        AwsApiFactory.ResolveStaticCredentials();
+                    }
+                    catch (OctoshiftCliException e)
+                    {
+                        throw new OctoshiftCliException("Unable to resolve AWS credentials. " +
+                                                        "Either --aws-access-key/--aws-secret-key must be set or AWS SDK environment keys have to be set. " +
+                                                        "More on credential resolution: https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/creds-assign.html", e);
+                    }
                 }
             }
-            else if (args.AwsAccessKey.HasValue() || args.AwsSecretKey.HasValue())
+            if (!shouldUseAwsS3 && (args.AwsAccessKey.HasValue() || args.AwsSecretKey.HasValue()))
             {
                 throw new OctoshiftCliException("--aws-access-key and --aws-secret-key can only be provided with --aws-bucket-name.");
             }
@@ -483,11 +488,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             }
         }
     }
-
-    private string GetAwsAccessKey(MigrateRepoCommandArgs args) => args.AwsAccessKey.HasValue() ? args.AwsAccessKey : _environmentVariableProvider.AwsAccessKey(false);
-
-    private string GetAwsSecretKey(MigrateRepoCommandArgs args) => args.AwsSecretKey.HasValue() ? args.AwsSecretKey : _environmentVariableProvider.AwsSecretKey(false);
-
+    
     private string GetAzureStorageConnectionString(MigrateRepoCommandArgs args) => args.AzureStorageConnectionString.HasValue()
         ? args.AzureStorageConnectionString
         : _environmentVariableProvider.AzureStorageConnectionString(false);

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -453,7 +453,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
                     "specified together.");
             }
 
-            
+
             if (shouldUseAwsS3)
             {
                 if (!args.AwsSecretKey.HasValue() || !args.AwsAccessKey.HasValue())
@@ -470,7 +470,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
                     }
                 }
             }
-            if (!shouldUseAwsS3 && (args.AwsAccessKey.HasValue() || args.AwsSecretKey.HasValue()))
+            else if (!shouldUseAwsS3 && (args.AwsAccessKey.HasValue() || args.AwsSecretKey.HasValue()))
             {
                 throw new OctoshiftCliException("--aws-access-key and --aws-secret-key can only be provided with --aws-bucket-name.");
             }
@@ -488,7 +488,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             }
         }
     }
-    
+
     private string GetAzureStorageConnectionString(MigrateRepoCommandArgs args) => args.AzureStorageConnectionString.HasValue()
         ? args.AzureStorageConnectionString
         : _environmentVariableProvider.AzureStorageConnectionString(false);


### PR DESCRIPTION
## Background

AWS .NET SDK provides a way to automatically get the credentials based on conventions defined in [this document](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/creds-assign.html).
This is how it works when you are creating any entity that works with the API.

This is meant to "just work" in AWS environments: be it lambda, ECS, EC2 or anything else. It works just as well with the local profiles and environment variables.

Basically, using this approach would be interoperable with everything else that usually works with AWS CLI.

For example, this should also allow to interop with solutions like `aws-vault` where these credentials would be basically injected into your application whenever you run this.

I tried to provide compatibility with the old approach, too though I would just deprecate this over this more standard way of doing things.

One bit that is still missing is the `AWS_REGION`: as far as I remember (and it's been a while since I used it) this is the variable that you can rely on to get the region if it's set. (Just checked: [yeah, here it is](https://github.com/aws/aws-sdk-net/blob/d8218832bfe590f858fe195faaf57eeceb8a1ee6/sdk/src/Core/Amazon.Runtime/AWSRegion.cs#L74)).

I am not making this change here and I am not changing the behavior of just using the default Virginia region here, though I would recommend doing it.

## Proposed changes

* Use FallbackCredentialsFactory instead of always relying on basic credentials: this code can be found [here](https://github.com/aws/aws-sdk-net/blob/master/sdk/src/Services/S3/Generated/_bcl45/AmazonS3Client.cs#L80)
* Kind of keep backward compatibility with checking the parameters: I am just explicitly creating the credentials and if an exception is thrown, I fail
* Add a deprecation note to for the old variables

## Notes

More information on credential resolution here:
https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/creds-assign.html

Closes #738
Closes #692

Supersedes #824 #731


<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->