### PR TITLE
Rename AWS env variables to align with AWS CLI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -207,8 +207,8 @@ jobs:
         AZURE_STORAGE_CONNECTION_STRING_LINUX: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_LINUX }}
         AZURE_STORAGE_CONNECTION_STRING_MACOS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_MACOS }}
         AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}
-        AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         GEI_DEBUG_MODE: 'true'
         LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:${{ github.workspace }}/src/OctoshiftCLI.IntegrationTests/bin/Debug/net6.0/runtimes/ubuntu.18.04-x64/native'
       run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -133,8 +133,8 @@ jobs:
         AZURE_STORAGE_CONNECTION_STRING_LINUX: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_LINUX }}
         AZURE_STORAGE_CONNECTION_STRING_MACOS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_MACOS }}
         AZURE_STORAGE_CONNECTION_STRING_WINDOWS: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_WINDOWS }}
-        AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         GEI_DEBUG_MODE: 'true'
         LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:${{ github.workspace }}/src/OctoshiftCLI.IntegrationTests/bin/Debug/net6.0/runtimes/ubuntu.18.04-x64/native'
       run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Rename `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` environment variables to `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` respectively to align with the environment variables that the AWS CLI already uses. Old environment variables are still supported but they will be removed in future. 

--- a/src/Octoshift/AwsApi.cs
+++ b/src/Octoshift/AwsApi.cs
@@ -17,15 +17,15 @@ public class AwsApi : IDisposable
     private readonly ITransferUtility _transferUtility;
 
 #pragma warning disable CA2000
-    public AwsApi(string awsAccessKey, string awsSecretKey, string awsRegion = null, string awsSessionToken = null)
-        : this(new TransferUtility(BuildAmazonS3Client(awsAccessKey, awsSecretKey, awsRegion, awsSessionToken)))
+    public AwsApi(string awsAccessKeyId, string awsSecretAccessKey, string awsRegion = null, string awsSessionToken = null)
+        : this(new TransferUtility(BuildAmazonS3Client(awsAccessKeyId, awsSecretAccessKey, awsRegion, awsSessionToken)))
 #pragma warning restore CA2000
     {
     }
 
     internal AwsApi(ITransferUtility transferUtility) => _transferUtility = transferUtility;
 
-    private static AmazonS3Client BuildAmazonS3Client(string awsAccessKey, string awsSecretKey, string awsRegion, string awsSessionToken)
+    private static AmazonS3Client BuildAmazonS3Client(string awsAccessKeyId, string awsSecretAccessKey, string awsRegion, string awsSessionToken)
     {
         var regionEndpoint = DefaultRegionEndpoint;
         if (awsRegion.HasValue())
@@ -35,8 +35,8 @@ public class AwsApi : IDisposable
         }
 
         return awsSessionToken.HasValue()
-            ? new AmazonS3Client(awsAccessKey, awsSecretKey, awsSessionToken, regionEndpoint)
-            : new AmazonS3Client(awsAccessKey, awsSecretKey, regionEndpoint);
+            ? new AmazonS3Client(awsAccessKeyId, awsSecretAccessKey, awsSessionToken, regionEndpoint)
+            : new AmazonS3Client(awsAccessKeyId, awsSecretAccessKey, regionEndpoint);
     }
 
     public virtual async Task<string> UploadToBucket(string bucketName, string fileName, string keyName)

--- a/src/Octoshift/EnvironmentVariableProvider.cs
+++ b/src/Octoshift/EnvironmentVariableProvider.cs
@@ -8,8 +8,8 @@ public class EnvironmentVariableProvider
     private const string TARGET_GH_PAT = "GH_PAT";
     private const string ADO_PAT = "ADO_PAT";
     private const string AZURE_STORAGE_CONNECTION_STRING = "AZURE_STORAGE_CONNECTION_STRING";
-    private const string AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
-    private const string AWS_SECRET_KEY = "AWS_SECRET_KEY";
+    private const string AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID";
+    private const string AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
     private const string AWS_SESSION_TOKEN = "AWS_SESSION_TOKEN";
     private const string AWS_REGION = "AWS_REGION";
     private const string BBS_USERNAME = "BBS_USERNAME";
@@ -35,11 +35,11 @@ public class EnvironmentVariableProvider
     public virtual string AzureStorageConnectionString(bool throwIfNotFound = true) =>
         GetSecret(AZURE_STORAGE_CONNECTION_STRING, throwIfNotFound);
 
-    public virtual string AwsSecretKey(bool throwIfNotFound = true) =>
-        GetSecret(AWS_SECRET_KEY, throwIfNotFound);
+    public virtual string AwsSecretAccessKey(bool throwIfNotFound = true) =>
+        GetSecret(AWS_SECRET_ACCESS_KEY, throwIfNotFound);
 
-    public virtual string AwsAccessKey(bool throwIfNotFound = true) =>
-        GetSecret(AWS_ACCESS_KEY, throwIfNotFound);
+    public virtual string AwsAccessKeyId(bool throwIfNotFound = true) =>
+        GetSecret(AWS_ACCESS_KEY_ID, throwIfNotFound);
 
     public virtual string AwsSessionToken(bool throwIfNotFound = true) =>
         GetSecret(AWS_SESSION_TOKEN, throwIfNotFound);

--- a/src/Octoshift/EnvironmentVariableProvider.cs
+++ b/src/Octoshift/EnvironmentVariableProvider.cs
@@ -10,6 +10,8 @@ public class EnvironmentVariableProvider
     private const string AZURE_STORAGE_CONNECTION_STRING = "AZURE_STORAGE_CONNECTION_STRING";
     private const string AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID";
     private const string AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
+    private const string AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
+    private const string AWS_SECRET_KEY = "AWS_SECRET_KEY";
     private const string AWS_SESSION_TOKEN = "AWS_SESSION_TOKEN";
     private const string AWS_REGION = "AWS_REGION";
     private const string BBS_USERNAME = "BBS_USERNAME";
@@ -40,6 +42,14 @@ public class EnvironmentVariableProvider
 
     public virtual string AwsAccessKeyId(bool throwIfNotFound = true) =>
         GetSecret(AWS_ACCESS_KEY_ID, throwIfNotFound);
+
+    [Obsolete("AwsSecretKey is deprecated, please use AwsSecretAccessKey instead.")]
+    public virtual string AwsSecretKey(bool throwIfNotFound = true) =>
+        GetSecret(AWS_SECRET_KEY, throwIfNotFound);
+
+    [Obsolete("AwsAccessKey is deprecated, please use AwsAccessKeyId instead.")]
+    public virtual string AwsAccessKey(bool throwIfNotFound = true) =>
+        GetSecret(AWS_ACCESS_KEY, throwIfNotFound);
 
     public virtual string AwsSessionToken(bool throwIfNotFound = true) =>
         GetSecret(AWS_SESSION_TOKEN, throwIfNotFound);

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -112,8 +112,8 @@ public sealed class BbsToGithub : IDisposable
         }
         else
         {
-            _tokens.Add("AWS_ACCESS_KEY", Environment.GetEnvironmentVariable("AWS_ACCESS_KEY"));
-            _tokens.Add("AWS_SECRET_KEY", Environment.GetEnvironmentVariable("AWS_SECRET_KEY"));
+            _tokens.Add("AWS_ACCESS_KEY_ID", Environment.GetEnvironmentVariable("AWS_ACCESS_KEY_ID"));
+            _tokens.Add("AWS_SECRET_ACCESS_KEY", Environment.GetEnvironmentVariable("AWS_SECRET_ACCESS_KEY"));
             archiveUploadOptions = $" --aws-bucket-name {AWS_BUCKET_NAME}";
         }
 

