### PR TITLE
Fix NullReferenceException when running on Bitbucket server

### DIFF
--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -224,10 +224,12 @@ namespace OctoshiftCLI.Tests.bbs2gh.Handlers
         public async Task Happy_Path_Full_Flow_Running_On_Bbs_Server()
         {
             // Arrange
+            const string bbsSharedHome = "bbs-shared-home";
+            var archivePath = $"{bbsSharedHome}/data/migration/export/Bitbucket_export_{BBS_EXPORT_ID}.tar";
+
             _mockBbsApi.Setup(x => x.StartExport(BBS_PROJECT, BBS_REPO)).ReturnsAsync(BBS_EXPORT_ID);
             _mockBbsApi.Setup(x => x.GetExport(BBS_EXPORT_ID)).ReturnsAsync(("COMPLETED", "The export is complete", 100));
-            _mockBbsArchiveDownloader.Setup(x => x.GetSourceExportArchiveAbsolutePath(BBS_EXPORT_ID)).Returns(ARCHIVE_PATH);
-            _mockFileSystemProvider.Setup(x => x.ReadAllBytesAsync(ARCHIVE_PATH)).ReturnsAsync(ARCHIVE_DATA);
+            _mockFileSystemProvider.Setup(x => x.ReadAllBytesAsync(archivePath)).ReturnsAsync(ARCHIVE_DATA);
             _mockAzureApi.Setup(x => x.UploadToBlob(It.IsAny<string>(), ARCHIVE_DATA)).ReturnsAsync(new Uri(ARCHIVE_URL));
             _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
             _mockGithubApi.Setup(x => x.CreateBbsMigrationSource(GITHUB_ORG_ID).Result).Returns(MIGRATION_SOURCE_ID);
@@ -244,10 +246,24 @@ namespace OctoshiftCLI.Tests.bbs2gh.Handlers
                 GithubOrg = GITHUB_ORG,
                 GithubRepo = GITHUB_REPO,
                 GithubPat = GITHUB_PAT,
+                BbsSharedHome = bbsSharedHome
             };
-            await _handler.Handle(args);
+
+            var handler = new MigrateRepoCommandHandler(
+                _mockOctoLogger.Object,
+                _mockGithubApi.Object,
+                _mockBbsApi.Object,
+                _mockEnvironmentVariableProvider.Object,
+                null, // in case of running on Bitbucket server, the downloader will be null
+                _mockAzureApi.Object,
+                _mockAwsApi.Object,
+                _mockFileSystemProvider.Object
+            );
+            await handler.Handle(args);
 
             // Assert
