### PR TITLE
Add --no-ssl-verify to bbs2gh commands

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,4 +2,4 @@
 - Rename `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` environment variables to `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` respectively to align with the environment variables that the AWS CLI already uses. Old environment variables are still supported but they will be removed in future. 
 - Send a `User-Agent` header with the current CLI version when downloading migration archives from GitHub Enterprise Server
 - Add support for migration archives larger than 2GB when using the blob storage flow
-- Add `--no-ssh-verify` option to `gh bbs2gh generate-script` and `gh bbs2gh migrate-repo` commands to support migrating from a Bitbucket instance that uses a self-signed SSL certificate.
+- Add `--no-ssh-verify` option to `gh bbs2gh generate-script` and `gh bbs2gh migrate-repo` commands to support migrating from a Bitbucket Server/Data Center instance that uses a self-signed SSL certificate

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
 - Fix `gh bbs2gh grant-migrator-role` so it doesn't throw `System.InvalidOperationException`
 - Rename `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` environment variables to `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` respectively to align with the environment variables that the AWS CLI already uses. Old environment variables are still supported but they will be removed in future. 
 - Send a `User-Agent` header with the current CLI version when downloading migration archives from GitHub Enterprise Server
+- Add `--no-ssh-verify` option to `gh bbs2gh generate-script` and `gh bbs2gh migrate-repo` commands to support migrating from a Bitbucket instance that uses a self-signed SSL certificate.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,4 +2,4 @@
 - Rename `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` environment variables to `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` respectively to align with the environment variables that the AWS CLI already uses. Old environment variables are still supported but they will be removed in future. 
 - Send a `User-Agent` header with the current CLI version when downloading migration archives from GitHub Enterprise Server
 - Add support for migration archives larger than 2GB when using the blob storage flow
-- Add `--no-ssh-verify` option to `gh bbs2gh generate-script` and `gh bbs2gh migrate-repo` commands to support migrating from a Bitbucket Server/Data Center instance that uses a self-signed SSL certificate
+- Add `--no-ssh-verify` option to `gh bbs2gh generate-script` and `gh bbs2gh migrate-repo` commands to support migrating from a Bitbucket Server or Bitbucket Data Center instance that uses a self-signed SSL certificate

--- a/src/OctoshiftCLI.Tests/bbs2gh/BbsApiFactoryTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/BbsApiFactoryTests.cs
@@ -55,5 +55,39 @@ namespace OctoshiftCLI.Tests.bbs2gh.Commands
             githubApi.Should().NotBeNull();
             httpClient.DefaultRequestHeaders.Accept.First().MediaType.Should().Be("application/json");
         }
+
+        [Fact]
+        public void Should_Create_BbsApi_With_No_Ssl_Verify()
+        {
+            using var httpClient = new HttpClient();
+
+            _mockHttpClientFactory
+                .Setup(x => x.CreateClient("NoSSL"))
+                .Returns(httpClient);
+
+            // Act
+            var githubApi = _bbsApiFactory.Create(BBS_SERVER_URL, "user", "pass", true);
+
+            // Assert
+            githubApi.Should().NotBeNull();
+            httpClient.DefaultRequestHeaders.Accept.First().MediaType.Should().Be("application/json");
+        }
+
+        [Fact]
+        public void Should_Create_BbsApi_With_Kerberos_And_No_Ssl_Verify()
+        {
+            using var httpClient = new HttpClient();
+
+            _mockHttpClientFactory
+                .Setup(x => x.CreateClient("KerberosNoSSL"))
+                .Returns(httpClient);
+
+            // Act
+            var githubApi = _bbsApiFactory.CreateKerberos(BBS_SERVER_URL, true);
+
+            // Assert
+            githubApi.Should().NotBeNull();
+            httpClient.DefaultRequestHeaders.Accept.First().MediaType.Should().Be("application/json");
+        }
     }
 }

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
@@ -35,7 +35,7 @@ public class GenerateScriptCommandTests
     {
         _command.Should().NotBeNull();
         _command.Name.Should().Be("generate-script");
-        _command.Options.Count.Should().Be(17);
+        _command.Options.Count.Should().Be(18);
 
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-server-url", true);
         TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
@@ -54,6 +54,7 @@ public class GenerateScriptCommandTests
         TestHelpers.VerifyCommandOption(_command.Options, "aws-bucket-name", false);
         TestHelpers.VerifyCommandOption(_command.Options, "aws-region", false);
         TestHelpers.VerifyCommandOption(_command.Options, "keep-archive", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "no-ssl-verify", false);
     }
 
     [Fact]