--- a/src/OctoshiftCLI.Tests/Octoshift/EnvironmentVariableProviderTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/EnvironmentVariableProviderTests.cs
@@ -12,8 +12,8 @@ public class EnvironmentVariableProviderTests
     private const string TARGET_GH_PAT = "GH_PAT";
     private const string ADO_PAT = "ADO_PAT";
     private const string AZURE_STORAGE_CONNECTION_STRING = "AZURE_STORAGE_CONNECTION_STRING";
-    private const string AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
-    private const string AWS_SECRET_KEY = "AWS_SECRET_KEY";
+    private const string AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID";
+    private const string AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
     private const string BBS_USERNAME = "BBS_USERNAME";
     private const string BBS_PASSWORD = "BBS_PASSWORD";
 
@@ -119,8 +119,8 @@ public class EnvironmentVariableProviderTests
         Environment.SetEnvironmentVariable(TARGET_GH_PAT, null);
         Environment.SetEnvironmentVariable(ADO_PAT, null);
         Environment.SetEnvironmentVariable(AZURE_STORAGE_CONNECTION_STRING, null);
-        Environment.SetEnvironmentVariable(AWS_ACCESS_KEY, null);
-        Environment.SetEnvironmentVariable(AWS_SECRET_KEY, null);
+        Environment.SetEnvironmentVariable(AWS_ACCESS_KEY_ID, null);
+        Environment.SetEnvironmentVariable(AWS_SECRET_ACCESS_KEY, null);
         Environment.SetEnvironmentVariable(BBS_USERNAME, null);
         Environment.SetEnvironmentVariable(BBS_PASSWORD, null);
     }

--- a/src/OctoshiftCLI.Tests/bbs2gh/AwsApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/AwsApiFactoryTests.cs
@@ -1,0 +1,52 @@
+using Moq;
+using OctoshiftCLI.BbsToGithub;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.BbsToGithub;
+
+public class AwsApiFactoryTests
+{
+    private readonly Mock<EnvironmentVariableProvider> _mockEnvironmentVariableProvider = TestHelpers.CreateMock<EnvironmentVariableProvider>();
+    private readonly AwsApiFactory _awsApiFactory;
+
+    public AwsApiFactoryTests()
+    {
+        _awsApiFactory = new AwsApiFactory(_mockEnvironmentVariableProvider.Object);
+    }
+
+    [Fact]
+    public void It_Falls_Back_To_Aws_Access_Key_Environment_Variable_If_Aws_Access_Key_Id_Is_Not_Set()
+    {
+        // Arrange
+        const string awsAccessKey = "AWS_ACCESS_KEY";
+#pragma warning disable CS0618
+        _mockEnvironmentVariableProvider.Setup(m => m.AwsAccessKey(false)).Returns(awsAccessKey);
+#pragma warning restore CS0618
+
+        // Act
+        _awsApiFactory.Create("aws-region", null, "aws-secret-access-key", "aws-session-token");
+
+        // Assert
+#pragma warning disable CS0618
+        _mockEnvironmentVariableProvider.Verify(m => m.AwsAccessKey(false), Times.Once);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void It_Falls_Back_To_Aws_Secret_Key_Environment_Variable_If_Aws_Secret_Access_Key_Is_Not_Set()
+    {
+        // Arrange
+        const string awsSecretKey = "AWS_SECRET_KEY";
+#pragma warning disable CS0618
+        _mockEnvironmentVariableProvider.Setup(m => m.AwsSecretKey(false)).Returns(awsSecretKey);
+#pragma warning restore CS0618
+
+        // Act
+        _awsApiFactory.Create("aws-region", "aws-access-key-id", null, "aws-session-token");
+
+        // Assert
+#pragma warning disable CS0618
+        _mockEnvironmentVariableProvider.Verify(m => m.AwsSecretKey(false), Times.Once);
+#pragma warning restore CS0618
+    }
+}

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -32,6 +32,8 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
         private const string AWS_BUCKET_NAME = "aws-bucket-name";
         private const string AWS_ACCESS_KEY_ID = "aws-access-key-id";
         private const string AWS_SECRET_ACCESS_KEY = "aws-secret-access-key";
+        private const string AWS_ACCESS_KEY = "aws-access-key";
+        private const string AWS_SECRET_KEY = "aws-secret-key";
         private const string AWS_SESSION_TOKEN = "aws-session-token";
         private const string AWS_REGION = "aws-region";
         private const string AZURE_STORAGE_CONNECTION_STRING = "azure-storage-connection-string";
@@ -834,7 +836,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
         }
 
         [Fact]
