### PR TITLE
Consistently convert GraphQL errors to `OctoshiftCliException`s with helpful error messages across `GithubApi`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
 - Adds retry logic during GHES archive generation in cases of transient failure
 - Added log output linking to migration log URL after migration completes
 - Add support for specifying `--archive-download-host` with `gh bbs2gh migrate-repo` and `gh bbs2gh generate-script`, rather than taking the host from the `--bbs-server-url`
+- Improve handling of GraphQL errors, throwing an exception with the specific error message returned by the API

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -167,10 +167,7 @@ namespace OctoshiftCLI
 
             var response = await _retryPolicy.Retry(async () =>
             {
-                var httpResponse = await _client.PostAsync(url, payload);
-                var data = JObject.Parse(httpResponse);
-
-                EnsureSuccessGraphQLResponse(data);
+                var data = await _client.PostGraphQLAsync(url, payload);
 
                 return (string)data["data"]["organization"]["id"];
             });
@@ -192,10 +189,7 @@ namespace OctoshiftCLI
 
             var response = await _retryPolicy.Retry(async () =>
             {
-                var httpResponse = await _client.PostAsync(url, payload);
-                var data = JObject.Parse(httpResponse);
-
-                EnsureSuccessGraphQLResponse(data);
+                var data = await _client.PostGraphQLAsync(url, payload);
 
                 return (string)data["data"]["enterprise"]["id"];
             });
@@ -227,10 +221,7 @@ namespace OctoshiftCLI
                 operationName = "createMigrationSource"
             };
 
-            var response = await _client.PostAsync(url, payload);
-            var data = JObject.Parse(response);
-
-            EnsureSuccessGraphQLResponse(data);
+            var data = await _client.PostGraphQLAsync(url, payload);
 
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
@@ -255,10 +246,7 @@ namespace OctoshiftCLI
                 operationName = "createMigrationSource"
             };
 
-            var response = await _client.PostAsync(url, payload);
-            var data = JObject.Parse(response);
-
-            EnsureSuccessGraphQLResponse(data);
+            var data = await _client.PostGraphQLAsync(url, payload);
 
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
@@ -283,10 +271,7 @@ namespace OctoshiftCLI
                 operationName = "createMigrationSource"
             };
 
-            var response = await _client.PostAsync(url, payload);
-            var data = JObject.Parse(response);
-
-            EnsureSuccessGraphQLResponse(data);
+            var data = await _client.PostGraphQLAsync(url, payload);
 
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
@@ -357,10 +342,7 @@ namespace OctoshiftCLI
                 operationName = "startRepositoryMigration"
             };
 
-            var response = await _client.PostAsync(url, payload);
-            var data = JObject.Parse(response);
-
-            EnsureSuccessGraphQLResponse(data);
+            var data = await _client.PostGraphQLAsync(url, payload);
 
             return (string)data["data"]["startRepositoryMigration"]["repositoryMigration"]["id"];
         }
@@ -401,10 +383,7 @@ namespace OctoshiftCLI
                 operationName = "startOrganizationMigration"
             };
 
-            var response = await _client.PostAsync(url, payload);
-            var data = JObject.Parse(response);
-
-            EnsureSuccessGraphQLResponse(data);
+            var data = await _client.PostGraphQLAsync(url, payload);
 
             return (string)data["data"]["startOrganizationMigration"]["orgMigration"]["id"];
         }
@@ -420,10 +399,7 @@ namespace OctoshiftCLI
 
             var response = await _retryPolicy.Retry(async () =>
             {
-                var httpResponse = await _client.PostAsync(url, payload);
-                var data = JObject.Parse(httpResponse);
-
-                EnsureSuccessGraphQLResponse(data);
+                var data = await _client.PostGraphQLAsync(url, payload);
 
                 return (
                     State: (string)data["data"]["node"]["state"],
@@ -464,10 +440,7 @@ namespace OctoshiftCLI
 
             var response = await _retryPolicy.Retry(async () =>
             {
-                var httpResponse = await _client.PostAsync(url, payload);
-                var data = JObject.Parse(httpResponse);
-
-                EnsureSuccessGraphQLResponse(data);
+                var data = await _client.PostGraphQLAsync(url, payload);
 
                 return (
                     State: (string)data["data"]["node"]["state"],
@@ -500,10 +473,7 @@ namespace OctoshiftCLI
 
             var response = await _retryPolicy.Retry(async () =>
             {
-                var httpResponse = await _client.PostAsync(url, payload);
-                var data = JObject.Parse(httpResponse);
-
-                EnsureSuccessGraphQLResponse(data);
+                var data = await _client.PostGraphQLAsync(url, payload);
 
                 var nodes = (JArray)data["data"]["organization"]["repositoryMigrations"]["nodes"];
 
@@ -561,10 +531,7 @@ namespace OctoshiftCLI
 
             try
             {
-                var response = await _client.PostAsync(url, payload);
-                var data = JObject.Parse(response);
-
-                EnsureSuccessGraphQLResponse(data);
+                var data = await _client.PostGraphQLAsync(url, payload);
 
                 return (bool)data["data"]["grantMigratorRole"]["success"];
             }
@@ -590,10 +557,7 @@ namespace OctoshiftCLI
 
             try
             {
-                var response = await _client.PostAsync(url, payload);
-                var data = JObject.Parse(response);
-
-                EnsureSuccessGraphQLResponse(data);
+                var data = await _client.PostGraphQLAsync(url, payload);
 
                 return (bool)data["data"]["revokeMigratorRole"]["success"];
             }
@@ -707,10 +671,7 @@ namespace OctoshiftCLI
             };
 
             // TODO: Add retry logic here, but need to inspect the actual error message and differentiate between transient failure vs user doesn't exist (only retry on failure)
-            var response = await _client.PostAsync(url, payload);
-            var data = JObject.Parse(response);
-
-            EnsureSuccessGraphQLResponse(data);
+            var data = await _client.PostGraphQLAsync(url, payload);
 
             return data["data"]["user"].Any() ? (string)data["data"]["user"]["id"] : null;
         }
@@ -838,16 +799,6 @@ namespace OctoshiftCLI
                                     }
                                     : null
             };
-        }
-
-        private void EnsureSuccessGraphQLResponse(JObject response)
-        {
-            if (response.TryGetValue("errors", out var jErrors) && jErrors is JArray { Count: > 0 } errors)
-            {
-                var error = (JObject)errors[0];
-                var errorMessage = error.TryGetValue("message", out var jMessage) ? (string)jMessage : null;
-                throw new OctoshiftCliException($"{errorMessage ?? "UNKNOWN"}");
-            }
         }
 
         private static GithubSecretScanningAlert BuildSecretScanningAlert(JToken secretAlert) =>

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -673,7 +673,7 @@ namespace OctoshiftCLI
             // TODO: Add retry logic here, but need to inspect the actual error message and differentiate between transient failure vs user doesn't exist (only retry on failure)
             var data = await _client.PostGraphQLAsync(url, payload);
 
-            return data["data"]["user"].Any() ? (string)data["data"]["user"]["id"] : null;
+            return (string)data["data"]["user"]["id"];
         }
 
         public virtual async Task<MannequinReclaimResult> ReclaimMannequin(string orgId, string mannequinId, string targetUserId)

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -286,7 +286,6 @@ namespace OctoshiftCLI
             var response = await _client.PostAsync(url, payload);
             var data = JObject.Parse(response);
 
-            // {"data":{"createMigrationSource":null},"errors":[{"type":"FORBIDDEN","path":["createMigrationSource"],"extensions":{"saml_failure":true},"locations":[{"line":1,"column":109}],"message":"Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization."}]}
             EnsureSuccessGraphQLResponse(data);
 
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -230,6 +230,8 @@ namespace OctoshiftCLI
             var response = await _client.PostAsync(url, payload);
             var data = JObject.Parse(response);
 
+            EnsureSuccessGraphQLResponse(data);
+
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
 
@@ -256,6 +258,8 @@ namespace OctoshiftCLI
             var response = await _client.PostAsync(url, payload);
             var data = JObject.Parse(response);
 
+            EnsureSuccessGraphQLResponse(data);
+
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
 
@@ -281,6 +285,9 @@ namespace OctoshiftCLI
 
             var response = await _client.PostAsync(url, payload);
             var data = JObject.Parse(response);
+
+            // {"data":{"createMigrationSource":null},"errors":[{"type":"FORBIDDEN","path":["createMigrationSource"],"extensions":{"saml_failure":true},"locations":[{"line":1,"column":109}],"message":"Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization."}]}
+            EnsureSuccessGraphQLResponse(data);
 
             return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
         }
@@ -558,6 +565,8 @@ namespace OctoshiftCLI
                 var response = await _client.PostAsync(url, payload);
                 var data = JObject.Parse(response);
 
+                EnsureSuccessGraphQLResponse(data);
+
                 return (bool)data["data"]["grantMigratorRole"]["success"];
             }
             catch (HttpRequestException)