@@ -67,11 +68,44 @@ public class GenerateScriptCommandTests
 
         _command.BuildHandler(args, _mockServiceProvider.Object);
 
-        _mockBbsApiFactory.Verify(m => m.CreateKerberos(BBS_SERVER_URL));
+        _mockBbsApiFactory.Verify(m => m.CreateKerberos(BBS_SERVER_URL, false));
     }
 
     [Fact]
-    public void It_Gets_A_Default_HttpClient_When_Kerberos_Is_Not_Set()
+    public void It_Gets_A_Kerberos_With_No_Ssl_Verify_HttpClient_When_Kerberos_And_No_Ssl_Verify_Are_True()
+    {
+        var args = new GenerateScriptCommandArgs
+        {
+            BbsServerUrl = BBS_SERVER_URL,
+            Kerberos = true,
+            NoSslVerify = true
+        };
+
+        _command.BuildHandler(args, _mockServiceProvider.Object);
+
+        _mockBbsApiFactory.Verify(m => m.CreateKerberos(BBS_SERVER_URL, true));
+    }
+
+    [Fact]
+    public void It_Gets_A_Default_HttpClient_When_Kerberos_And_No_Ssl_Verify_Are_Not_Set()
+    {
+        var bbsTestUser = "user";
+        var bbsTestPassword = "password";
+
+        var args = new GenerateScriptCommandArgs
+        {
+            BbsServerUrl = BBS_SERVER_URL,
+            BbsUsername = bbsTestUser,
+            BbsPassword = bbsTestPassword
+        };
+
+        _command.BuildHandler(args, _mockServiceProvider.Object);
+
+        _mockBbsApiFactory.Verify(m => m.Create(BBS_SERVER_URL, bbsTestUser, bbsTestPassword, false));
+    }
+
+    [Fact]
+    public void It_Gets_A_No_Ssl_Verify_HttpClient_When_No_Ssl_Verify_Is_Set()
     {
         var bbsTestUser = "user";
         var bbsTestPassword = "password";
@@ -81,10 +115,11 @@ public class GenerateScriptCommandTests
             BbsServerUrl = BBS_SERVER_URL,
             BbsUsername = bbsTestUser,
             BbsPassword = bbsTestPassword,
+            NoSslVerify = true
         };
 
         _command.BuildHandler(args, _mockServiceProvider.Object);
 
-        _mockBbsApiFactory.Verify(m => m.Create(BBS_SERVER_URL, bbsTestUser, bbsTestPassword));
+        _mockBbsApiFactory.Verify(m => m.Create(BBS_SERVER_URL, bbsTestUser, bbsTestPassword, true));
     }
 }

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -1149,6 +1149,25 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
         }
 
         [Fact]
+        public async Task Errors_If_BbsServer_Url_Not_Provided_But_No_Ssl_Verify_Is_Provided()
+        {
+            // Act
+            var args = new MigrateRepoCommandArgs
+            {
+                ArchivePath = ARCHIVE_PATH,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                NoSslVerify = true
+            };
+
+            // Assert
+            await _handler.Invoking(x => x.Handle(args))
+                .Should()
+                .ThrowExactlyAsync<OctoshiftCliException>()
+                .WithMessage("*--no-ssl-verify*--bbs-server-url*");
+        }
+
+        [Fact]
         public async Task Errors_If_BbsServer_Url_Not_Provided_But_Ssh_User_Is_Provided()
         {
             // Act

--- a/src/bbs2gh/BbsApiFactory.cs
+++ b/src/bbs2gh/BbsApiFactory.cs
@@ -20,20 +20,20 @@ namespace OctoshiftCLI.BbsToGithub
             _retryPolicy = retryPolicy;
         }
 