-        public async Task It_Throws_When_Aws_Bucket_Name_Is_Provided_But_But_No_Aws_Access_Key()
+        public async Task It_Throws_When_Aws_Bucket_Name_Is_Provided_But_But_No_Aws_Access_Key_Id()
         {
             await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
             {
@@ -849,7 +851,42 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
         }
 
         [Fact]
-        public async Task It_Throws_When_Aws_Bucket_Name_Is_Provided_But_No_Aws_Secret_Key()
+        public async Task It_Does_Not_Throw_When_Aws_Bucket_Name_Is_Provided_And_Can_Fallback_To_Aws_Access_Key_Environment_Variable()
+        {
+            // Arrange
+            _mockBbsApi.Setup(x => x.StartExport(BBS_PROJECT, BBS_REPO)).ReturnsAsync(BBS_EXPORT_ID);
+            _mockBbsApi.Setup(x => x.GetExport(BBS_EXPORT_ID)).ReturnsAsync(("COMPLETED", "The export is complete", 100));
+            _mockBbsArchiveDownloader.Setup(x => x.Download(BBS_EXPORT_ID, It.IsAny<string>())).ReturnsAsync(ARCHIVE_PATH);
+            _mockAwsApi.Setup(x => x.UploadToBucket(AWS_BUCKET_NAME, ARCHIVE_PATH, It.IsAny<string>())).ReturnsAsync(ARCHIVE_URL);
+            _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
+            _mockGithubApi.Setup(x => x.CreateBbsMigrationSource(GITHUB_ORG_ID).Result).Returns(MIGRATION_SOURCE_ID);
+#pragma warning disable CS0618
+            _mockEnvironmentVariableProvider.Setup(x => x.AwsAccessKey(false)).Returns(AWS_ACCESS_KEY);
+#pragma warning restore CS0618
+
+            // Act, Assert
+            var args = new MigrateRepoCommandArgs
+            {
+                BbsServerUrl = BBS_SERVER_URL,
+                BbsUsername = BBS_USERNAME,
+                BbsPassword = BBS_PASSWORD,
+                BbsProject = BBS_PROJECT,
+                BbsRepo = BBS_REPO,
+                SshUser = SSH_USER,
+                SshPrivateKey = PRIVATE_KEY,
+                AwsBucketName = AWS_BUCKET_NAME,
+                AwsSecretKey = AWS_SECRET_ACCESS_KEY,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                GithubPat = GITHUB_PAT,
+            };
+            await _handler.Invoking(async x => await x.Handle(args)).Should().NotThrowAsync();
+
+            _mockOctoLogger.Verify(m => m.LogWarning(It.Is<string>(msg => msg.Contains("AWS_ACCESS_KEY"))));
+        }
+
+        [Fact]
+        public async Task It_Throws_When_Aws_Bucket_Name_Is_Provided_But_No_Aws_Secret_Access_Key()
         {
             await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
             {
@@ -862,6 +899,41 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
                 .WithMessage("*--aws-secret-key*AWS_SECRET_ACCESS_KEY*");
+        }
+
+        [Fact]
+        public async Task It_Does_Not_Throw_When_Aws_Bucket_Name_Is_Provided_And_Can_Fallback_To_Aws_Secret_Key_Environment_Variable()
+        {
+            // Arrange
+            _mockBbsApi.Setup(x => x.StartExport(BBS_PROJECT, BBS_REPO)).ReturnsAsync(BBS_EXPORT_ID);
+            _mockBbsApi.Setup(x => x.GetExport(BBS_EXPORT_ID)).ReturnsAsync(("COMPLETED", "The export is complete", 100));
+            _mockBbsArchiveDownloader.Setup(x => x.Download(BBS_EXPORT_ID, It.IsAny<string>())).ReturnsAsync(ARCHIVE_PATH);
+            _mockAwsApi.Setup(x => x.UploadToBucket(AWS_BUCKET_NAME, ARCHIVE_PATH, It.IsAny<string>())).ReturnsAsync(ARCHIVE_URL);
+            _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
+            _mockGithubApi.Setup(x => x.CreateBbsMigrationSource(GITHUB_ORG_ID).Result).Returns(MIGRATION_SOURCE_ID);
+#pragma warning disable CS0618
+            _mockEnvironmentVariableProvider.Setup(x => x.AwsSecretKey(false)).Returns(AWS_SECRET_KEY);
+#pragma warning restore CS0618
+
+            // Act, Assert
+            var args = new MigrateRepoCommandArgs
+            {
+                BbsServerUrl = BBS_SERVER_URL,
+                BbsUsername = BBS_USERNAME,
+                BbsPassword = BBS_PASSWORD,
+                BbsProject = BBS_PROJECT,
+                BbsRepo = BBS_REPO,
+                SshUser = SSH_USER,
+                SshPrivateKey = PRIVATE_KEY,
+                AwsBucketName = AWS_BUCKET_NAME,
+                AwsAccessKey = AWS_ACCESS_KEY_ID,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                GithubPat = GITHUB_PAT,
+            };
+            await _handler.Invoking(async x => await x.Handle(args)).Should().NotThrowAsync();
+
+            _mockOctoLogger.Verify(m => m.LogWarning(It.Is<string>(msg => msg.Contains("AWS_SECRET_KEY"))));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -30,8 +30,8 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
         private const string GITHUB_REPO = "target-repo";
         private const string GITHUB_PAT = "github pat";
         private const string AWS_BUCKET_NAME = "aws-bucket-name";
-        private const string AWS_ACCESS_KEY = "aws-access-key";
-        private const string AWS_SECRET_KEY = "aws-secret-key";
+        private const string AWS_ACCESS_KEY_ID = "aws-access-key-id";
+        private const string AWS_SECRET_ACCESS_KEY = "aws-secret-access-key";
         private const string AWS_SESSION_TOKEN = "aws-session-token";
         private const string AWS_REGION = "aws-region";
         private const string AZURE_STORAGE_CONNECTION_STRING = "azure-storage-connection-string";
@@ -204,8 +204,8 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
                 SshUser = SSH_USER,
                 SshPrivateKey = PRIVATE_KEY,
                 AwsBucketName = AWS_BUCKET_NAME,
-                AwsAccessKey = AWS_ACCESS_KEY,
-                AwsSecretKey = AWS_SECRET_KEY,
+                AwsAccessKey = AWS_ACCESS_KEY_ID,
+                AwsSecretKey = AWS_SECRET_ACCESS_KEY,
                 GithubOrg = GITHUB_ORG,
                 GithubRepo = GITHUB_REPO,
                 GithubPat = GITHUB_PAT,
@@ -782,8 +782,8 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
                 GithubOrg = GITHUB_ORG,
                 GithubRepo = GITHUB_REPO,
                 ArchivePath = ARCHIVE_PATH,
-                AwsAccessKey = AWS_ACCESS_KEY,
-                AwsSecretKey = AWS_SECRET_KEY,
+                AwsAccessKey = AWS_ACCESS_KEY_ID,
+                AwsSecretKey = AWS_SECRET_ACCESS_KEY,
                 AwsBucketName = AWS_BUCKET_NAME
             };
 
@@ -813,7 +813,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
                     }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
-                .WithMessage("*--azure-storage-connection-string*AZURE_STORAGE_CONNECTION_STRING*or*--aws-bucket-name*--aws-access-key*AWS_ACCESS_KEY*--aws-secret-key*AWS_SECRET_KEY*");
+                .WithMessage("*--azure-storage-connection-string*AZURE_STORAGE_CONNECTION_STRING*or*--aws-bucket-name*--aws-access-key*AWS_ACCESS_KEY_ID*--aws-secret-key*AWS_SECRET_ACCESS_KEY*");
         }
 
         [Fact]
@@ -830,7 +830,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
                     }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
-                .WithMessage("*--azure-storage-connection-string*AZURE_STORAGE_CONNECTION_STRING*and*--aws-bucket-name*--aws-access-key*AWS_ACCESS_KEY*--aws-secret-key*AWS_SECRET_KEY*");
+                .WithMessage("*--azure-storage-connection-string*AZURE_STORAGE_CONNECTION_STRING*and*--aws-bucket-name*--aws-access-key*AWS_ACCESS_KEY_ID*--aws-secret-key*AWS_SECRET_ACCESS_KEY*");
         }
 
         [Fact]
@@ -845,7 +845,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
-                .WithMessage("*--aws-access-key*AWS_ACCESS_KEY*");
+                .WithMessage("*--aws-access-key*AWS_ACCESS_KEY_ID*");
         }
 
         [Fact]
@@ -857,11 +857,11 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
                 GithubOrg = GITHUB_ORG,
                 GithubRepo = GITHUB_REPO,
                 AwsBucketName = AWS_BUCKET_NAME,