@@ -584,6 +593,8 @@ namespace OctoshiftCLI
             {
                 var response = await _client.PostAsync(url, payload);
                 var data = JObject.Parse(response);
+
+                EnsureSuccessGraphQLResponse(data);
 
                 return (bool)data["data"]["revokeMigratorRole"]["success"];
             }
@@ -699,6 +710,8 @@ namespace OctoshiftCLI
             // TODO: Add retry logic here, but need to inspect the actual error message and differentiate between transient failure vs user doesn't exist (only retry on failure)
             var response = await _client.PostAsync(url, payload);
             var data = JObject.Parse(response);
+
+            EnsureSuccessGraphQLResponse(data);
 
             return data["data"]["user"].Any() ? (string)data["data"]["user"]["id"] : null;
         }

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -103,6 +103,7 @@ namespace OctoshiftCLI
 
                 var (content, _) = await SendAsync(HttpMethod.Post, url, jBody, customHeaders: customHeaders);
                 var jContent = JObject.Parse(content);
+
                 foreach (var jResult in resultCollectionSelector(jContent))
                 {
                     yield return jResult;

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -103,7 +103,6 @@ namespace OctoshiftCLI
 
                 var (content, _) = await SendAsync(HttpMethod.Post, url, jBody, customHeaders: customHeaders);
                 var jContent = JObject.Parse(content);
-
                 foreach (var jResult in resultCollectionSelector(jContent))
                 {
                     yield return jResult;

--- a/src/Octoshift/GithubClient.cs
+++ b/src/Octoshift/GithubClient.cs
@@ -83,7 +83,7 @@ namespace OctoshiftCLI
 
             var (content, _) = await SendAsync(HttpMethod.Post, url, jBody, customHeaders: customHeaders);
             var response = JObject.Parse(content);
-            
+
             if (response.TryGetValue("errors", out var jErrors) && jErrors is JArray { Count: > 0 } errors)
             {
                 var error = (JObject)errors[0];

--- a/src/Octoshift/ReclaimService.cs
+++ b/src/Octoshift/ReclaimService.cs
@@ -99,10 +99,6 @@ namespace Octoshift
             }
 
             var targetUserId = await _githubApi.GetUserId(targetUser);
-            if (targetUserId == null)
-            {
-                throw new OctoshiftCliException($"Target user {targetUser} not found.");
-            }
 
             var success = true;
 

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -27,7 +27,8 @@ namespace OctoshiftCLI.Tests
         private const string GITHUB_REPO = "REPOSITORY_NAME";
         private const string TARGET_ORG = "TARGET_ORG";
         private const string LOG_URL = "URL";
-        private const string GQL_ERROR_RESPONSE = @"
+        
+        private readonly JObject GQL_ERROR_RESPONSE = JObject.Parse(@"
         {
             ""data"": {
                 ""node"":null
@@ -39,7 +40,7 @@ namespace OctoshiftCLI.Tests
                     ""locations"":[{""line"":1,""column"":19}],
                     ""message"":""GitHub Enterprise Importer is currently unavailable. Please try again later.""
                 }]
-        }";
+        }");
 
         public GithubApiTests()
         {
@@ -502,7 +503,7 @@ namespace OctoshiftCLI.Tests
             var url = $"https://api.github.com/graphql";
             var payload =
                 $"{{\"query\":\"query($login: String!) {{organization(login: $login) {{ login, id, name }} }}\",\"variables\":{{\"login\":\"{GITHUB_ORG}\"}}}}";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": 
                     {{
@@ -513,10 +514,10 @@ namespace OctoshiftCLI.Tests
                                 ""name"": ""github"" 
                             }} 
                     }} 
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -536,7 +537,7 @@ namespace OctoshiftCLI.Tests
             var payload =
                 $"{{\"query\":\"query($login: String!) {{organization(login: $login) {{ login, id, name }} }}\",\"variables\":{{\"login\":\"{GITHUB_ORG}\"}}}}";
 
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": 
                     {{
@@ -547,10 +548,10 @@ namespace OctoshiftCLI.Tests
                                 ""name"": ""github"" 
                             }} 
                     }} 
-            }}";
+            }}");
 
             _githubClientMock
-                .SetupSequence(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .SetupSequence(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(GQL_ERROR_RESPONSE)
                 .ReturnsAsync(GQL_ERROR_RESPONSE)
                 .ReturnsAsync(response);
@@ -571,7 +572,7 @@ namespace OctoshiftCLI.Tests
             var url = $"https://api.github.com/graphql";
             var payload =
                 $"{{\"query\":\"query($slug: String!) {{enterprise (slug: $slug) {{ slug, id }} }}\",\"variables\":{{\"slug\":\"{GITHUB_ENTERPRISE}\"}}}}";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": 
                     {{
@@ -581,10 +582,10 @@ namespace OctoshiftCLI.Tests
                                 ""id"": ""{enterpriseId}""
                             }} 
                     }} 
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -604,7 +605,7 @@ namespace OctoshiftCLI.Tests
             var payload =
                 $"{{\"query\":\"query($slug: String!) {{enterprise (slug: $slug) {{ slug, id }} }}\",\"variables\":{{\"slug\":\"{GITHUB_ENTERPRISE}\"}}}}";
 
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": 
                     {{
@@ -614,10 +615,10 @@ namespace OctoshiftCLI.Tests
                                 ""id"": ""{enterpriseId}""
                             }} 
                     }} 