-        public virtual BbsApi Create(string bbsServerUrl, string bbsUsername, string bbsPassword)
+        public virtual BbsApi Create(string bbsServerUrl, string bbsUsername, string bbsPassword, bool noSsl = false)
         {
             bbsUsername ??= _environmentVariableProvider.BbsUsername();
             bbsPassword ??= _environmentVariableProvider.BbsPassword();
 
-            var httpClient = _clientFactory.CreateClient("Default");
+            var httpClient = noSsl ? _clientFactory.CreateClient("NoSSL") : _clientFactory.CreateClient("Default");
 
             var bbsClient = new BbsClient(_octoLogger, httpClient, _versionProvider, _retryPolicy, bbsUsername, bbsPassword);
             return new BbsApi(bbsClient, bbsServerUrl, _octoLogger);
         }
 
-        public virtual BbsApi CreateKerberos(string bbsServerUrl)
+        public virtual BbsApi CreateKerberos(string bbsServerUrl, bool noSsl = false)
         {
-            var httpClient = _clientFactory.CreateClient("Kerberos");
+            var httpClient = noSsl ? _clientFactory.CreateClient("KerberosNoSSL") : _clientFactory.CreateClient("Kerberos");
 
             var bbsClient = new BbsClient(_octoLogger, httpClient, _versionProvider, _retryPolicy);
             return new BbsApi(bbsClient, bbsServerUrl, _octoLogger);

--- a/src/bbs2gh/Commands/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepoCommand.cs
@@ -43,6 +43,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         AddOption(Kerberos);
         AddOption(Verbose);
         AddOption(KeepArchive);
+        AddOption(NoSslVerify);
     }
 
     public Option<string> BbsServerUrl { get; } = new(
@@ -163,6 +164,11 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         name: "--keep-archive",
         description: "Keeps the downloaded export archive after successfully uploading it. By default, it will be automatically deleted.");
 
+    public Option<bool> NoSslVerify { get; } = new(
+        name: "--no-ssl-verify",
+        description: "Disables SSL verification when communicating with your Bitbucket Server/Data Center instance. All other migration steps will continue to verify SSL. " +
+                     "If your Bitbucket instance has a self-signed SSL certificate then setting this flag will allow the migration archive to be exported.");
+
     public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, IServiceProvider sp)
     {
         if (args is null)
@@ -194,7 +200,9 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         {
             var bbsApiFactory = sp.GetRequiredService<BbsApiFactory>();
 
-            bbsApi = args.Kerberos ? bbsApiFactory.CreateKerberos(args.BbsServerUrl) : bbsApiFactory.Create(args.BbsServerUrl, args.BbsUsername, args.BbsPassword);
+            bbsApi = args.Kerberos
+                ? bbsApiFactory.CreateKerberos(args.BbsServerUrl, args.NoSslVerify)
+                : bbsApiFactory.Create(args.BbsServerUrl, args.BbsUsername, args.BbsPassword, args.NoSslVerify);
         }
 
         if (args.SshUser.HasValue() || args.SmbUser.HasValue())
@@ -249,6 +257,8 @@ public class MigrateRepoCommandArgs
     public string BbsUsername { get; set; }
     public string BbsPassword { get; set; }
     public string BbsSharedHome { get; set; }
+    public bool NoSslVerify { get; set; }
+
 
     public string SshUser { get; set; }
     public string SshPrivateKey { get; set; }

--- a/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
+++ b/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
@@ -44,6 +44,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         _log.LogInformation("Generating Script...");
 
         LogOptions(args);
+        ValidateOptions(args);
 
         _log.RegisterSecret(args.BbsPassword);
 
@@ -116,9 +117,10 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         var awsBucketNameOption = args.AwsBucketName.HasValue() ? $" --aws-bucket-name \"{args.AwsBucketName}\"" : "";
         var awsRegionOption = args.AwsRegion.HasValue() ? $" --aws-region \"{args.AwsRegion}\"" : "";
         var keepArchive = args.KeepArchive ? " --keep-archive" : "";
+        var noSslVerify = args.NoSslVerify ? " --no-ssl-verify" : "";
 
         return $"gh bbs2gh migrate-repo{bbsServerUrlOption}{bbsUsernameOption}{bbsSharedHomeOption}{bbsProjectOption}{bbsRepoOption}{sshArchiveDownloadOptions}" +
-               $"{smbArchiveDownloadOptions}{githubOrgOption}{githubRepoOption}{verboseOption}{waitOption}{kerberosOption}{awsBucketNameOption}{awsRegionOption}{keepArchive}";
+               $"{smbArchiveDownloadOptions}{githubOrgOption}{githubRepoOption}{verboseOption}{waitOption}{kerberosOption}{awsBucketNameOption}{awsRegionOption}{keepArchive}{noSslVerify}";
     }
 
     private string Exec(string script) => Wrap(script, "Exec");