-                AwsAccessKey = AWS_ACCESS_KEY
+                AwsAccessKey = AWS_ACCESS_KEY_ID
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
-                .WithMessage("*--aws-secret-key*AWS_SECRET_KEY*");
+                .WithMessage("*--aws-secret-key*AWS_SECRET_ACCESS_KEY*");
         }
 
         [Fact]
@@ -873,8 +873,8 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
                 GithubOrg = GITHUB_ORG,
                 GithubRepo = GITHUB_REPO,
                 AwsBucketName = AWS_BUCKET_NAME,
-                AwsAccessKey = AWS_ACCESS_KEY,
-                AwsSecretKey = AWS_SECRET_KEY,
+                AwsAccessKey = AWS_ACCESS_KEY_ID,
+                AwsSecretKey = AWS_SECRET_ACCESS_KEY,
                 AwsSessionToken = AWS_SESSION_TOKEN
             }))
                 .Should()
@@ -891,7 +891,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
                 GithubOrg = GITHUB_ORG,
                 GithubRepo = GITHUB_REPO,
                 AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING,
-                AwsAccessKey = AWS_ACCESS_KEY
+                AwsAccessKey = AWS_ACCESS_KEY_ID
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
@@ -907,7 +907,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
                 GithubOrg = GITHUB_ORG,
                 GithubRepo = GITHUB_REPO,
                 AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING,
-                AwsSecretKey = AWS_SECRET_KEY
+                AwsSecretKey = AWS_SECRET_ACCESS_KEY
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()

--- a/src/OctoshiftCLI.Tests/gei/AwsApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/AwsApiFactoryTests.cs
@@ -1,0 +1,52 @@
+using Moq;
+using OctoshiftCLI.GithubEnterpriseImporter;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.GithubEnterpriseImporter;
+
+public class AwsApiFactoryTests
+{
+    private readonly Mock<EnvironmentVariableProvider> _mockEnvironmentVariableProvider = TestHelpers.CreateMock<EnvironmentVariableProvider>();
+    private readonly AwsApiFactory _awsApiFactory;
+
+    public AwsApiFactoryTests()
+    {
+        _awsApiFactory = new AwsApiFactory(_mockEnvironmentVariableProvider.Object);
+    }
+
+    [Fact]
+    public void It_Falls_Back_To_Aws_Access_Key_Environment_Variable_If_Aws_Access_Key_Id_Is_Not_Set()
+    {
+        // Arrange
+        const string awsAccessKey = "AWS_ACCESS_KEY";
+#pragma warning disable CS0618
+        _mockEnvironmentVariableProvider.Setup(m => m.AwsAccessKey(false)).Returns(awsAccessKey);
+#pragma warning restore CS0618
+
+        // Act
+        _awsApiFactory.Create("aws-region", null, "aws-secret-access-key", "aws-session-token");
+
+        // Assert
+#pragma warning disable CS0618
+        _mockEnvironmentVariableProvider.Verify(m => m.AwsAccessKey(false), Times.Once);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void It_Falls_Back_To_Aws_Secret_Key_Environment_Variable_If_Aws_Secret_Access_Key_Is_Not_Set()
+    {
+        // Arrange
+        const string awsSecretKey = "AWS_SECRET_KEY";
+#pragma warning disable CS0618
+        _mockEnvironmentVariableProvider.Setup(m => m.AwsSecretKey(false)).Returns(awsSecretKey);
+#pragma warning restore CS0618
+
+        // Act
+        _awsApiFactory.Create("aws-region", "aws-access-key-id", null, "aws-session-token");
+
+        // Assert
+#pragma warning disable CS0618
+        _mockEnvironmentVariableProvider.Verify(m => m.AwsSecretKey(false), Times.Once);
+#pragma warning restore CS0618
+    }
+}

--- a/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -33,7 +33,9 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         private const string GITHUB_SOURCE_PAT = "github-source-pat";
         private const string AWS_BUCKET_NAME = "aws-bucket-name";
         private const string AWS_ACCESS_KEY_ID = "aws-access-key-id";
+        private const string AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
         private const string AWS_SECRET_ACCESS_KEY = "aws-secret-access-key";
+        private const string AWS_SECRET_KEY = "AWS_SECRET_KEY";
         private const string AWS_SESSION_TOKEN = "aws-session-token";
         private const string AWS_REGION = "aws-region";
 
@@ -1397,7 +1399,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         }
 
         [Fact]
-        public async Task Ghes_When_Aws_Bucket_Name_Is_Provided_But_No_Aws_Access_Key_Throws()
+        public async Task Ghes_When_Aws_Bucket_Name_Is_Provided_But_No_Aws_Access_Key_Id_Throws()
         {
             await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
             {
@@ -1412,6 +1414,88 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
                 .WithMessage("*--aws-access-key*");
+        }
+
+        [Fact]
+        public async Task Ghes_When_Aws_Bucket_Name_Is_Provided_And_Can_Fallback_To_Aws_Access_Key_Environment_Variable_Does_Not_Throw()
+        {
+            var githubOrgId = Guid.NewGuid().ToString();
+            var migrationSourceId = Guid.NewGuid().ToString();
+            var sourceGithubPat = Guid.NewGuid().ToString();
+            var targetGithubPat = Guid.NewGuid().ToString();
+            var githubRepoUrl = $"https://myghes/{SOURCE_ORG}/{SOURCE_REPO}";
+            var migrationId = Guid.NewGuid().ToString();
+            var gitArchiveId = 1;
+            var metadataArchiveId = 2;
+
+            var gitArchiveUrl = $"https://example.com/{gitArchiveId}";
+            var metadataArchiveUrl = $"https://example.com/{metadataArchiveId}";
+            var gitArchiveContent = new byte[] { 1, 2, 3, 4, 5 };
+            var metadataArchiveContent = new byte[] { 6, 7, 8, 9, 10 };
+
+            var archiveUrl = $"https://s3.amazonaws.com/{AWS_BUCKET_NAME}/archive.tar";
+
+            _mockTargetGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
+            _mockTargetGithubApi.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
+            _mockTargetGithubApi
+                .Setup(x => x.StartMigration(
+                    migrationSourceId,
+                    githubRepoUrl,
+                    githubOrgId,
+                    TARGET_REPO,
+                    sourceGithubPat,
+                    targetGithubPat,
+                    archiveUrl,
+                    archiveUrl,
+                    false,
+                    false).Result)
+                .Returns(migrationId);
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null));
+            _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
+
+            _mockSourceGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
+            _mockSourceGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false, false).Result).Returns(metadataArchiveId);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
+
+            _mockHttpDownloadService.Setup(x => x.DownloadToBytes(gitArchiveUrl).Result).Returns(gitArchiveContent);
+            _mockHttpDownloadService.Setup(x => x.DownloadToBytes(metadataArchiveUrl).Result).Returns(metadataArchiveContent);
+
+            _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken(It.IsAny<bool>())).Returns(sourceGithubPat);
+            _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
+#pragma warning disable CS0618
+            _mockEnvironmentVariableProvider.Setup(m => m.AwsAccessKey(false)).Returns(AWS_ACCESS_KEY);
+#pragma warning restore CS0618
+
+            _mockAwsApi.Setup(m => m.UploadToBucket(AWS_BUCKET_NAME, It.IsAny<byte[]>(), It.IsAny<string>())).ReturnsAsync(archiveUrl);
+
+            var handler = new MigrateRepoCommandHandler(
+                _mockOctoLogger.Object,
+                _mockSourceGithubApi.Object,
+                _mockTargetGithubApi.Object,
+                _mockEnvironmentVariableProvider.Object,
+                _mockAzureApi.Object,
+                _mockAwsApi.Object,
+                _mockHttpDownloadService.Object);
+
+            // Act, Assert
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                TargetApiUrl = TARGET_API_URL,
+                GhesApiUrl = GHES_API_URL,
+                AwsBucketName = AWS_BUCKET_NAME,
+                AwsSecretKey = AWS_SECRET_ACCESS_KEY,
+                Wait = true
+            };
+            await handler.Invoking(async x => await x.Handle(args)).Should().NotThrowAsync();
+
+            _mockOctoLogger.Verify(m => m.LogWarning(It.Is<string>(msg => msg.Contains("AWS_ACCESS_KEY"))));
         }
 
         [Fact]
