### PR TITLE
Fix incorrect help texts for some gei commands

### DIFF
--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -86,19 +86,19 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         };
         public Option<string> AzureStorageConnectionString { get; } = new("--azure-storage-connection-string")
         {
-            Description = "Required if migrating from GHES (Not required for GHES 3.8.0 and later). The connection string for the Azure storage account, used to upload data archives pre-migration. For example: \"DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net\""
+            Description = "Required if migrating from GHES (Not required if migrating from GitHub Enterprise Server 3.8.0 or later). The connection string for the Azure storage account, used to upload data archives pre-migration. For example: \"DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net\""
         };
         public Option<string> AwsBucketName { get; } = new("--aws-bucket-name")
         {
-            Description = "If using AWS, the name of the S3 bucket to upload the data archives to (Not required for GHES 3.8.0 and later)."
+            Description = "If using AWS, the name of the S3 bucket to upload the data archives to. Not required if migrating from GitHub Enterprise Server 3.8.0 or later."
         };
         public Option<string> AwsAccessKey { get; } = new("--aws-access-key")
         {
-            Description = "If uploading to S3, the AWS access key. If not provided, it will be read from AWS_ACCESS_KEY environment variable (Not required for GHES 3.8.0 and later)."
+            Description = "If uploading to S3, the AWS access key. If not provided, it will be read from AWS_ACCESS_KEY environment variable. Not required if migrating from GitHub Enterprise Server 3.8.0 or later."
         };
         public Option<string> AwsSecretKey { get; } = new("--aws-secret-key")
         {
-            Description = "If uploading to S3, the AWS secret key. If not provided, it will be read from AWS_SECRET_KEY environment variable (Not required for GHES 3.8.0 and later)."
+            Description = "If uploading to S3, the AWS secret key. If not provided, it will be read from AWS_SECRET_KEY environment variable. Not required if migrating from GitHub Enterprise Server 3.8.0 or later."
         };
         public Option<bool> NoSslVerify { get; } = new("--no-ssl-verify")
         {

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -90,7 +90,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         };
         public Option<string> AwsBucketName { get; } = new("--aws-bucket-name")
         {
-            Description = "If using AWS, the name of the S3 bucket to upload the BBS archive to (Not required for GHES 3.8.0 and later)."
+            Description = "If using AWS, the name of the S3 bucket to upload the data archives to (Not required for GHES 3.8.0 and later)."
         };
         public Option<string> AwsAccessKey { get; } = new("--aws-access-key")
         {

--- a/src/gei/Commands/WaitForMigrationCommand.cs
+++ b/src/gei/Commands/WaitForMigrationCommand.cs
@@ -9,7 +9,7 @@ public sealed class WaitForMigrationCommand : WaitForMigrationCommandBase
     public WaitForMigrationCommand() : base()
     {
         Description += Environment.NewLine;
-        Description += $"Note: Expects GH_PAT env variable or --{GithubPat.ArgumentHelpName} option to be set.";
+        Description += $"Note: Expects GH_PAT env variable or --{GithubPat.Name} option to be set.";
 
         AddOptions();
     }


### PR DESCRIPTION
Fixes #790 

This PR fixes a couple of incorrect help texts for `gh gei`. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)
