### PR TITLE
Validate github-repo and github-org in import archive scenarios

### DIFF
--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -724,6 +724,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
                 BbsRepo = BBS_REPO,
                 AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING,
                 GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO
             };
             await _handler.Handle(args);
 
@@ -744,6 +745,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
                 ArchivePath = ARCHIVE_PATH,
                 AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING,
                 GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO
             };
             await _handler.Handle(args);
 
@@ -759,7 +761,9 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
             var args = new MigrateRepoCommandArgs
             {
                 ArchiveUrl = ARCHIVE_URL,
-                AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING
+                AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO
             };
             await _handler.Handle(args);
 
@@ -1070,6 +1074,67 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
                 .Should()
                 .ThrowExactlyAsync<OctoshiftCliException>()
                 .WithMessage("*SSH*SMB*--bbs-server-url*");
+        }
+
+        [Fact]
+        public async Task It_Throws_If_Github_Org_Is_Provided_But_Github_Repo_Is_Not()
+        {
+            // Act
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubOrg = GITHUB_ORG,
+                BbsServerUrl = BBS_SERVER_URL,
+                SshUser = SSH_USER,
+                SshPrivateKey = PRIVATE_KEY,
+                BbsProject = BBS_PROJECT,
+                BbsRepo = BBS_REPO,
+                GithubPat = GITHUB_PAT,
+                BbsUsername = BBS_USERNAME,
+                BbsPassword = BBS_PASSWORD,
+                AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING
+            };
+
+            // Assert
+            await _handler.Invoking(x => x.Handle(args))
+                .Should()
+                .ThrowExactlyAsync<OctoshiftCliException>()
+                .WithMessage("*--github-repo*");
+        }
+
+        [Fact]
+        public async Task It_Throws_If_Archive_Url_Is_Provided_But_Github_Org_Is_Not()
+        {
+            // Act
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubPat = GITHUB_PAT,
+                ArchiveUrl = ARCHIVE_URL,
+                GithubRepo = GITHUB_REPO
+            };
+
+            // Assert
+            await _handler.Invoking(x => x.Handle(args))
+                .Should()
+                .ThrowExactlyAsync<OctoshiftCliException>()
+                .WithMessage("*--github-org*");
+        }
+
+        [Fact]
+        public async Task It_Throws_If_Archive_Url_Is_Provided_But_Github_Repo_Is_Not()
+        {
+            // Act
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubPat = GITHUB_PAT,
+                ArchiveUrl = ARCHIVE_URL,
+                GithubOrg = GITHUB_ORG
+            };
+
+            // Assert
+            await _handler.Invoking(x => x.Handle(args))
+                .Should()
+                .ThrowExactlyAsync<OctoshiftCliException>()
+                .WithMessage("*--github-repo*");
         }
     }
 }

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -130,7 +130,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
     private bool ShouldImportArchive(MigrateRepoCommandArgs args)
     {
-        return args.ArchiveUrl.HasValue();
+        return args.ArchiveUrl.HasValue() || args.GithubOrg.HasValue();
     }
 
     private async Task<string> DownloadArchive(long exportId)
@@ -421,6 +421,11 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         {
             ValidateUploadOptions(args);
         }
+
+        if (ShouldImportArchive(args))
+        {
+            ValidateImportOptions(args);
+        }
     }
 
     private void ValidateDownloadOptions(MigrateRepoCommandArgs args)
@@ -481,6 +486,19 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         else if (args.AwsAccessKey.HasValue() || args.AwsSecretKey.HasValue())
         {
             throw new OctoshiftCliException("--aws-access-key and --aws-secret-key can only be provided with --aws-bucket-name.");
+        }
+    }
+
+    private void ValidateImportOptions(MigrateRepoCommandArgs args)
+    {
+        if (args.GithubOrg.IsNullOrWhiteSpace())
+        {
+            throw new OctoshiftCliException("--github-org must be provided in order to import the Bitbucket archive.");
+        }
+
+        if (args.GithubRepo.IsNullOrWhiteSpace())
+        {
+            throw new OctoshiftCliException("--github-repo must be provided in order to import the Bitbucket archive.");
         }
     }
 


### PR DESCRIPTION
Fixes #750 

Previously in scenarios that led to importing the BBS archive we weren't validating the `github-repo`'s presence and it was causing a GQL request failure. This PR adds extra validations for import archive scenarios including `github-repo` and `girhub-org`.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)