@@ -1430,6 +1514,88 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
                 .WithMessage("*--aws-secret-key*");
+        }
+
+        [Fact]
+        public async Task Ghes_When_Aws_Bucket_Name_Is_Provided_And_Can_Fallback_To_Aws_Secret_Key_Environment_Variable_Does_Not_Throw()
+        {
+            var githubOrgId = Guid.NewGuid().ToString();
+            var migrationSourceId = Guid.NewGuid().ToString();
+            var sourceGithubPat = Guid.NewGuid().ToString();
+            var targetGithubPat = Guid.NewGuid().ToString();
+            var githubRepoUrl = $"https://myghes/{SOURCE_ORG}/{SOURCE_REPO}";
+            var migrationId = Guid.NewGuid().ToString();
+            var gitArchiveId = 1;
+            var metadataArchiveId = 2;
+
+            var gitArchiveUrl = $"https://example.com/{gitArchiveId}";
+            var metadataArchiveUrl = $"https://example.com/{metadataArchiveId}";
+            var gitArchiveContent = new byte[] { 1, 2, 3, 4, 5 };
+            var metadataArchiveContent = new byte[] { 6, 7, 8, 9, 10 };
+
+            var archiveUrl = $"https://s3.amazonaws.com/{AWS_BUCKET_NAME}/archive.tar";
+
+            _mockTargetGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
+            _mockTargetGithubApi.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
+            _mockTargetGithubApi
+                .Setup(x => x.StartMigration(
+                    migrationSourceId,
+                    githubRepoUrl,
+                    githubOrgId,
+                    TARGET_REPO,
+                    sourceGithubPat,
+                    targetGithubPat,
+                    archiveUrl,
+                    archiveUrl,
+                    false,
+                    false).Result)
+                .Returns(migrationId);
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null));
+            _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
+
+            _mockSourceGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
+            _mockSourceGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false, false).Result).Returns(metadataArchiveId);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
+
+            _mockHttpDownloadService.Setup(x => x.DownloadToBytes(gitArchiveUrl).Result).Returns(gitArchiveContent);
+            _mockHttpDownloadService.Setup(x => x.DownloadToBytes(metadataArchiveUrl).Result).Returns(metadataArchiveContent);
+
+            _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken(It.IsAny<bool>())).Returns(sourceGithubPat);
+            _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
+#pragma warning disable CS0618
+            _mockEnvironmentVariableProvider.Setup(m => m.AwsSecretKey(false)).Returns(AWS_SECRET_KEY);
+#pragma warning restore CS0618
+
+            _mockAwsApi.Setup(m => m.UploadToBucket(AWS_BUCKET_NAME, It.IsAny<byte[]>(), It.IsAny<string>())).ReturnsAsync(archiveUrl);
+
+            var handler = new MigrateRepoCommandHandler(
+                _mockOctoLogger.Object,
+                _mockSourceGithubApi.Object,
+                _mockTargetGithubApi.Object,
+                _mockEnvironmentVariableProvider.Object,
+                _mockAzureApi.Object,
+                _mockAwsApi.Object,
+                _mockHttpDownloadService.Object);
+
+            // Act, Assert
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                TargetApiUrl = TARGET_API_URL,
+                GhesApiUrl = GHES_API_URL,
+                AwsBucketName = AWS_BUCKET_NAME,
+                AwsAccessKey = AWS_ACCESS_KEY,
+                Wait = true
+            };
+            await handler.Invoking(async x => await x.Handle(args)).Should().NotThrowAsync();
+
+            _mockOctoLogger.Verify(m => m.LogWarning(It.Is<string>(msg => msg.Contains("AWS_SECRET_KEY"))));
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -32,8 +32,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         private const string GITHUB_TARGET_PAT = "github-target-pat";
         private const string GITHUB_SOURCE_PAT = "github-source-pat";
         private const string AWS_BUCKET_NAME = "aws-bucket-name";
-        private const string AWS_ACCESS_KEY = "aws-access-key";
-        private const string AWS_SECRET_KEY = "aws-secret-key";
+        private const string AWS_ACCESS_KEY_ID = "aws-access-key-id";
+        private const string AWS_SECRET_ACCESS_KEY = "aws-secret-access-key";
         private const string AWS_SESSION_TOKEN = "aws-session-token";
         private const string AWS_REGION = "aws-region";
 
@@ -1311,8 +1311,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var gitArchiveContent = new byte[] { 1, 2, 3, 4, 5 };
             var metadataArchiveContent = new byte[] { 6, 7, 8, 9, 10 };
 
-            var awsAccessKey = "awsAccessKey";
-            var awsSecretKey = "awsSecretKey";
+            var awsAccessKeyId = "awsAccessKeyId";
+            var awsSecretAccessKey = "awsSecretAccessKey";
             var awsBucketName = "awsBucketName";
             var archiveUrl = $"https://s3.amazonaws.com/{awsBucketName}/archive.tar";
 
@@ -1368,8 +1368,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 TargetApiUrl = TARGET_API_URL,
                 GhesApiUrl = GHES_API_URL,
                 AwsBucketName = awsBucketName,
-                AwsAccessKey = awsAccessKey,
-                AwsSecretKey = awsSecretKey,
+                AwsAccessKey = awsAccessKeyId,
+                AwsSecretKey = awsSecretAccessKey,
                 Wait = true
             };
 
@@ -1407,7 +1407,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 TargetRepo = TARGET_REPO,
                 GhesApiUrl = GHES_API_URL,
                 AwsBucketName = AWS_BUCKET_NAME,
