### PR TITLE
Use read-only permissions when creating a SAS to generate Azure Blob Storage SAS URL

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Create shared access signature (SAS) with read-only permissions - not read-write - when generating Azure Blob Storage URL

--- a/src/Octoshift/AzureApi.cs
+++ b/src/Octoshift/AzureApi.cs
@@ -78,7 +78,7 @@ namespace OctoshiftCLI
 
                 ExpiresOn = DateTimeOffset.UtcNow.AddHours(AUTHORIZATION_TIMEOUT_IN_HOURS)
             };
-            sasBuilder.SetPermissions(BlobSasPermissions.Read | BlobSasPermissions.Write);
+            sasBuilder.SetPermissions(BlobSasPermissions.Read);
 
             return blobClient.GenerateSasUri(sasBuilder);
         }


### PR DESCRIPTION
After uploading an archive to Azure Blob Storage, we need to generate a temporary URL for the file to send to the GitHub API. In the world of Azure, this is called a "SAS URL".

To be able to create a SAS URL, we create a shared access signature (SAS). 

At the moment, the SAS is created with read-write permissions, which is unnecessary, given that we only need to be able to read the file.

This changes it to use read-only permissions.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->