### PR TITLE
Set the `User-Agent` based on the CLI version when downloading archives from GHES/GHAE

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - Fix `gh bbs2gh grant-migrator-role` so it doesn't throw `System.InvalidOperationException`
 - Rename `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` environment variables to `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` respectively to align with the environment variables that the AWS CLI already uses. Old environment variables are still supported but they will be removed in future. 
+- Send a `User-Agent` header with the current CLI version when downloading migration archives from GitHub Enterprise Server

--- a/src/Octoshift/HttpDownloadService.cs
+++ b/src/Octoshift/HttpDownloadService.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.IO;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using OctoshiftCLI.Contracts;
 
 [assembly: InternalsVisibleTo("OctoshiftCLI.Tests")]
 namespace OctoshiftCLI
@@ -14,7 +16,7 @@ namespace OctoshiftCLI
         private readonly OctoLogger _log;
         private readonly HttpClient _httpClient;
 
-        public HttpDownloadService(OctoLogger log, HttpClient httpClient)
+        public HttpDownloadService(OctoLogger log, HttpClient httpClient, IVersionProvider versionProvider)
         {
             _log = log;
             _httpClient = httpClient;
@@ -22,6 +24,11 @@ namespace OctoshiftCLI
             if (_httpClient is not null)
             {
                 _httpClient.Timeout = TimeSpan.FromHours(1);
+                _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OctoshiftCLI", versionProvider?.GetCurrentVersion()));
+                if (versionProvider?.GetVersionComments() is { } comments)
+                {
+                    _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(comments));
+                }
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/github/gh-gei/issues/676.

I spotted this issue when going through the backlog, and figured it would be easy to fix, so I decided to quickly tackle it 🙌🏻 

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->