### PR TITLE
Configure implementation of `ITargetGithubApiFactory` for `gh bbs2gh` to get `grant-migrator-role` working

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Fix `gh bbs2gh grant-migrator-role` so it doesn't throw `System.InvalidOperationException`

--- a/src/bbs2gh/Program.cs
+++ b/src/bbs2gh/Program.cs
@@ -39,6 +39,7 @@ namespace OctoshiftCLI.BbsToGithub
                 .AddSingleton<DateTimeProvider>()
                 .AddSingleton<IVersionProvider, VersionChecker>(sp => sp.GetRequiredService<VersionChecker>())
                 .AddSingleton<BbsArchiveDownloaderFactory>()
+                .AddSingleton<ITargetGithubApiFactory>(sp => sp.GetRequiredService<GithubApiFactory>())
                 .AddHttpClient("Kerberos")
                 .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler()
                 {


### PR DESCRIPTION
Fixes #859.

It would probably be a good idea to add some tests so we catch an issue like this in the future - but I don't see any obvious tests I can copy, and I'm not confident enough with my C# to suggest something new!

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->