-            }}";
+            }}");
 
             _githubClientMock
-                .SetupSequence(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .SetupSequence(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(GQL_ERROR_RESPONSE)
                 .ReturnsAsync(GQL_ERROR_RESPONSE)
                 .ReturnsAsync(response);
@@ -640,7 +641,7 @@ namespace OctoshiftCLI.Tests
                 "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, type: $type}) { migrationSource { id, name, url, type } } }\"" +
                 $",\"variables\":{{\"name\":\"Azure DevOps Source\",\"url\":\"https://dev.azure.com\",\"ownerId\":\"{orgId}\",\"type\":\"AZURE_DEVOPS\"}},\"operationName\":\"createMigrationSource\"}}";
             const string actualMigrationSourceId = "MS_kgC4NjFhOTVjOTc4ZTRhZjEwMDA5NjNhOTdm";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""createMigrationSource"": {{
@@ -652,10 +653,10 @@ namespace OctoshiftCLI.Tests
                         }}
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -663,46 +664,6 @@ namespace OctoshiftCLI.Tests
 
             // Assert
             expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
-        }
-
-        [Fact]
-        public async Task CreateAdoMigrationSource_Throws_When_GraphQL_Response_Has_Errors()
-        {
-            // Arrange
-            const string expectedErrorMessage = "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.";
-            const string response = $@"
-            {{
-                ""data"": {{ 
-                    ""createMigrationSource"": null
-                 }},
-                ""errors"": [
-                     {{
-                        ""type"": ""FORBIDDEN"",
-                        ""path"": [
-                            ""createMigrationSource""
-                         ],
-                        ""locations"": [
-                            {{
-                                ""line"": 13,
-                                ""column"": 17
-                            }}
-                         ],
-                        ""message"": ""{expectedErrorMessage}""
-                     }}
-                 ]
-            }}";
-
-            _githubClientMock
-                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
-                .ReturnsAsync(response);
-
-            // Act, Assert
-            await _githubApi.Invoking(api => api.CreateAdoMigrationSource(
-                    It.IsAny<string>(),
-                    null))
-                .Should()
-                .ThrowAsync<OctoshiftCliException>()
-                .WithMessage(expectedErrorMessage);
         }
 
         [Fact]
@@ -717,7 +678,7 @@ namespace OctoshiftCLI.Tests
                 "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, type: $type}) { migrationSource { id, name, url, type } } }\"" +
                 $",\"variables\":{{\"name\":\"Azure DevOps Source\",\"url\":\"{adoServerUrl}\",\"ownerId\":\"{orgId}\",\"type\":\"AZURE_DEVOPS\"}},\"operationName\":\"createMigrationSource\"}}";
             const string actualMigrationSourceId = "MS_kgC4NjFhOTVjOTc4ZTRhZjEwMDA5NjNhOTdm";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""createMigrationSource"": {{
@@ -729,10 +690,10 @@ namespace OctoshiftCLI.Tests
                         }}
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -753,7 +714,7 @@ namespace OctoshiftCLI.Tests
                 "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, type: $type}) { migrationSource { id, name, url, type } } }\"" +
                 $",\"variables\":{{\"name\":\"Bitbucket Server Source\",\"url\":\"https://not-used\",\"ownerId\":\"{orgId}\",\"type\":\"BITBUCKET_SERVER\"}},\"operationName\":\"createMigrationSource\"}}";
             const string actualMigrationSourceId = "MS_kgC4NjFhOTVjOTc4ZTRhZjEwMDA5NjNhOTdm";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""createMigrationSource"": {{
@@ -765,10 +726,10 @@ namespace OctoshiftCLI.Tests
                         }}
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -789,7 +750,7 @@ namespace OctoshiftCLI.Tests
                 "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, type: $type}) { migrationSource { id, name, url, type } } }\"" +
                 $",\"variables\":{{\"name\":\"GHEC Source\",\"url\":\"https://github.com\",\"ownerId\":\"{orgId}\",\"type\":\"GITHUB_ARCHIVE\"}},\"operationName\":\"createMigrationSource\"}}";
             const string actualMigrationSourceId = "MS_kgC4NjFhOTVjOTc4ZTRhZjEwMDA5NjNhOTdm";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""createMigrationSource"": {{
@@ -801,10 +762,10 @@ namespace OctoshiftCLI.Tests
                         }}
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -812,44 +773,6 @@ namespace OctoshiftCLI.Tests
 
             // Assert
             expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
-        }
-
-        [Fact]
-        public async Task CreateGhecMigrationSource_Throws_When_GraphQL_Response_Has_Errors()
-        {
-            // Arrange
-            const string expectedErrorMessage = "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.";
-            const string response = $@"
-            {{
-                ""data"": {{ 
-                    ""createMigrationSource"": null
-                 }},
-                ""errors"": [
-                     {{
-                        ""type"": ""FORBIDDEN"",
-                        ""path"": [
-                            ""createMigrationSource""
-                         ],
-                        ""locations"": [
-                            {{
-                                ""line"": 13,
-                                ""column"": 17
-                            }}
-                         ],
-                        ""message"": ""{expectedErrorMessage}""
-                     }}
-                 ]
-            }}";
-
-            _githubClientMock
-                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
-                .ReturnsAsync(response);
-
-            // Act, Assert
-            await _githubApi.Invoking(api => api.CreateGhecMigrationSource(It.IsAny<string>()))
-                .Should()
-                .ThrowAsync<OctoshiftCliException>()
-                .WithMessage(expectedErrorMessage);
         }
 
         [Fact]