@@ -195,6 +197,19 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         if (args.KeepArchive)
         {
             _log.LogInformation("KEEP ARCHIVE: true");
+        }
+
+        if (args.NoSslVerify)
+        {
+            _log.LogInformation("NO SSL VERIFY: true");
+        }
+    }
+
+    private void ValidateOptions(GenerateScriptCommandArgs args)
+    {
+        if (args.NoSslVerify && args.BbsServerUrl.IsNullOrWhiteSpace())
+        {
+            throw new OctoshiftCliException("--no-ssl-verify can only be provided with --bbs-server-url.");
         }
     }
 

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -356,6 +356,11 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         {
             _log.LogInformation("KEEP ARCHIVE: true");
         }
+
+        if (args.NoSslVerify)
+        {
+            _log.LogInformation("NO SSL VERIFY: true");
+        }
     }
 
     private void LogAwsOptions(MigrateRepoCommandArgs args)
@@ -440,6 +445,11 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             if (args.BbsUsername.HasValue() || args.BbsPassword.HasValue())
             {
                 throw new OctoshiftCliException("--bbs-username and --bbs-password can only be provided with --bbs-server-url.");
+            }
+
+            if (args.NoSslVerify)
+            {
+                throw new OctoshiftCliException("--no-ssl-verify can only be provided with --bbs-server-url.");
             }
 
             if (new[] { args.SshUser, args.SshPrivateKey, args.SmbUser, args.SmbPassword, args.SmbDomain }.Any(obj => obj.HasValue()))

--- a/src/bbs2gh/Program.cs
+++ b/src/bbs2gh/Program.cs
@@ -46,6 +46,21 @@ namespace OctoshiftCLI.BbsToGithub
                     UseDefaultCredentials = true
                 })
                 .Services
+                .AddHttpClient("NoSSL")
+                .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler()
+                {
+                    CheckCertificateRevocationList = false,
+                    ServerCertificateCustomValidationCallback = delegate { return true; }
+                })
+                .Services
+                .AddHttpClient("KerberosNoSSL")
+                .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler()
+                {
+                    UseDefaultCredentials = true,
+                    CheckCertificateRevocationList = false,
+                    ServerCertificateCustomValidationCallback = delegate { return true; }
+                })
+                .Services
                 .AddHttpClient("Default");
 
             var serviceProvider = serviceCollection.BuildServiceProvider();


### PR DESCRIPTION
Fixes #864 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

### Description
This PR adds `--no-ssl-verify` option to `migrate-repo` and `generate-script` commands for `bbs2gh` to support migrating form servers that use self-singed SSL certificates.