+            args.ArchivePath.Should().Be(archivePath);
+
             _mockGithubApi.Verify(m => m.StartBbsMigration(
                 MIGRATION_SOURCE_ID,
                 GITHUB_ORG_ID,
@@ -609,33 +625,6 @@ namespace OctoshiftCLI.Tests.bbs2gh.Handlers
                 .Should()
                 .ThrowExactlyAsync<OctoshiftCliException>()
                 .WithMessage("*--bbs-server-url*--archive-path*--archive-url*");
-        }
-
-        [Fact]
-        public async Task It_Sets_The_Archive_Path_To_Default_Local_Path_When_Archive_Path_And_Archive_Url_Are_Not_Provided()
-        {
-            // Arrange
-            _mockBbsApi.Setup(x => x.StartExport(BBS_PROJECT, BBS_REPO)).ReturnsAsync(BBS_EXPORT_ID);
-            _mockBbsApi.Setup(x => x.GetExport(BBS_EXPORT_ID)).ReturnsAsync(("COMPLETED", "The export is complete", 100));
-            _mockAzureApi.Setup(x => x.UploadToBlob(It.IsAny<string>(), It.IsAny<byte[]>())).ReturnsAsync(new Uri(ARCHIVE_URL));
-            _mockBbsArchiveDownloader.Setup(x => x.GetSourceExportArchiveAbsolutePath(BBS_EXPORT_ID)).Returns(ARCHIVE_PATH);
-
-            // Act
-            var args = new MigrateRepoCommandArgs
-            {
-                BbsServerUrl = BBS_SERVER_URL,
-                BbsUsername = BBS_USERNAME,
-                BbsPassword = BBS_PASSWORD,
-                BbsProject = BBS_PROJECT,
-                BbsRepo = BBS_REPO,
-                AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING,
-                GithubOrg = GITHUB_ORG,
-            };
-            await _handler.Handle(args);
-
-            // Assert
-            args.ArchivePath.Should().Be(ARCHIVE_PATH);
-            _mockFileSystemProvider.Verify(m => m.ReadAllBytesAsync(ARCHIVE_PATH));
         }
 
         [Fact]

--- a/src/bbs2gh/BbsArchiveDownloaderFactory.cs
+++ b/src/bbs2gh/BbsArchiveDownloaderFactory.cs
@@ -18,12 +18,12 @@ public class BbsArchiveDownloaderFactory
     public virtual IBbsArchiveDownloader CreateSshDownloader(string host, string sshUser, string privateKeyFileFullPath, int sshPort = 22, string bbsSharedHomeDirectory = null) =>
         new BbsSshArchiveDownloader(_log, _fileSystemProvider, host, sshUser, privateKeyFileFullPath, sshPort)
         {
-            BbsSharedHomeDirectory = bbsSharedHomeDirectory ?? BbsSshArchiveDownloader.DEFAULT_BBS_SHARED_HOME_DIRECTORY
+            BbsSharedHomeDirectory = bbsSharedHomeDirectory ?? BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_LINUX
         };
 
     public virtual IBbsArchiveDownloader CreateSmbDownloader(string host, string smbUser, string smbPassword, string domainName = null, string bbsSharedHomeDirectory = null) =>
         new BbsSmbArchiveDownloader(_log, _fileSystemProvider, host, smbUser, smbPassword ?? _environmentVariableProvider.SmbPassword(), domainName)
         {
-            BbsSharedHomeDirectory = bbsSharedHomeDirectory ?? BbsSmbArchiveDownloader.DEFAULT_BBS_SHARED_HOME_DIRECTORY
+            BbsSharedHomeDirectory = bbsSharedHomeDirectory ?? BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_WINDOWS
         };
 }

--- a/src/bbs2gh/BbsSettings.cs
+++ b/src/bbs2gh/BbsSettings.cs
@@ -1,0 +1,8 @@
+namespace OctoshiftCLI.BbsToGithub;
+
+public static class BbsSettings
+{
+    public const string DEFAULT_BBS_SHARED_HOME_DIRECTORY_WINDOWS = "c$\\atlassian\\applicationdata\\bitbucket\\shared";
+
+    public const string DEFAULT_BBS_SHARED_HOME_DIRECTORY_LINUX = "/var/atlassian/application-data/bitbucket/shared";
+}

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using OctoshiftCLI.BbsToGithub.Commands;
 using OctoshiftCLI.BbsToGithub.Services;
@@ -74,7 +75,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             // This is for the case where the CLI is being run on the BBS server itself
             if (args.ArchivePath.IsNullOrWhiteSpace())
             {
-                args.ArchivePath = _bbsArchiveDownloader.GetSourceExportArchiveAbsolutePath(exportId);
+                args.ArchivePath = GetSourceExportArchiveAbsolutePath(args.BbsSharedHome, exportId);
             }
 
             args.ArchiveUrl = args.AwsBucketName.HasValue()
@@ -86,6 +87,15 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         {
             await ImportArchive(args, args.ArchiveUrl);
         }
