### PR TITLE
Allow multiple migrations to continue with `gh gei generate-script`

### DIFF
--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -242,7 +242,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             }
             if (archiveStatus == ArchiveMigrationStatus.Failed)
             {
-                _log.LogInformation($"Archive generation failed for id: {archiveId}");
+                _log.LogError($"Archive generation failed for id: {archiveId}");
                 break;
             }
             await Task.Delay(CHECK_STATUS_DELAY_IN_MILLISECONDS);

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -242,7 +242,8 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             }
             if (archiveStatus == ArchiveMigrationStatus.Failed)
             {
-                throw new OctoshiftCliException($"Archive generation failed for id: {archiveId}");
+                _log.LogInformation($"Archive generation failed for id: {archiveId}");
+                break;
             }
             await Task.Delay(CHECK_STATUS_DELAY_IN_MILLISECONDS);
         }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

This allow multiple migrations to continue when archive generation fails for a single repo during multiple migrations with `gh gei generate-script` instead of throwing an exception so the rest of the migration can continue.

This fixes #838

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->