-                AwsSecretKey = AWS_SECRET_KEY
+                AwsSecretKey = AWS_SECRET_ACCESS_KEY
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
@@ -1425,7 +1425,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 TargetRepo = TARGET_REPO,
                 GhesApiUrl = GHES_API_URL,
                 AwsBucketName = AWS_BUCKET_NAME,
-                AwsAccessKey = AWS_ACCESS_KEY
+                AwsAccessKey = AWS_ACCESS_KEY_ID
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
@@ -1443,8 +1443,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 TargetRepo = TARGET_REPO,
                 GhesApiUrl = GHES_API_URL,
                 AwsBucketName = AWS_BUCKET_NAME,
-                AwsAccessKey = AWS_ACCESS_KEY,
-                AwsSecretKey = AWS_SECRET_KEY,
+                AwsAccessKey = AWS_ACCESS_KEY_ID,
+                AwsSecretKey = AWS_SECRET_ACCESS_KEY,
                 AwsSessionToken = AWS_SESSION_TOKEN
             }))
                 .Should()
@@ -1463,7 +1463,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 TargetRepo = TARGET_REPO,
                 GhesApiUrl = GHES_API_URL,
                 AzureStorageConnectionString = AZURE_CONNECTION_STRING,
-                AwsAccessKey = AWS_ACCESS_KEY
+                AwsAccessKey = AWS_ACCESS_KEY_ID
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
@@ -1481,7 +1481,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 TargetRepo = TARGET_REPO,
                 GhesApiUrl = GHES_API_URL,
                 AzureStorageConnectionString = AZURE_CONNECTION_STRING,
-                AwsSecretKey = AWS_SECRET_KEY
+                AwsSecretKey = AWS_SECRET_ACCESS_KEY
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
@@ -1499,7 +1499,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 TargetRepo = TARGET_REPO,
                 GhesApiUrl = GHES_API_URL,
                 AzureStorageConnectionString = AZURE_CONNECTION_STRING,
-                AwsSessionToken = AWS_SECRET_KEY
+                AwsSessionToken = AWS_SECRET_ACCESS_KEY
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()

--- a/src/bbs2gh/AwsApiFactory.cs
+++ b/src/bbs2gh/AwsApiFactory.cs
@@ -11,8 +11,14 @@ public class AwsApiFactory
 
     public virtual AwsApi Create(string awsRegion = null, string awsAccessKeyId = null, string awsSecretAccessKey = null, string awsSessionToken = null)
     {
-        awsAccessKeyId ??= _environmentVariableProvider.AwsAccessKeyId();
-        awsSecretAccessKey ??= _environmentVariableProvider.AwsSecretAccessKey();
+#pragma warning disable CS0618
+        awsAccessKeyId ??= _environmentVariableProvider.AwsAccessKeyId(false)
+                           ?? _environmentVariableProvider.AwsAccessKey(false)
+                           ?? _environmentVariableProvider.AwsAccessKeyId();
+        awsSecretAccessKey ??= _environmentVariableProvider.AwsSecretAccessKey(false)
+                               ?? _environmentVariableProvider.AwsSecretKey()
+                               ?? _environmentVariableProvider.AwsSecretAccessKey();
+#pragma warning restore CS0618
         awsSessionToken ??= _environmentVariableProvider.AwsSessionToken(false);
         awsRegion ??= _environmentVariableProvider.AwsRegion(false);
 

--- a/src/bbs2gh/AwsApiFactory.cs
+++ b/src/bbs2gh/AwsApiFactory.cs
@@ -16,7 +16,7 @@ public class AwsApiFactory
                            ?? _environmentVariableProvider.AwsAccessKey(false)
                            ?? _environmentVariableProvider.AwsAccessKeyId();
         awsSecretAccessKey ??= _environmentVariableProvider.AwsSecretAccessKey(false)
-                               ?? _environmentVariableProvider.AwsSecretKey()
+                               ?? _environmentVariableProvider.AwsSecretKey(false)
                                ?? _environmentVariableProvider.AwsSecretAccessKey();
 #pragma warning restore CS0618
         awsSessionToken ??= _environmentVariableProvider.AwsSessionToken(false);

--- a/src/bbs2gh/AwsApiFactory.cs
+++ b/src/bbs2gh/AwsApiFactory.cs
@@ -9,13 +9,13 @@ public class AwsApiFactory
         _environmentVariableProvider = environmentVariableProvider;
     }
 
-    public virtual AwsApi Create(string awsRegion = null, string awsAccessKey = null, string awsSecretKey = null, string awsSessionToken = null)
+    public virtual AwsApi Create(string awsRegion = null, string awsAccessKeyId = null, string awsSecretAccessKey = null, string awsSessionToken = null)
     {
-        awsAccessKey ??= _environmentVariableProvider.AwsAccessKey();
-        awsSecretKey ??= _environmentVariableProvider.AwsSecretKey();
+        awsAccessKeyId ??= _environmentVariableProvider.AwsAccessKeyId();
+        awsSecretAccessKey ??= _environmentVariableProvider.AwsSecretAccessKey();
         awsSessionToken ??= _environmentVariableProvider.AwsSessionToken(false);
         awsRegion ??= _environmentVariableProvider.AwsRegion(false);
 
-        return new AwsApi(awsAccessKey, awsSecretKey, awsRegion, awsSessionToken);
+        return new AwsApi(awsAccessKeyId, awsSecretAccessKey, awsRegion, awsSessionToken);
     }
 }