+    }
+
+    private string GetSourceExportArchiveAbsolutePath(string bbsSharedHomeDirectory, long exportId)
+    {
+        static string GetDefaultBbsSharedHomeDirectory() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? BbsSmbArchiveDownloader.DEFAULT_BBS_SHARED_HOME_DIRECTORY
+            : BbsSshArchiveDownloader.DEFAULT_BBS_SHARED_HOME_DIRECTORY;
+
+        return IBbsArchiveDownloader.GetSourceExportArchiveAbsolutePath(bbsSharedHomeDirectory ?? GetDefaultBbsSharedHomeDirectory(), exportId);
     }
 
     private bool ShouldGenerateArchive(MigrateRepoCommandArgs args)

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -102,8 +102,8 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
     private string GetSourceExportArchiveAbsolutePath(string bbsSharedHomeDirectory, long exportId)
     {
         static string GetDefaultBbsSharedHomeDirectory() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? BbsSmbArchiveDownloader.DEFAULT_BBS_SHARED_HOME_DIRECTORY
-            : BbsSshArchiveDownloader.DEFAULT_BBS_SHARED_HOME_DIRECTORY;
+            ? BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_WINDOWS
+            : BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_LINUX;
 
         return IBbsArchiveDownloader.GetSourceExportArchiveAbsolutePath(bbsSharedHomeDirectory ?? GetDefaultBbsSharedHomeDirectory(), exportId);
     }

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -101,11 +101,14 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
     private string GetSourceExportArchiveAbsolutePath(string bbsSharedHomeDirectory, long exportId)
     {
-        static string GetDefaultBbsSharedHomeDirectory() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_WINDOWS
-            : BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_LINUX;
+        if (bbsSharedHomeDirectory.IsNullOrWhiteSpace())
+        {
+            bbsSharedHomeDirectory = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_WINDOWS
+                : BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_LINUX;
+        }
 
-        return IBbsArchiveDownloader.GetSourceExportArchiveAbsolutePath(bbsSharedHomeDirectory ?? GetDefaultBbsSharedHomeDirectory(), exportId);
+        return IBbsArchiveDownloader.GetSourceExportArchiveAbsolutePath(bbsSharedHomeDirectory, exportId);
     }
 
     private void DeleteArchive(string path)

--- a/src/bbs2gh/Services/BbsSmbArchiveDownloader.cs
+++ b/src/bbs2gh/Services/BbsSmbArchiveDownloader.cs
@@ -48,8 +48,8 @@ public sealed class BbsSmbArchiveDownloader : IBbsArchiveDownloader
 
     public string BbsSharedHomeDirectory { get; init; } = DEFAULT_BBS_SHARED_HOME_DIRECTORY;
 