@@ -926,7 +849,7 @@ namespace OctoshiftCLI.Tests
                 operationName = "startRepositoryMigration"
             };
             const string actualRepositoryMigrationId = "RM_kgC4NjFhNmE2NGU2ZWE1YTQwMDA5ODliZjhi";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""startRepositoryMigration"": {{
@@ -943,10 +866,10 @@ namespace OctoshiftCLI.Tests
                         }}
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -1052,7 +975,7 @@ namespace OctoshiftCLI.Tests
                 operationName = "startRepositoryMigration"
             };
             const string actualRepositoryMigrationId = "RM_kgC4NjFhNmE2NGU2ZWE1YTQwMDA5ODliZjhi";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""startRepositoryMigration"": {{
@@ -1069,10 +992,10 @@ namespace OctoshiftCLI.Tests
                         }}
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -1083,142 +1006,10 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task CreateBbsMigrationSource_Throws_When_GraphQL_Response_Has_Errors()
-        {
-            // Arrange
-            const string expectedErrorMessage = "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.";
-            const string response = $@"
-            {{
-                ""data"": {{ 
-                    ""createMigrationSource"": null
-                 }},
-                ""errors"": [
-                     {{
-                        ""type"": ""FORBIDDEN"",
-                        ""path"": [
-                            ""createMigrationSource""
-                         ],
-                        ""locations"": [
-                            {{
-                                ""line"": 13,
-                                ""column"": 17
-                            }}
-                         ],
-                        ""message"": ""{expectedErrorMessage}""
-                     }}
-                 ]
-            }}";
-
-            _githubClientMock
-                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
-                .ReturnsAsync(response);
-
-            // Act, Assert
-            await _githubApi.Invoking(api => api.StartBbsMigration(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()
-                ))
-                .Should()
-                .ThrowAsync<OctoshiftCliException>()
-                .WithMessage(expectedErrorMessage);
-        }
-
-        [Fact]
-        public async Task StartMigration_Throws_When_GraphQL_Response_Has_Errors()
-        {
-            // Arrange
-            const string expectedErrorMessage = "Please make sure that githubPat includes the workflow scope";
-            const string response = $@"
-            {{
-                ""data"": {{ 
-                    ""startRepositoryMigration"": null
-                 }},
-                ""errors"": [
-                     {{
-                        ""type"": ""FORBIDDEN"",
-                        ""path"": [
-                            ""startRepositoryMigration""
-                         ],
-                        ""locations"": [
-                            {{
-                                ""line"": 13,
-                                ""column"": 17
-                            }}
-                         ],
-                        ""message"": ""{expectedErrorMessage}""
-                     }}
-                 ]
-            }}";
-
-            _githubClientMock
-                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
-                .ReturnsAsync(response);
-
-            // Act, Assert
-            await _githubApi.Invoking(api => api.StartMigration(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()))
-                .Should()
-                .ThrowAsync<OctoshiftCliException>()
-                .WithMessage(expectedErrorMessage);
-        }
-
-        [Fact]
-        public async Task StartMigration_Does_Not_Include_Error_Message_If_Missing()
-        {
-            // Arrange
-            const string response = @"
-            {
-                ""data"": { 
-                    ""startRepositoryMigration"": null
-                 },
-                ""errors"": [
-                     {
-                        ""type"": ""FORBIDDEN"",
-                        ""path"": [
-                            ""startRepositoryMigration""
-                         ],
-                        ""locations"": [
-                            {
-                                ""line"": 13,
-                                ""column"": 17
-                            }
-                         ]
-                     }
-                 ]
-            }";
-
-            const string expectedErrorMessage = "UNKNOWN";
-
-            _githubClientMock
-                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
-                .ReturnsAsync(response);
-
-            // Act, Assert
-            await _githubApi.Invoking(api => api.StartMigration(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>()))
-                .Should()
-                .ThrowAsync<OctoshiftCliException>()
-                .WithMessage(expectedErrorMessage);
-        }
-
-        [Fact]
         public async Task StartMigration_Does_Not_Throw_When_Errors_Is_Empty()
         {
             // Arrange
-            const string response = @"
+            var response = JObject.Parse(@"
             {
                 ""data"": { 
                     ""startRepositoryMigration"": {
@@ -1228,10 +1019,10 @@ namespace OctoshiftCLI.Tests
                      }
                  },
                 ""errors"": []
-            }";
+            }");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
+                .Setup(m => m.PostGraphQLAsync(It.IsAny<string>(), It.IsAny<object>(), null))
                 .ReturnsAsync(response);
 
             // Act, Assert
@@ -1257,7 +1048,7 @@ namespace OctoshiftCLI.Tests
                 "{\"query\":\"query($id: ID!) { node(id: $id) { ... on Migration { id, sourceUrl, migrationLogUrl, migrationSource { name }, state, failureReason, repositoryName } } }\"" +
                 $",\"variables\":{{\"id\":\"{migrationId}\"}}}}";
             const string actualMigrationState = "SUCCEEDED";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""node"": {{
@@ -1272,10 +1063,10 @@ namespace OctoshiftCLI.Tests
                         ""migrationLogUrl"": ""{LOG_URL}""
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -1299,7 +1090,7 @@ namespace OctoshiftCLI.Tests
                 "{\"query\":\"query($id: ID!) { node(id: $id) { ... on Migration { id, sourceUrl, migrationLogUrl, migrationSource { name }, state, failureReason, repositoryName } } }\"" +
                 $",\"variables\":{{\"id\":\"{migrationId}\"}}}}";
             const string actualMigrationState = "SUCCEEDED";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""node"": {{
@@ -1313,10 +1104,10 @@ namespace OctoshiftCLI.Tests
                         ""migrationLogUrl"": ""{LOG_URL}""
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .SetupSequence(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .SetupSequence(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .Throws(new HttpRequestException(null, null, statusCode: HttpStatusCode.BadGateway))
                 .Throws(new HttpRequestException(null, null, statusCode: HttpStatusCode.BadGateway))
                 .ReturnsAsync(response);
@@ -1340,7 +1131,7 @@ namespace OctoshiftCLI.Tests
                 $",\"variables\":{{\"id\":\"{migrationId}\"}}}}";
             const string actualMigrationState = "SUCCEEDED";
 
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""node"": {{
@@ -1354,10 +1145,10 @@ namespace OctoshiftCLI.Tests
                         ""migrationLogUrl"": ""{LOG_URL}""
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .SetupSequence(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .SetupSequence(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(GQL_ERROR_RESPONSE)
                 .ReturnsAsync(GQL_ERROR_RESPONSE)
                 .ReturnsAsync(response);
@@ -1380,7 +1171,7 @@ namespace OctoshiftCLI.Tests
                 "{\"query\":\"query($id: ID!) { node(id: $id) { ... on Migration { id, sourceUrl, migrationLogUrl, migrationSource { name }, state, failureReason, repositoryName } } }\"" +
                 $",\"variables\":{{\"id\":\"{migrationId}\"}}}}";
             const string actualFailureReason = "FAILURE_REASON";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""node"": {{
@@ -1395,10 +1186,10 @@ namespace OctoshiftCLI.Tests
                         ""migrationLogUrl"": ""{LOG_URL}""
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -1422,7 +1213,7 @@ namespace OctoshiftCLI.Tests
             const string actualMigrationState = "SUCCEEDED";
             const int actualRemainingRepositoriesCount = 0;
             const int actualTotalRepositoriesCount = 9000;
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""node"": {{
@@ -1434,10 +1225,10 @@ namespace OctoshiftCLI.Tests
                         ""totalRepositoriesCount"": {actualTotalRepositoriesCount}
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -1466,7 +1257,7 @@ namespace OctoshiftCLI.Tests
             const string actualMigrationState = "SUCCEEDED";
             const int actualRemainingRepositoriesCount = 0;
             const int actualTotalRepositoriesCount = 9000;
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""node"": {{
@@ -1478,10 +1269,10 @@ namespace OctoshiftCLI.Tests
                         ""totalRepositoriesCount"": {actualTotalRepositoriesCount}
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .SetupSequence(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .SetupSequence(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .Throws(new HttpRequestException(null, null, statusCode: HttpStatusCode.BadGateway))
                 .Throws(new HttpRequestException(null, null, statusCode: HttpStatusCode.BadGateway))
                 .ReturnsAsync(response);
@@ -1505,7 +1296,7 @@ namespace OctoshiftCLI.Tests
                 "{\"query\":\"query($id: ID!) { node(id: $id) { ... on OrganizationMigration { state, sourceOrgUrl, targetOrgName, failureReason, remainingRepositoriesCount, totalRepositoriesCount } } }\"" +
                 $",\"variables\":{{\"id\":\"{migrationId}\"}}}}";
             const string actualMigrationState = "SUCCEEDED";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""node"": {{
@@ -1515,10 +1306,10 @@ namespace OctoshiftCLI.Tests
                         ""targetOrgName"": ""{TARGET_ORG}""
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .SetupSequence(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .SetupSequence(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(GQL_ERROR_RESPONSE)
                 .ReturnsAsync(GQL_ERROR_RESPONSE)
                 .ReturnsAsync(response);
@@ -1544,7 +1335,7 @@ namespace OctoshiftCLI.Tests
             const string actualFailureReason = "FAILURE_REASON";
             const int actualRemainingRepositoriesCount = 9000;
             const int actualTotalRepositoriesCount = 9000;
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""node"": {{
@@ -1556,10 +1347,10 @@ namespace OctoshiftCLI.Tests
                         ""totalRepositoriesCount"": {actualTotalRepositoriesCount}
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -1589,7 +1380,7 @@ namespace OctoshiftCLI.Tests
             var payload = new { query = $"{query} {{ {gql} }}", variables = new { org = GITHUB_ORG, repo = GITHUB_REPO } };
 
             const string migrationLogUrl = "MIGRATION_LOG_URL";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""organization"": {{
@@ -1602,10 +1393,10 @@ namespace OctoshiftCLI.Tests
                         }}
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -1635,7 +1426,7 @@ namespace OctoshiftCLI.Tests
             var payload = new { query = $"{query} {{ {gql} }}", variables = new { org = GITHUB_ORG, repo = GITHUB_REPO } };
 
             const string migrationLogUrl = "MIGRATION_LOG_URL";
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""organization"": {{
@@ -1648,10 +1439,10 @@ namespace OctoshiftCLI.Tests
                         }}
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .SetupSequence(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
+                .SetupSequence(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
                 .ReturnsAsync(GQL_ERROR_RESPONSE)
                 .ReturnsAsync(GQL_ERROR_RESPONSE)
                 .ReturnsAsync(response);
@@ -1681,7 +1472,7 @@ namespace OctoshiftCLI.Tests
             ";
 
             var payload = new { query = $"{query} {{ {gql} }}", variables = new { org = GITHUB_ORG, repo = GITHUB_REPO } };
-            var response = @"
+            var response = JObject.Parse(@"
             {
                 ""data"": {
                     ""organization"": {
@@ -1691,10 +1482,10 @@ namespace OctoshiftCLI.Tests
                         }
                     }
                 }
-            }";
+            }");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -1829,17 +1620,17 @@ namespace OctoshiftCLI.Tests
                 $",\"variables\":{{\"organizationId\":\"{GITHUB_ORG}\",\"actor\":\"{actor}\",\"actor_type\":\"{actorType}\"}}," +
                 "\"operationName\":\"grantMigratorRole\"}";
             const bool expectedSuccessState = true;
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""grantMigratorRole"": {{
                         ""success"": {expectedSuccessState.ToString().ToLower()}
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -1864,7 +1655,7 @@ namespace OctoshiftCLI.Tests
                 "\"operationName\":\"grantMigratorRole\"}";
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .Throws<HttpRequestException>();
 
             // Act
@@ -1872,44 +1663,6 @@ namespace OctoshiftCLI.Tests
 
             // Assert
             actualSuccessState.Should().BeFalse();
-        }
-
-        [Fact]
-        public async Task GrantMigratorRole_Throws_When_GraphQL_Response_Has_Errors()
-        {
-            // Arrange
-            const string expectedErrorMessage = "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.";
-            const string response = $@"
-            {{
-                ""data"": {{ 
-                    ""grantMigratorRole"": null
-                 }},
-                ""errors"": [
-                     {{
-                        ""type"": ""FORBIDDEN"",
-                        ""path"": [
-                            ""grantMigratorRole""
-                         ],
-                        ""locations"": [
-                            {{
-                                ""line"": 13,
-                                ""column"": 17
-                            }}
-                         ],
-                        ""message"": ""{expectedErrorMessage}""
-                     }}
-                 ]
-            }}";
-
-            _githubClientMock
-                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
-                .ReturnsAsync(response);
-
-            // Act, Assert
-            await _githubApi.Invoking(api => api.GrantMigratorRole(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Should()
-                .ThrowAsync<OctoshiftCliException>()
-                .WithMessage(expectedErrorMessage);
         }
 
         [Fact]
@@ -1926,17 +1679,17 @@ namespace OctoshiftCLI.Tests
                 $",\"variables\":{{\"organizationId\":\"{GITHUB_ORG}\",\"actor\":\"{actor}\",\"actor_type\":\"{actorType}\"}}," +
                 "\"operationName\":\"revokeMigratorRole\"}";
             const bool expectedSuccessState = true;
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": {{
                     ""revokeMigratorRole"": {{
                         ""success"": {expectedSuccessState.ToString().ToLower()}
                     }}
                 }}
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -1961,7 +1714,7 @@ namespace OctoshiftCLI.Tests
                 "\"operationName\":\"revokeMigratorRole\"}";
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .Throws<HttpRequestException>();
 
             // Act
@@ -1969,44 +1722,6 @@ namespace OctoshiftCLI.Tests
 
             // Assert
             actualSuccessState.Should().BeFalse();
-        }
-
-        [Fact]
-        public async Task RevokeMigratorRole_Throws_When_GraphQL_Response_Has_Errors()
-        {
-            // Arrange
-            const string expectedErrorMessage = "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.";
-            const string response = $@"
-            {{
-                ""data"": {{ 
-                    ""revokeMigratorRole"": null
-                 }},
-                ""errors"": [
-                     {{
-                        ""type"": ""FORBIDDEN"",
-                        ""path"": [
-                            ""revokeMigratorRole""
-                         ],
-                        ""locations"": [
-                            {{
-                                ""line"": 13,
-                                ""column"": 17
-                            }}
-                         ],
-                        ""message"": ""{expectedErrorMessage}""
-                     }}
-                 ]
-            }}";
-
-            _githubClientMock
-                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
-                .ReturnsAsync(response);
-
-            // Act, Assert
-            await _githubApi.Invoking(api => api.RevokeMigratorRole(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Should()
-                .ThrowAsync<OctoshiftCliException>()
-                .WithMessage(expectedErrorMessage);
         }
 
         [Fact]
@@ -2033,7 +1748,7 @@ namespace OctoshiftCLI.Tests
             var payload =
                 $"{{\"query\":\"query($login: String!) {{user(login: $login) {{ id, name }} }}\",\"variables\":{{\"login\":\"{login}\"}}}}";
 
-            var response = $@"
+            var response = JObject.Parse($@"
             {{
                 ""data"": 
                     {{
@@ -2043,10 +1758,10 @@ namespace OctoshiftCLI.Tests
                                 ""name"": ""{login}"" 
                             }} 
                     }} 
-            }}";
+            }}");
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
                 .ReturnsAsync(response);
 
             // Act
@@ -2054,44 +1769,6 @@ namespace OctoshiftCLI.Tests
 
             // Assert
             result.Should().Be(userId);
-        }
-
-        [Fact]
-        public async Task GetUserId_Throws_When_GraphQL_Response_Has_Errors()
-        {
-            // Arrange
-            const string expectedErrorMessage = "Could not resolve to a User with the login of 'idonotexist'.";
-            const string response = $@"
-            {{
-                ""data"": {{ 
-                    ""user"": null
-                 }},
-                ""errors"": [
-                     {{
-                        ""type"": ""FORBIDDEN"",
-                        ""path"": [
-                            ""user""
-                         ],
-                        ""locations"": [
-                            {{
-                                ""line"": 13,
-                                ""column"": 17
-                            }}
-                         ],
-                        ""message"": ""{expectedErrorMessage}""
-                     }}
-                 ]
-            }}";
-
-            _githubClientMock
-                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
-                .ReturnsAsync(response);
-
-            // Act, Assert
-            await _githubApi.Invoking(api => api.GetUserId(It.IsAny<string>()))
-                .Should()
-                .ThrowAsync<OctoshiftCliException>()
-                .WithMessage(expectedErrorMessage);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -666,6 +666,46 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task CreateAdoMigrationSource_Throws_When_GraphQL_Response_Has_Errors()
+        {
+            // Arrange
+            const string expectedErrorMessage = "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.";
+            const string response = $@"
+            {{
+                ""data"": {{ 
+                    ""createMigrationSource"": null
+                 }},
+                ""errors"": [
+                     {{
+                        ""type"": ""FORBIDDEN"",
+                        ""path"": [
+                            ""createMigrationSource""
+                         ],
+                        ""locations"": [
+                            {{
+                                ""line"": 13,
+                                ""column"": 17
+                            }}
+                         ],
+                        ""message"": ""{expectedErrorMessage}""
+                     }}
+                 ]
+            }}";
+
+            _githubClientMock
+                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
+                .ReturnsAsync(response);
+
+            // Act, Assert
+            await _githubApi.Invoking(api => api.CreateAdoMigrationSource(
+                    It.IsAny<string>(),
+                    null))
+                .Should()
+                .ThrowAsync<OctoshiftCliException>()
+                .WithMessage(expectedErrorMessage);
+        }
+
+        [Fact]
         public async Task CreateAdoMigrationSource_Uses_Ado_Server_Url()
         {
             // Arrange
@@ -772,6 +812,44 @@ namespace OctoshiftCLI.Tests
 
             // Assert
             expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
+        }
+
+        [Fact]
+        public async Task CreateGhecMigrationSource_Throws_When_GraphQL_Response_Has_Errors()
+        {
+            // Arrange
+            const string expectedErrorMessage = "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.";
+            const string response = $@"
+            {{
+                ""data"": {{ 
+                    ""createMigrationSource"": null
+                 }},
+                ""errors"": [
+                     {{
+                        ""type"": ""FORBIDDEN"",
+                        ""path"": [
+                            ""createMigrationSource""
+                         ],
+                        ""locations"": [
+                            {{
+                                ""line"": 13,
+                                ""column"": 17
+                            }}
+                         ],
+                        ""message"": ""{expectedErrorMessage}""
+                     }}
+                 ]
+            }}";
+
+            _githubClientMock
+                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
+                .ReturnsAsync(response);
+
+            // Act, Assert
+            await _githubApi.Invoking(api => api.CreateGhecMigrationSource(It.IsAny<string>()))
+                .Should()
+                .ThrowAsync<OctoshiftCliException>()
+                .WithMessage(expectedErrorMessage);
         }
 
         [Fact]
@@ -1002,6 +1080,50 @@ namespace OctoshiftCLI.Tests
 
             // Assert
             expectedRepositoryMigrationId.Should().Be(actualRepositoryMigrationId);
+        }
+
+        [Fact]
+        public async Task CreateBbsMigrationSource_Throws_When_GraphQL_Response_Has_Errors()
+        {
+            // Arrange
+            const string expectedErrorMessage = "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.";
+            const string response = $@"
+            {{
+                ""data"": {{ 
+                    ""createMigrationSource"": null
+                 }},
+                ""errors"": [
+                     {{
+                        ""type"": ""FORBIDDEN"",
+                        ""path"": [
+                            ""createMigrationSource""
+                         ],
+                        ""locations"": [
+                            {{
+                                ""line"": 13,
+                                ""column"": 17
+                            }}
+                         ],
+                        ""message"": ""{expectedErrorMessage}""
+                     }}
+                 ]
+            }}";
+
+            _githubClientMock
+                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
+                .ReturnsAsync(response);
+
+            // Act, Assert
+            await _githubApi.Invoking(api => api.StartBbsMigration(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()
+                ))
+                .Should()
+                .ThrowAsync<OctoshiftCliException>()
+                .WithMessage(expectedErrorMessage);
         }
 
         [Fact]
@@ -1753,6 +1875,44 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task GrantMigratorRole_Throws_When_GraphQL_Response_Has_Errors()
+        {
+            // Arrange
+            const string expectedErrorMessage = "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.";
+            const string response = $@"
+            {{
+                ""data"": {{ 
+                    ""grantMigratorRole"": null
+                 }},
+                ""errors"": [
+                     {{
+                        ""type"": ""FORBIDDEN"",
+                        ""path"": [
+                            ""grantMigratorRole""
+                         ],
+                        ""locations"": [
+                            {{
+                                ""line"": 13,
+                                ""column"": 17
+                            }}
+                         ],
+                        ""message"": ""{expectedErrorMessage}""
+                     }}
+                 ]
+            }}";
+
+            _githubClientMock
+                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
+                .ReturnsAsync(response);
+
+            // Act, Assert
+            await _githubApi.Invoking(api => api.GrantMigratorRole(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Should()
+                .ThrowAsync<OctoshiftCliException>()
+                .WithMessage(expectedErrorMessage);
+        }
+
+        [Fact]
         public async Task RevokeMigratorRole_Returns_True_On_Success()
         {
             // Arrange
@@ -1812,6 +1972,44 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task RevokeMigratorRole_Throws_When_GraphQL_Response_Has_Errors()
+        {
+            // Arrange
+            const string expectedErrorMessage = "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.";
+            const string response = $@"
+            {{
+                ""data"": {{ 
+                    ""revokeMigratorRole"": null
+                 }},
+                ""errors"": [
+                     {{
+                        ""type"": ""FORBIDDEN"",
+                        ""path"": [
+                            ""revokeMigratorRole""
+                         ],
+                        ""locations"": [
+                            {{
+                                ""line"": 13,
+                                ""column"": 17
+                            }}
+                         ],
+                        ""message"": ""{expectedErrorMessage}""
+                     }}
+                 ]
+            }}";
+
+            _githubClientMock
+                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
+                .ReturnsAsync(response);
+
+            // Act, Assert
+            await _githubApi.Invoking(api => api.RevokeMigratorRole(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Should()
+                .ThrowAsync<OctoshiftCliException>()
+                .WithMessage(expectedErrorMessage);
+        }
+
+        [Fact]
         public async Task DeleteRepo_Calls_The_Right_Endpoint()
         {
             // Arrange
@@ -1859,45 +2057,41 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task GetUserId_For_No_Existant_User_Returns_Null()
+        public async Task GetUserId_Throws_When_GraphQL_Response_Has_Errors()
         {
             // Arrange
-            const string login = "idonotexist";
-
-            var url = $"https://api.github.com/graphql";
-            var payload =
-                $"{{\"query\":\"query($login: String!) {{user(login: $login) {{ id, name }} }}\",\"variables\":{{\"login\":\"{login}\"}}}}";
-
-            var response = @"{
-	            ""data"": {
-                    ""user"": null
-                },
-	            ""errors"": [
-		            {
-			            ""type"": ""NOT_FOUND"",
-			            ""path"": [
-				            ""user""
-			            ],
-			            ""locations"": [
-				            {
-					            ""line"": 4,
-					            ""column"": 3
-                            }
-			            ],
-			            ""message"": ""Could not resolve to a User with the login of 'idonotexist'.""
-		            }
-	            ]
-            }";
+            const string expectedErrorMessage = "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.";
+            const string response = $@"
+            {{
+                ""data"": {{ 
+                    ""grantMigratorRole"": null
+                 }},
+                ""errors"": [
+                     {{
+                        ""type"": ""FORBIDDEN"",
+                        ""path"": [
+                            ""grantMigratorRole""
+                         ],
+                        ""locations"": [
+                            {{
+                                ""line"": 13,
+                                ""column"": 17
+                            }}
+                         ],
+                        ""message"": ""{expectedErrorMessage}""
+                     }}
+                 ]
+            }}";
 
             _githubClientMock
-                .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<object>(), null))
                 .ReturnsAsync(response);
 
-            // Act
-            var result = await _githubApi.GetUserId(login);
-
-            // Assert
-            result.Should().BeNull();
+            // Act, Assert
+            await _githubApi.Invoking(api => api.GetUserId(It.IsAny<string>()))
+                .Should()
+                .ThrowAsync<OctoshiftCliException>()
+                .WithMessage(expectedErrorMessage);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -2060,17 +2060,17 @@ namespace OctoshiftCLI.Tests
         public async Task GetUserId_Throws_When_GraphQL_Response_Has_Errors()
         {
             // Arrange
-            const string expectedErrorMessage = "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.";
+            const string expectedErrorMessage = "Could not resolve to a User with the login of 'idonotexist'.";
             const string response = $@"
             {{
                 ""data"": {{ 
-                    ""grantMigratorRole"": null
+                    ""user"": null
                  }},
                 ""errors"": [
                      {{
                         ""type"": ""FORBIDDEN"",
                         ""path"": [
-                            ""grantMigratorRole""
+                            ""user""
                          ],
                         ""locations"": [
                             {{

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -27,7 +27,7 @@ namespace OctoshiftCLI.Tests
         private const string GITHUB_REPO = "REPOSITORY_NAME";
         private const string TARGET_ORG = "TARGET_ORG";
         private const string LOG_URL = "URL";
-        
+
         private readonly JObject GQL_ERROR_RESPONSE = JObject.Parse(@"
         {
             ""data"": {

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -637,10 +637,10 @@ namespace OctoshiftCLI.Tests
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
             // Act
-            var actualContent = await githubClient.PostGraphQLAsync("http://example.com", _rawRequestBody);
+            var response = await githubClient.PostGraphQLAsync("http://example.com", _rawRequestBody);
 
             // Assert
-            actualContent.Should().Equal(JObject.Parse(EXPECTED_GRAPHQL_JSON_RESPONSE_BODY));
+            Assert.True(JToken.DeepEquals(response, JObject.Parse(EXPECTED_GRAPHQL_JSON_RESPONSE_BODY)));
         }
 
         [Fact]
@@ -708,7 +708,7 @@ namespace OctoshiftCLI.Tests
             using var httpClient = new HttpClient(MockHttpHandlerForGraphQLPost().Object);
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
-            var expectedLogMessage = "HTTP BODY: {\"id\":\"ID\",\"variables\":{}}";
+            var expectedLogMessage = $"HTTP BODY: {EXPECTED_JSON_REQUEST_BODY}";
 
             // Act
             await githubClient.PostGraphQLAsync("http://example.com", _rawRequestBody);

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -18,7 +18,8 @@ namespace OctoshiftCLI.Tests
     public sealed class GithubClientTests : IDisposable
     {
         private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
-        private readonly HttpResponseMessage _httpResponse;
+        private readonly HttpResponseMessage _defaultHttpResponse;
+        private readonly HttpResponseMessage _graphqlHttpResponse;
         private readonly RetryPolicy _retryPolicy;
         private readonly Mock<DateTimeProvider> _dateTimeProvider = TestHelpers.CreateMock<DateTimeProvider>();
         private readonly object _rawRequestBody;
@@ -34,9 +35,14 @@ namespace OctoshiftCLI.Tests
         {
             _rawRequestBody = new { id = "ID" };
 
-            _httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            _defaultHttpResponse = new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(EXPECTED_RESPONSE_CONTENT)
+            };
+
+            _graphqlHttpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(EXPECTED_GRAPHQL_JSON_RESPONSE_BODY)
             };
 
             _retryPolicy = new RetryPolicy(_mockOctoLogger.Object)
@@ -47,7 +53,8 @@ namespace OctoshiftCLI.Tests
 
         public void Dispose()
         {
-            _httpResponse?.Dispose();
+            _defaultHttpResponse?.Dispose();
+            _graphqlHttpResponse?.Dispose();
         }
 
         [Fact]
@@ -168,7 +175,7 @@ namespace OctoshiftCLI.Tests
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
-            _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
+            _defaultHttpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
 
             const string expectedLogMessage = $"GITHUB REQUEST ID: {githubRequestId}";
 
@@ -542,7 +549,7 @@ namespace OctoshiftCLI.Tests
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
-            _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
+            _defaultHttpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
 
             const string expectedLogMessage = $"GITHUB REQUEST ID: {githubRequestId}";
 
@@ -578,7 +585,7 @@ namespace OctoshiftCLI.Tests
             using var httpClient = new HttpClient(MockHttpHandlerForPost().Object);
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
-            var expectedLogMessage = $"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
+            var expectedLogMessage = $"RESPONSE ({_defaultHttpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
 
             // Act
             await githubClient.PostAsync("http://example.com", _rawRequestBody);
@@ -682,6 +689,7 @@ namespace OctoshiftCLI.Tests
             // Arrange
             using var httpClient = new HttpClient(MockHttpHandlerForGraphQLPost().Object);
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
+            _graphqlHttpResponse.Headers.Add("X-GitHub-Request-Id", GITHUB_REQUEST_ID);
 
             const string expectedLogMessage = $"GITHUB REQUEST ID: {GITHUB_REQUEST_ID}";
 
@@ -717,7 +725,7 @@ namespace OctoshiftCLI.Tests
             using var httpClient = new HttpClient(MockHttpHandlerForGraphQLPost().Object);
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
-            var expectedLogMessage = $"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_GRAPHQL_JSON_RESPONSE_BODY}";
+            var expectedLogMessage = $"RESPONSE ({_graphqlHttpResponse.StatusCode}): {EXPECTED_GRAPHQL_JSON_RESPONSE_BODY}";
 
             // Act
             await githubClient.PostGraphQLAsync("http://example.com", _rawRequestBody);
@@ -735,16 +743,8 @@ namespace OctoshiftCLI.Tests
             {
                 Content = new StringContent(EXPECTED_GRAPHQL_JSON_ERROR_RESPONSE_BODY)
             };
-            var handlerMock = new Mock<HttpMessageHandler>();
-            handlerMock
-                .Protected()
-                .Setup<Task<HttpResponseMessage>>(
-                    "SendAsync",
-                    ItExpr.Is<HttpRequestMessage>(x =>
-                        true),
-                    ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(httpResponse);
 
+            var handlerMock = MockHttpHandlerForGraphQLPost(httpResponse);
             var loggerMock = TestHelpers.CreateMock<OctoLogger>();
 
             // Act
@@ -873,7 +873,7 @@ namespace OctoshiftCLI.Tests
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
-            _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
+            _defaultHttpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
 
             const string expectedLogMessage = $"GITHUB REQUEST ID: {githubRequestId}";
 
@@ -909,7 +909,7 @@ namespace OctoshiftCLI.Tests
             using var httpClient = new HttpClient(MockHttpHandlerForPut().Object);
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
-            var expectedLogMessage = $"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
+            var expectedLogMessage = $"RESPONSE ({_defaultHttpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
 
             // Act
             await githubClient.PutAsync("http://example.com", _rawRequestBody);
@@ -1061,7 +1061,7 @@ namespace OctoshiftCLI.Tests
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
-            _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
+            _defaultHttpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
 
             const string expectedLogMessage = $"GITHUB REQUEST ID: {githubRequestId}";
 
@@ -1097,7 +1097,7 @@ namespace OctoshiftCLI.Tests
             using var httpClient = new HttpClient(MockHttpHandlerForPatch().Object);
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
-            var expectedLogMessage = $"RESPONSE ({_httpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
+            var expectedLogMessage = $"RESPONSE ({_defaultHttpResponse.StatusCode}): {EXPECTED_RESPONSE_CONTENT}";
 
             // Act
             await githubClient.PatchAsync("http://example.com", _rawRequestBody);
@@ -1249,7 +1249,7 @@ namespace OctoshiftCLI.Tests
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
             const string githubRequestId = "123-456-789";
-            _httpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
+            _defaultHttpResponse.Headers.Add("X-GitHub-Request-Id", githubRequestId);
 
             const string expectedLogMessage = $"GITHUB REQUEST ID: {githubRequestId}";
 
@@ -2364,16 +2364,10 @@ query($id: ID!, $first: Int, $after: String) {
             MockHttpHandler(req =>
                 req.Method == HttpMethod.Post);
 
-        private Mock<HttpMessageHandler> MockHttpHandlerForGraphQLPost(string responseBody = EXPECTED_GRAPHQL_JSON_RESPONSE_BODY, string requestId = GITHUB_REQUEST_ID) {
-            var response = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(responseBody)
-            };
-
-            response.Headers.Add("X-GitHub-Request-Id", requestId);
-
+        private Mock<HttpMessageHandler> MockHttpHandlerForGraphQLPost(HttpResponseMessage httpResponseMessage = null)
+        {
             return MockHttpHandler(req =>
-                req.Method == HttpMethod.Post, response);
+                req.Method == HttpMethod.Post, httpResponseMessage ?? _graphqlHttpResponse);
         }
 
         private Mock<HttpMessageHandler> MockHttpHandlerForPut() =>
@@ -2398,7 +2392,7 @@ query($id: ID!, $first: Int, $after: String) {
                     "SendAsync",
                     ItExpr.Is<HttpRequestMessage>(x => requestMatcher(x)),
                     ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(httpResponse ?? _httpResponse);
+                .ReturnsAsync(httpResponse ?? _defaultHttpResponse);
             return handlerMock;
         }
     }

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -640,7 +640,7 @@ namespace OctoshiftCLI.Tests
             var response = await githubClient.PostGraphQLAsync("http://example.com", _rawRequestBody);
 
             // Assert
-            Assert.True(JToken.DeepEquals(response, JObject.Parse(EXPECTED_GRAPHQL_JSON_RESPONSE_BODY)));
+            response.ToJson().Should().Be(EXPECTED_JSON_REQUEST_BODY);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/Octoshift/ReclaimServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/ReclaimServiceTests.cs
@@ -867,14 +867,14 @@ namespace OctoshiftCLI.Tests.Octoshift
 
             _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
             _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
-            _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN)).Returns(Task.FromResult<string>(null));
+            _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN)).Throws(new OctoshiftCliException("Could not resolve to a User with the login of 'idonotexist'."));
 
             // Act
             var exception = await FluentActions
                 .Invoking(async () => await _service.ReclaimMannequin(MANNEQUIN_LOGIN, null, TARGET_USER_LOGIN, TARGET_ORG, false))
                 .Should().ThrowAsync<OctoshiftCliException>();
 
-            exception.WithMessage($"Target user {TARGET_USER_LOGIN} not found.");
+            exception.WithMessage($"Could not resolve to a User with the login of 'idonotexist'.");
 
             _mockGithubApi.Verify(x => x.GetUserId(TARGET_USER_LOGIN), Times.Once());
         }


### PR DESCRIPTION
In `GithubApi`, we have the helpful `EnsureSuccessGraphQLResponse` helper which checks the GraphQL response for errors, and if an error is found, it raises a `OctoshiftCliException`.

Currently, this helper is not used consistently across GraphQL API calls, which means that we have some cases where the GraphQL API returns an error and the CLI crashes with an unhelpful `System.InvalidOperationException: Cannot access child value on Newtonsoft.Json.Linq.JValue.`.

To find out what actually went wrong, the user has to either:

* (a) use the `--verbose` option or
* (b) manually check the verbose log file

This PR creates a new `PostGraphQLAsync` method on `GitHubClient` which includes the error handling logic from `EnsureSuccessGraphQLResponse`.

We then use the `PostGraphQLAsync` method instead of `PostAsync` for GraphQL requests, which means that we get this consistent error handling for free.

I do not apply this to `ReclaimMannequin` (which has its own error handling) and `GetMannequins` (which has some complex pagination logic which I didn't want to mess with right now).

Fixes https://github.com/github/gh-gei/issues/867.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->