--- a/src/bbs2gh/Commands/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepoCommand.cs
@@ -89,11 +89,11 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
 
     public Option<string> AwsAccessKey { get; } = new(
         name: "--aws-access-key",
-        description: "If uploading to S3, the AWS access key. If not provided, it will be read from AWS_ACCESS_KEY environment variable.");
+        description: "If uploading to S3, the AWS access key. If not provided, it will be read from AWS_ACCESS_KEY_ID environment variable.");
 
     public Option<string> AwsSecretKey { get; } = new(
         name: "--aws-secret-key",
-        description: "If uploading to S3, the AWS secret key. If not provided, it will be read from AWS_SECRET_KEY environment variable.");
+        description: "If uploading to S3, the AWS secret key. If not provided, it will be read from AWS_SECRET_ACCESS_KEY environment variable.");
 
     public Option<string> AwsSessionToken { get; } = new(
         name: "--aws-session-token",

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -506,12 +506,30 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         {
             if (!GetAwsAccessKey(args).HasValue())
             {
-                throw new OctoshiftCliException("Either --aws-access-key or AWS_ACCESS_KEY_ID environment variable must be set.");
+#pragma warning disable CS0618
+                if (_environmentVariableProvider.AwsAccessKey(false).HasValue())
+#pragma warning restore CS0618
+                {
+                    _log.LogWarning("AWS_ACCESS_KEY environment variable is deprecated and will be removed in future releases. Please consider using AWS_ACCESS_KEY_ID environment variable instead.");
+                }
+                else
+                {
+                    throw new OctoshiftCliException("Either --aws-access-key or AWS_ACCESS_KEY_ID environment variable must be set.");
+                }
             }
 
             if (!GetAwsSecretKey(args).HasValue())
             {
-                throw new OctoshiftCliException("Either --aws-secret-key or AWS_SECRET_ACCESS_KEY environment variable must be set.");
+#pragma warning disable CS0618
+                if (_environmentVariableProvider.AwsSecretKey(false).HasValue())
+#pragma warning restore CS0618
+                {
+                    _log.LogWarning("AWS_SECRET_KEY environment variable is deprecated and will be removed in future releases. Please consider using AWS_SECRET_ACCESS_KEY environment variable instead.");
+                }
+                else
+                {
+                    throw new OctoshiftCliException("Either --aws-secret-key or AWS_SECRET_ACCESS_KEY environment variable must be set.");
+                }
             }
 
             if (GetAwsSessionToken(args).HasValue() && GetAwsRegion(args).IsNullOrWhiteSpace())

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -490,7 +490,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         {
             throw new OctoshiftCliException(
                 "Either Azure storage connection (--azure-storage-connection-string or AZURE_STORAGE_CONNECTION_STRING env. variable) or " +
-                "AWS S3 connection (--aws-bucket-name, --aws-access-key (or AWS_ACCESS_KEY env. variable), --aws-secret-key (or AWS_SECRET_Key env.variable)) " +
+                "AWS S3 connection (--aws-bucket-name, --aws-access-key (or AWS_ACCESS_KEY_ID env. variable), --aws-secret-key (or AWS_SECRET_ACCESS_KEY env.variable)) " +
                 "must be provided.");
         }
 
@@ -498,7 +498,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         {
             throw new OctoshiftCliException(
                 "Azure storage connection (--azure-storage-connection-string or AZURE_STORAGE_CONNECTION_STRING env. variable) and " +
-                "AWS S3 connection (--aws-bucket-name, --aws-access-key (or AWS_ACCESS_KEY env. variable), --aws-secret-key (or AWS_SECRET_Key env.variable)) cannot be " +
+                "AWS S3 connection (--aws-bucket-name, --aws-access-key (or AWS_ACCESS_KEY_ID env. variable), --aws-secret-key (or AWS_SECRET_ACCESS_KEY env.variable)) cannot be " +
                 "specified together.");
         }
 
@@ -506,12 +506,12 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         {
             if (!GetAwsAccessKey(args).HasValue())
             {
-                throw new OctoshiftCliException("Either --aws-access-key or AWS_ACCESS_KEY environment variable must be set.");
+                throw new OctoshiftCliException("Either --aws-access-key or AWS_ACCESS_KEY_ID environment variable must be set.");
             }
 
             if (!GetAwsSecretKey(args).HasValue())
             {
-                throw new OctoshiftCliException("Either --aws-secret-key or AWS_SECRET_KEY environment variable must be set.");
+                throw new OctoshiftCliException("Either --aws-secret-key or AWS_SECRET_ACCESS_KEY environment variable must be set.");
             }
 
             if (GetAwsSessionToken(args).HasValue() && GetAwsRegion(args).IsNullOrWhiteSpace())
@@ -545,9 +545,9 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         }
     }
 
-    private string GetAwsAccessKey(MigrateRepoCommandArgs args) => args.AwsAccessKey.HasValue() ? args.AwsAccessKey : _environmentVariableProvider.AwsAccessKey(false);
+    private string GetAwsAccessKey(MigrateRepoCommandArgs args) => args.AwsAccessKey.HasValue() ? args.AwsAccessKey : _environmentVariableProvider.AwsAccessKeyId(false);
 
-    private string GetAwsSecretKey(MigrateRepoCommandArgs args) => args.AwsSecretKey.HasValue() ? args.AwsSecretKey : _environmentVariableProvider.AwsSecretKey(false);
+    private string GetAwsSecretKey(MigrateRepoCommandArgs args) => args.AwsSecretKey.HasValue() ? args.AwsSecretKey : _environmentVariableProvider.AwsSecretAccessKey(false);
 
     private string GetAwsRegion(MigrateRepoCommandArgs args) => args.AwsRegion.HasValue() ? args.AwsRegion : _environmentVariableProvider.AwsRegion(false);
 

--- a/src/gei/AwsApiFactory.cs
+++ b/src/gei/AwsApiFactory.cs
@@ -11,8 +11,14 @@ public class AwsApiFactory
 
     public virtual AwsApi Create(string awsRegion = null, string awsAccessKeyId = null, string awsSecretAccessKey = null, string awsSessionToken = null)
     {
-        awsAccessKeyId ??= _environmentVariableProvider.AwsAccessKeyId();
-        awsSecretAccessKey ??= _environmentVariableProvider.AwsSecretAccessKey();
+#pragma warning disable CS0618
+        awsAccessKeyId ??= _environmentVariableProvider.AwsAccessKeyId(false)
+                           ?? _environmentVariableProvider.AwsAccessKey(false)
+                           ?? _environmentVariableProvider.AwsAccessKeyId();
+        awsSecretAccessKey ??= _environmentVariableProvider.AwsSecretAccessKey(false)
+                               ?? _environmentVariableProvider.AwsSecretKey()
+                               ?? _environmentVariableProvider.AwsSecretAccessKey();
+#pragma warning restore CS0618
         awsSessionToken ??= _environmentVariableProvider.AwsSessionToken(false);
         awsRegion ??= _environmentVariableProvider.AwsRegion(false);
 

--- a/src/gei/AwsApiFactory.cs
+++ b/src/gei/AwsApiFactory.cs
@@ -16,7 +16,7 @@ public class AwsApiFactory
                            ?? _environmentVariableProvider.AwsAccessKey(false)
                            ?? _environmentVariableProvider.AwsAccessKeyId();
         awsSecretAccessKey ??= _environmentVariableProvider.AwsSecretAccessKey(false)
-                               ?? _environmentVariableProvider.AwsSecretKey()
+                               ?? _environmentVariableProvider.AwsSecretKey(false)
                                ?? _environmentVariableProvider.AwsSecretAccessKey();
 #pragma warning restore CS0618
         awsSessionToken ??= _environmentVariableProvider.AwsSessionToken(false);

--- a/src/gei/AwsApiFactory.cs
+++ b/src/gei/AwsApiFactory.cs
@@ -9,13 +9,13 @@ public class AwsApiFactory
         _environmentVariableProvider = environmentVariableProvider;
     }
 
-    public virtual AwsApi Create(string awsRegion = null, string awsAccessKey = null, string awsSecretKey = null, string awsSessionToken = null)
+    public virtual AwsApi Create(string awsRegion = null, string awsAccessKeyId = null, string awsSecretAccessKey = null, string awsSessionToken = null)
     {
-        awsAccessKey ??= _environmentVariableProvider.AwsAccessKey();
-        awsSecretKey ??= _environmentVariableProvider.AwsSecretKey();
+        awsAccessKeyId ??= _environmentVariableProvider.AwsAccessKeyId();
+        awsSecretAccessKey ??= _environmentVariableProvider.AwsSecretAccessKey();
         awsSessionToken ??= _environmentVariableProvider.AwsSessionToken(false);
         awsRegion ??= _environmentVariableProvider.AwsRegion(false);
 
-        return new AwsApi(awsAccessKey, awsSecretKey, awsRegion, awsSessionToken);
+        return new AwsApi(awsAccessKeyId, awsSecretAccessKey, awsRegion, awsSessionToken);
     }
 }

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -96,11 +96,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         };
         public Option<string> AwsAccessKey { get; } = new("--aws-access-key")
         {
-            Description = "If uploading to S3, the AWS access key. If not provided, it will be read from AWS_ACCESS_KEY environment variable. Not required if migrating from GitHub Enterprise Server 3.8.0 or later."
+            Description = "If uploading to S3, the AWS access key. If not provided, it will be read from AWS_ACCESS_KEY_ID environment variable. Not required if migrating from GitHub Enterprise Server 3.8.0 or later."
         };
         public Option<string> AwsSecretKey { get; } = new("--aws-secret-key")
         {
-            Description = "If uploading to S3, the AWS secret key. If not provided, it will be read from AWS_SECRET_KEY environment variable. Not required if migrating from GitHub Enterprise Server 3.8.0 or later."
+            Description = "If uploading to S3, the AWS secret key. If not provided, it will be read from AWS_SECRET_ACCESS_KEY environment variable. Not required if migrating from GitHub Enterprise Server 3.8.0 or later."
         };
         public Option<string> AwsSessionToken { get; } = new("--aws-session-token")
         {

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -484,12 +484,30 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             {
                 if (!GetAwsAccessKey(args).HasValue())
                 {
-                    throw new OctoshiftCliException("Either --aws-access-key or AWS_ACCESS_KEY_ID environment variable must be set.");
+#pragma warning disable CS0618
+                    if (_environmentVariableProvider.AwsAccessKey(false).HasValue())
+#pragma warning restore CS0618
+                    {
+                        _log.LogWarning("AWS_ACCESS_KEY environment variable is deprecated and will be removed in future releases. Please consider using AWS_ACCESS_KEY_ID environment variable instead.");
+                    }
+                    else
+                    {
+                        throw new OctoshiftCliException("Either --aws-access-key or AWS_ACCESS_KEY_ID environment variable must be set.");
+                    }
                 }
 
                 if (!GetAwsSecretKey(args).HasValue())
                 {
-                    throw new OctoshiftCliException("Either --aws-secret-key or AWS_SECRET_ACCESS_KEY environment variable must be set.");
+#pragma warning disable CS0618
+                    if (_environmentVariableProvider.AwsSecretKey(false).HasValue())
+#pragma warning restore CS0618
+                    {
+                        _log.LogWarning("AWS_SECRET_KEY environment variable is deprecated and will be removed in future releases. Please consider using AWS_SECRET_ACCESS_KEY environment variable instead.");
+                    }
+                    else
+                    {
+                        throw new OctoshiftCliException("Either --aws-secret-key or AWS_SECRET_ACCESS_KEY environment variable must be set.");
+                    }
                 }
 
                 if (GetAwsSessionToken(args).HasValue() && GetAwsRegion(args).IsNullOrWhiteSpace())

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -468,7 +468,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             {
                 throw new OctoshiftCliException(
                     "Either Azure storage connection (--azure-storage-connection-string or AZURE_STORAGE_CONNECTION_STRING env. variable) or " +
-                    "AWS S3 connection (--aws-bucket-name, --aws-access-key (or AWS_ACCESS_KEY env. variable), --aws-secret-key (or AWS_SECRET_KEY env.variable)) " +
+                    "AWS S3 connection (--aws-bucket-name, --aws-access-key (or AWS_ACCESS_KEY_ID env. variable), --aws-secret-key (or AWS_SECRET_ACCESS_KEY env.variable)) " +
                     "must be provided.");
             }
 
@@ -476,7 +476,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             {
                 throw new OctoshiftCliException(
                     "Azure storage connection (--azure-storage-connection-string or AZURE_STORAGE_CONNECTION_STRING env. variable) and " +
-                    "AWS S3 connection (--aws-bucket-name, --aws-access-key (or AWS_ACCESS_KEY env. variable), --aws-secret-key (or AWS_SECRET_Key env.variable)) cannot be " +
+                    "AWS S3 connection (--aws-bucket-name, --aws-access-key (or AWS_ACCESS_KEY_ID env. variable), --aws-secret-key (or AWS_SECRET_ACCESS_KEY env.variable)) cannot be " +
                     "specified together.");
             }
 
@@ -484,12 +484,12 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             {
                 if (!GetAwsAccessKey(args).HasValue())
                 {
-                    throw new OctoshiftCliException("Either --aws-access-key or AWS_ACCESS_KEY environment variable must be set.");
+                    throw new OctoshiftCliException("Either --aws-access-key or AWS_ACCESS_KEY_ID environment variable must be set.");
                 }
 
                 if (!GetAwsSecretKey(args).HasValue())
                 {
-                    throw new OctoshiftCliException("Either --aws-secret-key or AWS_SECRET_KEY environment variable must be set.");
+                    throw new OctoshiftCliException("Either --aws-secret-key or AWS_SECRET_ACCESS_KEY environment variable must be set.");
                 }
 
                 if (GetAwsSessionToken(args).HasValue() && GetAwsRegion(args).IsNullOrWhiteSpace())
@@ -523,9 +523,9 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         }
     }
 
-    private string GetAwsAccessKey(MigrateRepoCommandArgs args) => args.AwsAccessKey.HasValue() ? args.AwsAccessKey : _environmentVariableProvider.AwsAccessKey(false);
+    private string GetAwsAccessKey(MigrateRepoCommandArgs args) => args.AwsAccessKey.HasValue() ? args.AwsAccessKey : _environmentVariableProvider.AwsAccessKeyId(false);
 
-    private string GetAwsSecretKey(MigrateRepoCommandArgs args) => args.AwsSecretKey.HasValue() ? args.AwsSecretKey : _environmentVariableProvider.AwsSecretKey(false);
+    private string GetAwsSecretKey(MigrateRepoCommandArgs args) => args.AwsSecretKey.HasValue() ? args.AwsSecretKey : _environmentVariableProvider.AwsSecretAccessKey(false);
 
     private string GetAwsRegion(MigrateRepoCommandArgs args) => args.AwsRegion.HasValue() ? args.AwsRegion : _environmentVariableProvider.AwsRegion(false);
 


### PR DESCRIPTION
Related to #738 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

### Description

AWS CLI uses slightly [different environment variable names](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/creds-assign.html) than we use. In order to avoid confusion and be able to reuse already existing AWS CLI variables, we need to also rename our env. variables to align with AWS CLI ones. This PR only changes the environment variable names not the actual arg names for backward compatibility. We will tackle the actual arg name changes later when timing is right in a separate PR.
The old environment variables are still supported but we spit out a warning to notify the users that they will be removed in future. 

Note:
- Once this PR is merged, the old action secrets for INT tests should be removed. 