-    public string GetSourceExportArchiveAbsolutePath(long exportJobId) => Path.Join(BbsSharedHomeDirectory ?? DEFAULT_BBS_SHARED_HOME_DIRECTORY,
-        IBbsArchiveDownloader.GetSourceExportArchiveRelativePath(exportJobId)).ToWindowsPath();
+    private string GetSourceExportArchiveAbsolutePath(long exportJobId) =>
+        IBbsArchiveDownloader.GetSourceExportArchiveAbsolutePath(BbsSharedHomeDirectory ?? DEFAULT_BBS_SHARED_HOME_DIRECTORY, exportJobId).ToWindowsPath();
 
     public async Task<string> Download(long exportJobId, string targetDirectory = IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY)
     {

--- a/src/bbs2gh/Services/BbsSmbArchiveDownloader.cs
+++ b/src/bbs2gh/Services/BbsSmbArchiveDownloader.cs
@@ -11,7 +11,6 @@ namespace OctoshiftCLI.BbsToGithub.Services;
 
 public sealed class BbsSmbArchiveDownloader : IBbsArchiveDownloader
 {
-    public const string DEFAULT_BBS_SHARED_HOME_DIRECTORY = "c$\\atlassian\\applicationdata\\bitbucket\\shared";
     private const int DOWNLOAD_PROGRESS_REPORT_INTERVAL_IN_SECONDS = 10;
 
     private readonly ISMBClient _smbClient;
@@ -46,10 +45,10 @@ public sealed class BbsSmbArchiveDownloader : IBbsArchiveDownloader
         _domainName = domainName;
     }
 
-    public string BbsSharedHomeDirectory { get; init; } = DEFAULT_BBS_SHARED_HOME_DIRECTORY;
+    public string BbsSharedHomeDirectory { get; init; } = BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_WINDOWS;
 
     private string GetSourceExportArchiveAbsolutePath(long exportJobId) =>
-        IBbsArchiveDownloader.GetSourceExportArchiveAbsolutePath(BbsSharedHomeDirectory ?? DEFAULT_BBS_SHARED_HOME_DIRECTORY, exportJobId).ToWindowsPath();
+        IBbsArchiveDownloader.GetSourceExportArchiveAbsolutePath(BbsSharedHomeDirectory ?? BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_WINDOWS, exportJobId).ToWindowsPath();
 
     public async Task<string> Download(long exportJobId, string targetDirectory = IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY)
     {

--- a/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
+++ b/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
@@ -10,7 +10,6 @@ namespace OctoshiftCLI.BbsToGithub.Services;
 
 public sealed class BbsSshArchiveDownloader : IBbsArchiveDownloader, IDisposable
 {
-    public const string DEFAULT_BBS_SHARED_HOME_DIRECTORY = "/var/atlassian/application-data/bitbucket/shared";
     private const int DOWNLOAD_PROGRESS_REPORT_INTERVAL_IN_SECONDS = 10;
 
     private readonly ISftpClient _sftpClient;
@@ -72,10 +71,10 @@ public sealed class BbsSshArchiveDownloader : IBbsArchiveDownloader, IDisposable
         _sftpClient = sftpClient;
     }
 
-    public string BbsSharedHomeDirectory { get; init; } = DEFAULT_BBS_SHARED_HOME_DIRECTORY;
+    public string BbsSharedHomeDirectory { get; init; } = BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_LINUX;
 
     private string GetSourceExportArchiveAbsolutePath(long exportJobId) =>
-        IBbsArchiveDownloader.GetSourceExportArchiveAbsolutePath(BbsSharedHomeDirectory ?? DEFAULT_BBS_SHARED_HOME_DIRECTORY, exportJobId).ToUnixPath();
+        IBbsArchiveDownloader.GetSourceExportArchiveAbsolutePath(BbsSharedHomeDirectory ?? BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_LINUX, exportJobId).ToUnixPath();
 
     public async Task<string> Download(long exportJobId, string targetDirectory = IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY)
     {

--- a/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
+++ b/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
@@ -74,10 +74,8 @@ public sealed class BbsSshArchiveDownloader : IBbsArchiveDownloader, IDisposable
 
     public string BbsSharedHomeDirectory { get; init; } = DEFAULT_BBS_SHARED_HOME_DIRECTORY;
 
-    public string GetSourceExportArchiveAbsolutePath(long exportJobId)
-    {
-        return Path.Join(BbsSharedHomeDirectory ?? DEFAULT_BBS_SHARED_HOME_DIRECTORY, IBbsArchiveDownloader.GetSourceExportArchiveRelativePath(exportJobId)).ToUnixPath();
-    }
+    private string GetSourceExportArchiveAbsolutePath(long exportJobId) =>
+        IBbsArchiveDownloader.GetSourceExportArchiveAbsolutePath(BbsSharedHomeDirectory ?? DEFAULT_BBS_SHARED_HOME_DIRECTORY, exportJobId).ToUnixPath();
 
     public async Task<string> Download(long exportJobId, string targetDirectory = IBbsArchiveDownloader.DEFAULT_TARGET_DIRECTORY)
     {

--- a/src/bbs2gh/Services/IBbsArchiveDownloader.cs
+++ b/src/bbs2gh/Services/IBbsArchiveDownloader.cs
@@ -11,7 +11,8 @@ public interface IBbsArchiveDownloader
 
     Task<string> Download(long exportJobId, string targetDirectory = DEFAULT_TARGET_DIRECTORY);
 
-    string GetSourceExportArchiveAbsolutePath(long exportJobId);
+    static string GetSourceExportArchiveAbsolutePath(string bbsSharedHomeDirectory, long exportJobId) =>
+        Path.Join(bbsSharedHomeDirectory, GetSourceExportArchiveRelativePath(exportJobId)).ToUnixPath();
 
     static string GetExportArchiveFileName(long exportJobId) => $"Bitbucket_export_{exportJobId}.tar";
 


### PR DESCRIPTION
Fixes #745

We support a scenario where the CLI can be run on the Bitbucket server itself. In that case there will be naturally no download options and as a result the BBS downloader service won't be instantiated and will be injected into the handler as `null`. This was causing a `NullReferenceException` in the upload phase since we were trying to retrieve the source archive's path from an `IBbsArchiveDownloader` instance which was indeed `null`. To fix it, I basically moved the `GetSourceExportArchiveAbsolutePath()` method from a concrete implementation into the abstraction (`IBbsArchiveDownloader`) and added the `bbsSharedHomeDirectory` as an additional param to it. The result is a new static method in the interface the doesn't depend on a concrete implementation. 

Now in order to get the default Bitbucket's shared home directory (when `--bbs-shared-home` is `null`) in the handler, I detect the server's OS version and then get the default BBS home from the `BbsSettings` class.  

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)
