### PR TITLE
Add support for specifying custom host for SSH/SMB downloads with hidden `--archive-download-host` argument in `gh bbs2gh`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,3 @@
 - Adds retry logic during GHES archive generation in cases of transient failure
 - Added log output linking to migration log URL after migration completes
-- Add support for specifying `--ssh-host` with `gh bbs2gh migrate-repo` and `gh bbs2gh generate-script`, rather than taking the host from the `--bbs-server-url`
+- Add support for specifying `--archive-download-host` with `gh bbs2gh migrate-repo` and `gh bbs2gh generate-script`, rather than taking the host from the `--bbs-server-url`

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - Adds retry logic during GHES archive generation in cases of transient failure
 - Added log output linking to migration log URL after migration completes
+- Add support for specifying `--ssh-host` with `gh bbs2gh migrate-repo` and `gh bbs2gh generate-script`, rather than taking the host from the `--bbs-server-url`

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
@@ -35,7 +35,7 @@ public class GenerateScriptCommandTests
     {
         _command.Should().NotBeNull();
         _command.Name.Should().Be("generate-script");
-        _command.Options.Count.Should().Be(18);
+        _command.Options.Count.Should().Be(19);
 
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-server-url", true);
         TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
@@ -43,6 +43,7 @@ public class GenerateScriptCommandTests
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-password", false);
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-project-key", false);
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-shared-home", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "ssh-host", false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-user", false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-private-key", false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-port", false);

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
@@ -43,7 +43,7 @@ public class GenerateScriptCommandTests
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-password", false);
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-project-key", false);
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-shared-home", false);
-        TestHelpers.VerifyCommandOption(_command.Options, "archive-download-host", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "archive-download-host", false, true);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-user", false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-private-key", false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-port", false);

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
@@ -43,7 +43,7 @@ public class GenerateScriptCommandTests
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-password", false);
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-project-key", false);
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-shared-home", false);
-        TestHelpers.VerifyCommandOption(_command.Options, "ssh-host", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "archive-download-host", false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-user", false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-private-key", false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-port", false);

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
@@ -14,7 +14,7 @@ public class MigrateRepoCommandTests
     private const string SSH_PRIVATE_KEY = "ssh-private-key";
     private const int SSH_PORT = 1234;
     private const string BBS_SHARED_HOME = "shared-home";
-    private const string BBS_HOST = "bbs-server-url-host";
+    private const string BBS_HOST = "bbs-host";
     private const string BBS_SERVER_URL = $"https://{BBS_HOST}";
     private const string GITHUB_ORG = "github-org";
     private const string GITHUB_PAT = "github-pat";

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
@@ -9,12 +9,12 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands;
 
 public class MigrateRepoCommandTests
 {
+    private const string SSH_HOST = "ssh-host";
     private const string SSH_USER = "ssh-user";
     private const string SSH_PRIVATE_KEY = "ssh-private-key";
     private const int SSH_PORT = 1234;
     private const string BBS_SHARED_HOME = "shared-home";
-    private const string BBS_HOST = "bbs-host";
-    private const string BBS_SERVER_URL = $"https://{BBS_HOST}";
+    private const string BBS_SERVER_URL = $"https://bbs-server-url-host";
     private const string GITHUB_ORG = "github-org";
     private const string GITHUB_PAT = "github-pat";
     private const string BBS_USERNAME = "bbs-username";
@@ -52,7 +52,7 @@ public class MigrateRepoCommandTests
         var command = new MigrateRepoCommand();
         command.Should().NotBeNull();
         command.Name.Should().Be("migrate-repo");
-        command.Options.Count.Should().Be(28);
+        command.Options.Count.Should().Be(29);
 
         TestHelpers.VerifyCommandOption(command.Options, "bbs-server-url", false);
         TestHelpers.VerifyCommandOption(command.Options, "bbs-project", false);
@@ -70,6 +70,7 @@ public class MigrateRepoCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "github-org", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-repo", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
+        TestHelpers.VerifyCommandOption(command.Options, "ssh-host", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-user", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-private-key", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-port", false);
@@ -84,7 +85,7 @@ public class MigrateRepoCommandTests
     }
 
     [Fact]
-    public void BuildHandler_Creates_Bbs_Ssh_Archive_Downloader_When_Ssh_User_Is_Provided()
+    public void BuildHandler_Creates_Bbs_Ssh_Archive_Downloader_Based_On_Server_Url_When_Ssh_User_Is_Provided()
     {
         // Arrange
         var args = new MigrateRepoCommandArgs
@@ -101,7 +102,29 @@ public class MigrateRepoCommandTests
 
         // Assert
         handler.Should().NotBeNull();
-        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSshDownloader(BBS_HOST, SSH_USER, SSH_PRIVATE_KEY, SSH_PORT, BBS_SHARED_HOME));
+        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSshDownloader("bbs-server-url-host", SSH_USER, SSH_PRIVATE_KEY, SSH_PORT, BBS_SHARED_HOME));
+    }
+
+    [Fact]
+    public void BuildHandler_Creates_Bbs_Ssh_Archive_Downloader_When_Ssh_User_And_Ssh_Host_Is_Provided()
+    {
+        // Arrange
+        var args = new MigrateRepoCommandArgs
+        {
+            SshHost = SSH_HOST,
+            SshUser = SSH_USER,
+            SshPrivateKey = SSH_PRIVATE_KEY,
+            SshPort = SSH_PORT,
+            BbsSharedHome = BBS_SHARED_HOME,
+            BbsServerUrl = BBS_SERVER_URL
+        };
+
+        // Act
+        var handler = _command.BuildHandler(args, _mockServiceProvider.Object);
+
+        // Assert
+        handler.Should().NotBeNull();
+        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSshDownloader(SSH_HOST, SSH_USER, SSH_PRIVATE_KEY, SSH_PORT, BBS_SHARED_HOME));
     }
 
     [Fact]
@@ -122,7 +145,7 @@ public class MigrateRepoCommandTests
 
         // Assert
         handler.Should().NotBeNull();
-        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSmbDownloader(BBS_HOST, SMB_USER, SMB_PASSWORD, SMB_DOMAIN, BBS_SHARED_HOME));
+        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSmbDownloader("bbs-server-url-host", SMB_USER, SMB_PASSWORD, SMB_DOMAIN, BBS_SHARED_HOME));
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
@@ -9,12 +9,13 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands;
 
 public class MigrateRepoCommandTests
 {
-    private const string SSH_HOST = "ssh-host";
+    private const string ARCHIVE_DOWNLOAD_HOST = "archive-download-host";
     private const string SSH_USER = "ssh-user";
     private const string SSH_PRIVATE_KEY = "ssh-private-key";
     private const int SSH_PORT = 1234;
     private const string BBS_SHARED_HOME = "shared-home";
-    private const string BBS_SERVER_URL = $"https://bbs-server-url-host";
+    private const string BBS_HOST = "bbs-server-url-host";
+    private const string BBS_SERVER_URL = $"https://{BBS_HOST}";
     private const string GITHUB_ORG = "github-org";
     private const string GITHUB_PAT = "github-pat";
     private const string BBS_USERNAME = "bbs-username";
@@ -70,7 +71,7 @@ public class MigrateRepoCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "github-org", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-repo", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
-        TestHelpers.VerifyCommandOption(command.Options, "ssh-host", false);
+        TestHelpers.VerifyCommandOption(command.Options, "archive-download-host", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-user", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-private-key", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-port", false);
@@ -102,16 +103,16 @@ public class MigrateRepoCommandTests
 
         // Assert
         handler.Should().NotBeNull();
-        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSshDownloader("bbs-server-url-host", SSH_USER, SSH_PRIVATE_KEY, SSH_PORT, BBS_SHARED_HOME));
+        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSshDownloader(BBS_HOST, SSH_USER, SSH_PRIVATE_KEY, SSH_PORT, BBS_SHARED_HOME));
     }
 
     [Fact]
-    public void BuildHandler_Creates_Bbs_Ssh_Archive_Downloader_When_Ssh_User_And_Ssh_Host_Is_Provided()
+    public void BuildHandler_Creates_Bbs_Ssh_Archive_Downloader_When_Ssh_User_And_Archive_Download_Host_Is_Provided()
     {
         // Arrange
         var args = new MigrateRepoCommandArgs
         {
-            SshHost = SSH_HOST,
+            ArchiveDownloadHost = ARCHIVE_DOWNLOAD_HOST,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,
@@ -124,11 +125,11 @@ public class MigrateRepoCommandTests
 
         // Assert
         handler.Should().NotBeNull();
-        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSshDownloader(SSH_HOST, SSH_USER, SSH_PRIVATE_KEY, SSH_PORT, BBS_SHARED_HOME));
+        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSshDownloader(ARCHIVE_DOWNLOAD_HOST, SSH_USER, SSH_PRIVATE_KEY, SSH_PORT, BBS_SHARED_HOME));
     }
 
     [Fact]
-    public void BuildHandler_Creates_Bbs_Smb_Archive_Downloader_When_Smb_User_Is_Provided()
+    public void BuildHandler_Creates_Bbs_Smb_Archive_Downloader_Based_On_Server_Url_When_Smb_User_Is_Provided()
     {
         // Arrange
         var args = new MigrateRepoCommandArgs
@@ -145,7 +146,29 @@ public class MigrateRepoCommandTests
 
         // Assert
         handler.Should().NotBeNull();
-        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSmbDownloader("bbs-server-url-host", SMB_USER, SMB_PASSWORD, SMB_DOMAIN, BBS_SHARED_HOME));
+        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSmbDownloader(BBS_HOST, SMB_USER, SMB_PASSWORD, SMB_DOMAIN, BBS_SHARED_HOME));
+    }
+
+    [Fact]
+    public void BuildHandler_Creates_Bbs_Smb_Archive_Downloader_When_Smb_User_And_Archive_Download_Host_Is_Provided()
+    {
+        // Arrange
+        var args = new MigrateRepoCommandArgs
+        {
+            ArchiveDownloadHost = ARCHIVE_DOWNLOAD_HOST,
+            SmbUser = SMB_USER,
+            SmbPassword = SMB_PASSWORD,
+            SmbDomain = SMB_DOMAIN,
+            BbsSharedHome = BBS_SHARED_HOME,
+            BbsServerUrl = BBS_SERVER_URL
+        };
+
+        // Act
+        var handler = _command.BuildHandler(args, _mockServiceProvider.Object);
+
+        // Assert
+        handler.Should().NotBeNull();
+        _mockBbsArchiveDownloaderFactory.Verify(m => m.CreateSmbDownloader(ARCHIVE_DOWNLOAD_HOST, SMB_USER, SMB_PASSWORD, SMB_DOMAIN, BBS_SHARED_HOME));
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
@@ -71,7 +71,7 @@ public class MigrateRepoCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "github-org", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-repo", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
-        TestHelpers.VerifyCommandOption(command.Options, "archive-download-host", false);
+        TestHelpers.VerifyCommandOption(command.Options, "archive-download-host", false, true);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-user", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-private-key", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-port", false);

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
@@ -314,7 +314,7 @@ public class GenerateScriptCommandHandlerTests
     }
 
     [Fact]
-    public async Task One_Repo_With_Smb_And_Archive_Download_host()
+    public async Task One_Repo_With_Smb_And_Archive_Download_Host()
     {
         // Arrange
         _mockBbsApi.Setup(m => m.GetProjects()).ReturnsAsync(new[]

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
@@ -28,7 +28,7 @@ public class GenerateScriptCommandHandlerTests
     private const string BBS_PASSWORD = "BBS-PASSWORD";
     private const string SSH_USER = "SSH-USER";
     private const string SSH_PRIVATE_KEY = "path-to-ssh-private-key";
-    private const string SSH_HOST = "bbs-server-host";
+    private const string ARCHIVE_DOWNLOAD_HOST = "archive-download-host";
     private const int SSH_PORT = 2211;
     private const string SMB_USER = "SMB-USER";
     private const string SMB_DOMAIN = "SMB-DOMAIN";
@@ -125,10 +125,10 @@ public class GenerateScriptCommandHandlerTests
             (Id: 4, Slug: BBS_BAR_REPO_2_SLUG, Name: BBS_BAR_REPO_2_NAME)
         });
 
-        var migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --keep-archive }}";
-        var migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait --keep-archive }}";
-        var migrateRepoCommand3 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_1_SLUG}\" --verbose --wait --keep-archive }}";
-        var migrateRepoCommand4 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_2_SLUG}\" --verbose --wait --keep-archive }}";
+        var migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {ARCHIVE_DOWNLOAD_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --keep-archive }}";
+        var migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {ARCHIVE_DOWNLOAD_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait --keep-archive }}";
+        var migrateRepoCommand3 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {ARCHIVE_DOWNLOAD_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_1_SLUG}\" --verbose --wait --keep-archive }}";
+        var migrateRepoCommand4 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {ARCHIVE_DOWNLOAD_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_2_SLUG}\" --verbose --wait --keep-archive }}";
 
         // Act
         var args = new GenerateScriptCommandArgs
@@ -138,7 +138,7 @@ public class GenerateScriptCommandHandlerTests
             BbsUsername = BBS_USERNAME,
             BbsPassword = BBS_PASSWORD,
             BbsSharedHome = BBS_SHARED_HOME,
-            ArchiveDownloadHost = SSH_HOST,
+            ArchiveDownloadHost = ARCHIVE_DOWNLOAD_HOST,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,
@@ -178,8 +178,8 @@ public class GenerateScriptCommandHandlerTests
             (Id: 4, Slug: BBS_BAR_REPO_2_SLUG, Name: BBS_BAR_REPO_2_NAME)
         });
 
-        var migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait }}";
-        var migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait }}";
+        var migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {ARCHIVE_DOWNLOAD_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait }}";
+        var migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {ARCHIVE_DOWNLOAD_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait }}";
 
         // Act
         var args = new GenerateScriptCommandArgs
@@ -190,7 +190,7 @@ public class GenerateScriptCommandHandlerTests
             BbsPassword = BBS_PASSWORD,
             BbsProjectKey = BBS_FOO_PROJECT_KEY,
             BbsSharedHome = BBS_SHARED_HOME,
-            ArchiveDownloadHost = SSH_HOST,
+            ArchiveDownloadHost = ARCHIVE_DOWNLOAD_HOST,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,
@@ -219,7 +219,7 @@ public class GenerateScriptCommandHandlerTests
             (Id: 1, Slug: BBS_FOO_REPO_1_SLUG, Name: BBS_FOO_REPO_1_NAME),
         });
 
-        var migrateRepoCommand = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --kerberos }}";
+        var migrateRepoCommand = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {ARCHIVE_DOWNLOAD_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --kerberos }}";
 
         // Act
         var args = new GenerateScriptCommandArgs
@@ -229,7 +229,7 @@ public class GenerateScriptCommandHandlerTests
             BbsUsername = BBS_USERNAME,
             BbsPassword = BBS_PASSWORD,
             BbsSharedHome = BBS_SHARED_HOME,
-            ArchiveDownloadHost = SSH_HOST,
+            ArchiveDownloadHost = ARCHIVE_DOWNLOAD_HOST,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,
@@ -400,7 +400,7 @@ function Exec {
 
         var migrateRepoCommand = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" " +
                                  $"--bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" " +
-                                 $"--ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" " +
+                                 $"--ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {ARCHIVE_DOWNLOAD_HOST} --github-org \"{GITHUB_ORG}\" " +
                                  $"--github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --aws-bucket-name \"{AWS_BUCKET_NAME}\" " +
                                  $"--aws-region \"{AWS_REGION}\" }}";
 
@@ -412,7 +412,7 @@ function Exec {
             BbsUsername = BBS_USERNAME,
             BbsPassword = BBS_PASSWORD,
             BbsSharedHome = BBS_SHARED_HOME,
-            ArchiveDownloadHost = SSH_HOST,
+            ArchiveDownloadHost = ARCHIVE_DOWNLOAD_HOST,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
@@ -125,10 +125,10 @@ public class GenerateScriptCommandHandlerTests
             (Id: 4, Slug: BBS_BAR_REPO_2_SLUG, Name: BBS_BAR_REPO_2_NAME)
         });
 
-        var migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --keep-archive }}";
-        var migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait --keep-archive }}";
-        var migrateRepoCommand3 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_1_SLUG}\" --verbose --wait --keep-archive }}";
-        var migrateRepoCommand4 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_2_SLUG}\" --verbose --wait --keep-archive }}";
+        var migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --keep-archive }}";
+        var migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait --keep-archive }}";
+        var migrateRepoCommand3 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_1_SLUG}\" --verbose --wait --keep-archive }}";
+        var migrateRepoCommand4 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_2_SLUG}\" --verbose --wait --keep-archive }}";
 
         // Act
         var args = new GenerateScriptCommandArgs
@@ -138,7 +138,7 @@ public class GenerateScriptCommandHandlerTests
             BbsUsername = BBS_USERNAME,
             BbsPassword = BBS_PASSWORD,
             BbsSharedHome = BBS_SHARED_HOME,
-            SshHost = SSH_HOST,
+            ArchiveDownloadHost = SSH_HOST,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,
@@ -178,8 +178,8 @@ public class GenerateScriptCommandHandlerTests
             (Id: 4, Slug: BBS_BAR_REPO_2_SLUG, Name: BBS_BAR_REPO_2_NAME)
         });
 
-        var migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait }}";
-        var migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait }}";
+        var migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait }}";
+        var migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait }}";
 
         // Act
         var args = new GenerateScriptCommandArgs
@@ -190,7 +190,7 @@ public class GenerateScriptCommandHandlerTests
             BbsPassword = BBS_PASSWORD,
             BbsProjectKey = BBS_FOO_PROJECT_KEY,
             BbsSharedHome = BBS_SHARED_HOME,
-            SshHost = SSH_HOST,
+            ArchiveDownloadHost = SSH_HOST,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,
@@ -219,7 +219,7 @@ public class GenerateScriptCommandHandlerTests
             (Id: 1, Slug: BBS_FOO_REPO_1_SLUG, Name: BBS_FOO_REPO_1_NAME),
         });
 
-        var migrateRepoCommand = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --kerberos }}";
+        var migrateRepoCommand = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --kerberos }}";
 
         // Act
         var args = new GenerateScriptCommandArgs
@@ -229,7 +229,7 @@ public class GenerateScriptCommandHandlerTests
             BbsUsername = BBS_USERNAME,
             BbsPassword = BBS_PASSWORD,
             BbsSharedHome = BBS_SHARED_HOME,
-            SshHost = SSH_HOST,
+            ArchiveDownloadHost = SSH_HOST,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,
@@ -400,7 +400,7 @@ function Exec {
 
         var migrateRepoCommand = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" " +
                                  $"--bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" " +
-                                 $"--ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" " +
+                                 $"--ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --archive-download-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" " +
                                  $"--github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --aws-bucket-name \"{AWS_BUCKET_NAME}\" " +
                                  $"--aws-region \"{AWS_REGION}\" }}";
 
@@ -412,7 +412,7 @@ function Exec {
             BbsUsername = BBS_USERNAME,
             BbsPassword = BBS_PASSWORD,
             BbsSharedHome = BBS_SHARED_HOME,
-            SshHost = SSH_HOST,
+            ArchiveDownloadHost = SSH_HOST,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
@@ -314,6 +314,41 @@ public class GenerateScriptCommandHandlerTests
     }
 
     [Fact]
+    public async Task One_Repo_With_Smb_And_Archive_Download_host()
+    {
+        // Arrange
+        _mockBbsApi.Setup(m => m.GetProjects()).ReturnsAsync(new[]
+        {
+            (Id: 1, Key: BBS_FOO_PROJECT_KEY, Name: BBS_FOO_PROJECT_NAME),
+        });
+        _mockBbsApi.Setup(m => m.GetRepos(BBS_FOO_PROJECT_KEY)).ReturnsAsync(new[]
+        {
+            (Id: 1, Slug: BBS_FOO_REPO_1_SLUG, Name: BBS_FOO_REPO_1_NAME),
+        });
+
+        var migrateRepoCommand = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --smb-user \"{SMB_USER}\" --smb-domain {SMB_DOMAIN} --archive-download-host {ARCHIVE_DOWNLOAD_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait }}";
+
+        // Act
+        var args = new GenerateScriptCommandArgs
+        {
+            ArchiveDownloadHost = ARCHIVE_DOWNLOAD_HOST,
+            BbsServerUrl = BBS_SERVER_URL,
+            GithubOrg = GITHUB_ORG,
+            BbsUsername = BBS_USERNAME,
+            BbsPassword = BBS_PASSWORD,
+            BbsSharedHome = BBS_SHARED_HOME,
+            SmbUser = SMB_USER,
+            SmbDomain = SMB_DOMAIN,
+            Output = new FileInfo(OUTPUT),
+            Verbose = true
+        };
+        await _handler.Handle(args);
+
+        // Assert
+        _mockFileSystemProvider.Verify(m => m.WriteAllTextAsync(It.IsAny<string>(), It.Is<string>(script => script.Contains(migrateRepoCommand))));
+    }
+
+    [Fact]
     public async Task Generated_Script_Contains_The_Cli_Version_Comment()
     {
         // Arrange

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
@@ -28,6 +28,7 @@ public class GenerateScriptCommandHandlerTests
     private const string BBS_PASSWORD = "BBS-PASSWORD";
     private const string SSH_USER = "SSH-USER";
     private const string SSH_PRIVATE_KEY = "path-to-ssh-private-key";
+    private const string SSH_HOST = "bbs-server-host";
     private const int SSH_PORT = 2211;
     private const string SMB_USER = "SMB-USER";
     private const string SMB_DOMAIN = "SMB-DOMAIN";
@@ -124,10 +125,10 @@ public class GenerateScriptCommandHandlerTests
             (Id: 4, Slug: BBS_BAR_REPO_2_SLUG, Name: BBS_BAR_REPO_2_NAME)
         });
 
-        var migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --keep-archive }}";
-        var migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait --keep-archive }}";
-        var migrateRepoCommand3 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_1_SLUG}\" --verbose --wait --keep-archive }}";
-        var migrateRepoCommand4 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_2_SLUG}\" --verbose --wait --keep-archive }}";
+        var migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --keep-archive }}";
+        var migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait --keep-archive }}";
+        var migrateRepoCommand3 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_1_SLUG}\" --verbose --wait --keep-archive }}";
+        var migrateRepoCommand4 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_BAR_PROJECT_KEY}\" --bbs-repo \"{BBS_BAR_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_BAR_PROJECT_KEY}-{BBS_BAR_REPO_2_SLUG}\" --verbose --wait --keep-archive }}";
 
         // Act
         var args = new GenerateScriptCommandArgs
@@ -137,6 +138,7 @@ public class GenerateScriptCommandHandlerTests
             BbsUsername = BBS_USERNAME,
             BbsPassword = BBS_PASSWORD,
             BbsSharedHome = BBS_SHARED_HOME,
+            SshHost = SSH_HOST,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,
@@ -176,8 +178,8 @@ public class GenerateScriptCommandHandlerTests
             (Id: 4, Slug: BBS_BAR_REPO_2_SLUG, Name: BBS_BAR_REPO_2_NAME)
         });
 
-        var migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait }}";
-        var migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait }}";
+        var migrateRepoCommand1 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait }}";
+        var migrateRepoCommand2 = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_2_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_2_SLUG}\" --verbose --wait }}";
 
         // Act
         var args = new GenerateScriptCommandArgs
@@ -188,6 +190,7 @@ public class GenerateScriptCommandHandlerTests
             BbsPassword = BBS_PASSWORD,
             BbsProjectKey = BBS_FOO_PROJECT_KEY,
             BbsSharedHome = BBS_SHARED_HOME,
+            SshHost = SSH_HOST,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,
@@ -216,7 +219,7 @@ public class GenerateScriptCommandHandlerTests
             (Id: 1, Slug: BBS_FOO_REPO_1_SLUG, Name: BBS_FOO_REPO_1_NAME),
         });
 
-        var migrateRepoCommand = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --kerberos }}";
+        var migrateRepoCommand = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" --bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" --ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" --github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --kerberos }}";
 
         // Act
         var args = new GenerateScriptCommandArgs
@@ -226,6 +229,7 @@ public class GenerateScriptCommandHandlerTests
             BbsUsername = BBS_USERNAME,
             BbsPassword = BBS_PASSWORD,
             BbsSharedHome = BBS_SHARED_HOME,
+            SshHost = SSH_HOST,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,
@@ -396,7 +400,7 @@ function Exec {
 
         var migrateRepoCommand = $"Exec {{ gh bbs2gh migrate-repo --bbs-server-url \"{BBS_SERVER_URL}\" --bbs-username \"{BBS_USERNAME}\" " +
                                  $"--bbs-shared-home \"{BBS_SHARED_HOME}\" --bbs-project \"{BBS_FOO_PROJECT_KEY}\" --bbs-repo \"{BBS_FOO_REPO_1_SLUG}\" " +
-                                 $"--ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --github-org \"{GITHUB_ORG}\" " +
+                                 $"--ssh-user \"{SSH_USER}\" --ssh-private-key \"{SSH_PRIVATE_KEY}\" --ssh-port {SSH_PORT} --ssh-host {SSH_HOST} --github-org \"{GITHUB_ORG}\" " +
                                  $"--github-repo \"{BBS_FOO_PROJECT_KEY}-{BBS_FOO_REPO_1_SLUG}\" --verbose --wait --aws-bucket-name \"{AWS_BUCKET_NAME}\" " +
                                  $"--aws-region \"{AWS_REGION}\" }}";
 
@@ -408,6 +412,7 @@ function Exec {
             BbsUsername = BBS_USERNAME,
             BbsPassword = BBS_PASSWORD,
             BbsSharedHome = BBS_SHARED_HOME,
+            SshHost = SSH_HOST,
             SshUser = SSH_USER,
             SshPrivateKey = SSH_PRIVATE_KEY,
             SshPort = SSH_PORT,

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -38,8 +38,8 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
         private const string AWS_REGION = "aws-region";
         private const string AZURE_STORAGE_CONNECTION_STRING = "azure-storage-connection-string";
 
-        private const string BBS_HOST = "bbs-server-url-host";
-        private const string BBS_SERVER_URL = $"https://${BBS_HOST}";
+        private const string BBS_HOST = "our-bbs-server.com";
+        private const string BBS_SERVER_URL = $"https://{BBS_HOST}";
         private const string BBS_USERNAME = "bbs-username";
         private const string BBS_PASSWORD = "bbs-password";
         private const string BBS_PROJECT = "bbs-project";
@@ -502,6 +502,22 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
                 BbsRepo = BBS_REPO,
                 SshUser = SSH_USER,
                 SmbUser = SMB_USER
+            };
+            await _handler.Invoking(x => x.Handle(args)).Should().ThrowExactlyAsync<OctoshiftCliException>();
+        }
+
+        [Fact]
+        public async Task Errors_When_Archive_Download_Host_Provided_Without_Ssh_Or_Smb_Options()
+        {
+            // Act, Assert
+            var args = new MigrateRepoCommandArgs
+            {
+                BbsServerUrl = BBS_SERVER_URL,
+                BbsUsername = BBS_USERNAME,
+                BbsPassword = BBS_PASSWORD,
+                BbsProject = BBS_PROJECT,
+                BbsRepo = BBS_REPO,
+                ArchiveDownloadHost = "somehost"
             };
             await _handler.Invoking(x => x.Handle(args)).Should().ThrowExactlyAsync<OctoshiftCliException>();
         }

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -38,8 +38,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
         private const string AWS_REGION = "aws-region";
         private const string AZURE_STORAGE_CONNECTION_STRING = "azure-storage-connection-string";
 
-        private const string BBS_HOST = "our-bbs-server.com";
-        private const string BBS_SERVER_URL = $"https://{BBS_HOST}";
+        private const string BBS_SERVER_URL = $"https://bbs-server-url-host";
         private const string BBS_USERNAME = "bbs-username";
         private const string BBS_PASSWORD = "bbs-password";
         private const string BBS_PROJECT = "bbs-project";

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -38,7 +38,8 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Handlers
         private const string AWS_REGION = "aws-region";
         private const string AZURE_STORAGE_CONNECTION_STRING = "azure-storage-connection-string";
 
-        private const string BBS_SERVER_URL = $"https://bbs-server-url-host";
+        private const string BBS_HOST = "bbs-server-url-host";
+        private const string BBS_SERVER_URL = $"https://${BBS_HOST}";
         private const string BBS_USERNAME = "bbs-username";
         private const string BBS_PASSWORD = "bbs-password";
         private const string BBS_PROJECT = "bbs-project";

--- a/src/bbs2gh/Commands/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScriptCommand.cs
@@ -23,6 +23,7 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
         AddOption(SshUser);
         AddOption(SshPrivateKey);
         AddOption(SshPort);
+        AddOption(SshHost);
         AddOption(SmbUser);
         AddOption(SmbDomain);
         AddOption(Output);
@@ -57,6 +58,10 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
         name: "--bbs-shared-home",
         description: "Bitbucket server's shared home directory. Defaults to \"/var/atlassian/application-data/bitbucket/shared\" if downloading the archive from a server using SSH " +
                      "and \"c$\\atlassian\\applicationdata\\bitbucket\\shared\" if downloading using SMB.");
+
+    public Option<string> SshHost { get; } = new(
+        name: "--ssh-host",
+        description: "The host to use to connect to the Bitbucket Server via SSH. Defaults to the host from the Bitbucket Server URL (`--bbs-server-url`).");
 
     public Option<string> SshUser { get; } = new(
         name: "--ssh-user",
@@ -148,6 +153,7 @@ public class GenerateScriptCommandArgs
     public string BbsPassword { get; set; }
     public string BbsProjectKey { get; set; }
     public string BbsSharedHome { get; set; }
+    public string SshHost { get; set; }
     public string SshUser { get; set; }
     public string SshPrivateKey { get; set; }
     public int SshPort { get; set; }

--- a/src/bbs2gh/Commands/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScriptCommand.cs
@@ -61,7 +61,8 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
 
     public Option<string> ArchiveDownloadHost { get; } = new(
         name: "--archive-download-host",
-        description: "The host to use to connect to the Bitbucket Server via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).");
+        description: "The host to use to connect to the Bitbucket Server via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).")
+    { IsHidden = true };
 
     public Option<string> SshUser { get; } = new(
         name: "--ssh-user",

--- a/src/bbs2gh/Commands/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScriptCommand.cs
@@ -61,7 +61,7 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
 
     public Option<string> ArchiveDownloadHost { get; } = new(
         name: "--archive-download-host",
-        description: "The host to use to connect to the Bitbucket Server via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).")
+        description: "The host to use to connect to the Bitbucket Server/Data Center instance via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).")
     { IsHidden = true };
 
     public Option<string> SshUser { get; } = new(

--- a/src/bbs2gh/Commands/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScriptCommand.cs
@@ -23,7 +23,7 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
         AddOption(SshUser);
         AddOption(SshPrivateKey);
         AddOption(SshPort);
-        AddOption(SshHost);
+        AddOption(ArchiveDownloadHost);
         AddOption(SmbUser);
         AddOption(SmbDomain);
         AddOption(Output);
@@ -59,9 +59,9 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
         description: "Bitbucket server's shared home directory. Defaults to \"/var/atlassian/application-data/bitbucket/shared\" if downloading the archive from a server using SSH " +
                      "and \"c$\\atlassian\\applicationdata\\bitbucket\\shared\" if downloading using SMB.");
 
-    public Option<string> SshHost { get; } = new(
-        name: "--ssh-host",
-        description: "The host to use to connect to the Bitbucket Server via SSH. Defaults to the host from the Bitbucket Server URL (`--bbs-server-url`).");
+    public Option<string> ArchiveDownloadHost { get; } = new(
+        name: "--archive-download-host",
+        description: "The host to use to connect to the Bitbucket Server via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).");
 
     public Option<string> SshUser { get; } = new(
         name: "--ssh-user",
@@ -153,7 +153,7 @@ public class GenerateScriptCommandArgs
     public string BbsPassword { get; set; }
     public string BbsProjectKey { get; set; }
     public string BbsSharedHome { get; set; }
-    public string SshHost { get; set; }
+    public string ArchiveDownloadHost { get; set; }
     public string SshUser { get; set; }
     public string SshPrivateKey { get; set; }
     public int SshPort { get; set; }

--- a/src/bbs2gh/Commands/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepoCommand.cs
@@ -113,7 +113,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
 
     public Option<string> ArchiveDownloadHost { get; } = new(
         name: "--archive-download-host",
-        description: "The host to use to connect to the Bitbucket Server via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).")
+        description: "The host to use to connect to the Bitbucket Server/Data Center instance via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).")
     { IsHidden = true };
 
     public Option<string> SshUser { get; } = new(
@@ -214,11 +214,11 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         if (args.SshUser.HasValue() || args.SmbUser.HasValue())
         {
             var bbsArchiveDownloaderFactory = sp.GetRequiredService<BbsArchiveDownloaderFactory>();
-            var ComputedArchiveDownloadHost = args.ArchiveDownloadHost.HasValue() ? args.ArchiveDownloadHost : new Uri(args.BbsServerUrl).Host;
+            var bbsHost = args.ArchiveDownloadHost.HasValue() ? args.ArchiveDownloadHost : new Uri(args.BbsServerUrl).Host;
 
             bbsArchiveDownloader = args.SshUser.HasValue()
-                ? bbsArchiveDownloaderFactory.CreateSshDownloader(ComputedArchiveDownloadHost, args.SshUser, args.SshPrivateKey, args.SshPort, args.BbsSharedHome)
-                : bbsArchiveDownloaderFactory.CreateSmbDownloader(ComputedArchiveDownloadHost, args.SmbUser, args.SmbPassword, args.SmbDomain, args.BbsSharedHome);
+                ? bbsArchiveDownloaderFactory.CreateSshDownloader(bbsHost, args.SshUser, args.SshPrivateKey, args.SshPort, args.BbsSharedHome)
+                : bbsArchiveDownloaderFactory.CreateSmbDownloader(bbsHost, args.SmbUser, args.SmbPassword, args.SmbDomain, args.BbsSharedHome);
         }
 
         var azureStorageConnectionString = args.AzureStorageConnectionString ?? environmentVariableProvider.AzureStorageConnectionString(false);

--- a/src/bbs2gh/Commands/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepoCommand.cs
@@ -213,11 +213,11 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         if (args.SshUser.HasValue() || args.SmbUser.HasValue())
         {
             var bbsArchiveDownloaderFactory = sp.GetRequiredService<BbsArchiveDownloaderFactory>();
-            var ArchiveDownloadHost = args.ArchiveDownloadHost.HasValue() ? args.ArchiveDownloadHost : new Uri(args.BbsServerUrl).Host;
+            var ComputedArchiveDownloadHost = args.ArchiveDownloadHost.HasValue() ? args.ArchiveDownloadHost : new Uri(args.BbsServerUrl).Host;
 
             bbsArchiveDownloader = args.SshUser.HasValue()
-                ? bbsArchiveDownloaderFactory.CreateSshDownloader(ArchiveDownloadHost, args.SshUser, args.SshPrivateKey, args.SshPort, args.BbsSharedHome)
-                : bbsArchiveDownloaderFactory.CreateSmbDownloader(ArchiveDownloadHost, args.SmbUser, args.SmbPassword, args.SmbDomain, args.BbsSharedHome);
+                ? bbsArchiveDownloaderFactory.CreateSshDownloader(ComputedArchiveDownloadHost, args.SshUser, args.SshPrivateKey, args.SshPort, args.BbsSharedHome)
+                : bbsArchiveDownloaderFactory.CreateSmbDownloader(ComputedArchiveDownloadHost, args.SmbUser, args.SmbPassword, args.SmbDomain, args.BbsSharedHome);
         }
 
         var azureStorageConnectionString = args.AzureStorageConnectionString ?? environmentVariableProvider.AzureStorageConnectionString(false);

--- a/src/bbs2gh/Commands/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepoCommand.cs
@@ -29,7 +29,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         AddOption(SshUser);
         AddOption(SshPrivateKey);
         AddOption(SshPort);
-        AddOption(SshHost);
+        AddOption(ArchiveDownloadHost);
         AddOption(SmbUser);
         AddOption(SmbPassword);
         AddOption(SmbDomain);
@@ -111,9 +111,9 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
 
     public Option<string> GithubRepo { get; } = new("--github-repo");
 
-    public Option<string> SshHost { get; } = new(
-        name: "--ssh-host",
-        description: "The host to use to connect to the Bitbucket Server via SSH. Defaults to the host from the Bitbucket Server URL (`--bbs-server-url`).");
+    public Option<string> ArchiveDownloadHost { get; } = new(
+        name: "--archive-download-host",
+        description: "The host to use to connect to the Bitbucket Server via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).");
 
     public Option<string> SshUser { get; } = new(
         name: "--ssh-user",
@@ -213,11 +213,11 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         if (args.SshUser.HasValue() || args.SmbUser.HasValue())
         {
             var bbsArchiveDownloaderFactory = sp.GetRequiredService<BbsArchiveDownloaderFactory>();
-            var sshHost = args.SshHost.HasValue() ? args.SshHost : new Uri(args.BbsServerUrl).Host;
+            var ArchiveDownloadHost = args.ArchiveDownloadHost.HasValue() ? args.ArchiveDownloadHost : new Uri(args.BbsServerUrl).Host;
 
             bbsArchiveDownloader = args.SshUser.HasValue()
-                ? bbsArchiveDownloaderFactory.CreateSshDownloader(sshHost, args.SshUser, args.SshPrivateKey, args.SshPort, args.BbsSharedHome)
-                : bbsArchiveDownloaderFactory.CreateSmbDownloader(sshHost, args.SmbUser, args.SmbPassword, args.SmbDomain, args.BbsSharedHome);
+                ? bbsArchiveDownloaderFactory.CreateSshDownloader(ArchiveDownloadHost, args.SshUser, args.SshPrivateKey, args.SshPort, args.BbsSharedHome)
+                : bbsArchiveDownloaderFactory.CreateSmbDownloader(ArchiveDownloadHost, args.SmbUser, args.SmbPassword, args.SmbDomain, args.BbsSharedHome);
         }
 
         var azureStorageConnectionString = args.AzureStorageConnectionString ?? environmentVariableProvider.AzureStorageConnectionString(false);
@@ -266,7 +266,7 @@ public class MigrateRepoCommandArgs
     public bool NoSslVerify { get; set; }
 
 
-    public string SshHost { get; set; }
+    public string ArchiveDownloadHost { get; set; }
     public string SshUser { get; set; }
     public string SshPrivateKey { get; set; }
     public int SshPort { get; set; } = 22;

--- a/src/bbs2gh/Commands/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepoCommand.cs
@@ -113,7 +113,8 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
 
     public Option<string> ArchiveDownloadHost { get; } = new(
         name: "--archive-download-host",
-        description: "The host to use to connect to the Bitbucket Server via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).");
+        description: "The host to use to connect to the Bitbucket Server via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).")
+    { IsHidden = true };
 
     public Option<string> SshUser { get; } = new(
         name: "--ssh-user",

--- a/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
+++ b/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
@@ -110,7 +110,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         var sshArchiveDownloadOptions = args.SshUser.HasValue()
             ? $" --ssh-user \"{args.SshUser}\" --ssh-private-key \"{args.SshPrivateKey}\"{(args.SshPort.HasValue() ? $" --ssh-port {args.SshPort}" : "")}{(args.ArchiveDownloadHost.HasValue() ? $" --archive-download-host {args.ArchiveDownloadHost}" : "")}" : "";
         var smbArchiveDownloadOptions = args.SmbUser.HasValue()
-            ? $" --smb-user \"{args.SmbUser}\"{(args.SmbDomain.HasValue() ? $" --smb-domain {args.SmbDomain}" : "")}"
+            ? $" --smb-user \"{args.SmbUser}\"{(args.SmbDomain.HasValue() ? $" --smb-domain {args.SmbDomain}" : "")}{(args.ArchiveDownloadHost.HasValue() ? $" --archive-download-host {args.ArchiveDownloadHost}" : "")}"
             : "";
         var bbsSharedHomeOption = args.BbsSharedHome.HasValue() ? $" --bbs-shared-home \"{args.BbsSharedHome}\"" : "";
         var awsBucketNameOption = args.AwsBucketName.HasValue() ? $" --aws-bucket-name \"{args.AwsBucketName}\"" : "";
@@ -155,7 +155,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
 
         if (args.ArchiveDownloadHost.HasValue())
         {
-            _log.LogInformation($"SSH HOST: {args.ArchiveDownloadHost}");
+            _log.LogInformation($"ARCHIVE DOWNLOAD HOST: {args.ArchiveDownloadHost}");
         }
 
         if (args.SshUser.HasValue())

--- a/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
+++ b/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
@@ -108,7 +108,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         var kerberosOption = args.Kerberos ? " --kerberos" : "";
         var verboseOption = args.Verbose ? " --verbose" : "";
         var sshArchiveDownloadOptions = args.SshUser.HasValue()
-            ? $" --ssh-user \"{args.SshUser}\" --ssh-private-key \"{args.SshPrivateKey}\"{(args.SshPort.HasValue() ? $" --ssh-port {args.SshPort}" : "")}{(args.SshHost.HasValue() ? $" --ssh-host {args.SshHost}" : "")}" : "";
+            ? $" --ssh-user \"{args.SshUser}\" --ssh-private-key \"{args.SshPrivateKey}\"{(args.SshPort.HasValue() ? $" --ssh-port {args.SshPort}" : "")}{(args.ArchiveDownloadHost.HasValue() ? $" --archive-download-host {args.ArchiveDownloadHost}" : "")}" : "";
         var smbArchiveDownloadOptions = args.SmbUser.HasValue()
             ? $" --smb-user \"{args.SmbUser}\"{(args.SmbDomain.HasValue() ? $" --smb-domain {args.SmbDomain}" : "")}"
             : "";
@@ -153,9 +153,9 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
             _log.LogInformation($"BBS PROJECT KEY: {args.BbsProjectKey}");
         }
 
-        if (args.SshHost.HasValue())
+        if (args.ArchiveDownloadHost.HasValue())
         {
-            _log.LogInformation($"SSH HOST: {args.SshHost}");
+            _log.LogInformation($"SSH HOST: {args.ArchiveDownloadHost}");
         }
 
         if (args.SshUser.HasValue())

--- a/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
+++ b/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
@@ -108,8 +108,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         var kerberosOption = args.Kerberos ? " --kerberos" : "";
         var verboseOption = args.Verbose ? " --verbose" : "";
         var sshArchiveDownloadOptions = args.SshUser.HasValue()
-            ? $" --ssh-user \"{args.SshUser}\" --ssh-private-key \"{args.SshPrivateKey}\"{(args.SshPort.HasValue() ? $" --ssh-port {args.SshPort}" : "")}"
-            : "";
+            ? $" --ssh-user \"{args.SshUser}\" --ssh-private-key \"{args.SshPrivateKey}\"{(args.SshPort.HasValue() ? $" --ssh-port {args.SshPort}" : "")}{(args.SshHost.HasValue() ? $" --ssh-host {args.SshHost}" : "")}" : "";
         var smbArchiveDownloadOptions = args.SmbUser.HasValue()
             ? $" --smb-user \"{args.SmbUser}\"{(args.SmbDomain.HasValue() ? $" --smb-domain {args.SmbDomain}" : "")}"
             : "";
@@ -152,6 +151,11 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         if (args.BbsProjectKey.HasValue())
         {
             _log.LogInformation($"BBS PROJECT KEY: {args.BbsProjectKey}");
+        }
+
+        if (args.SshHost.HasValue())
+        {
+            _log.LogInformation($"SSH HOST: {args.SshHost}");
         }
 
         if (args.SshUser.HasValue())

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -311,7 +311,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         if (args.SshUser.HasValue())
         {
-            _log.LogInformation($"SSH HOST: {args.ArchiveDownloadHost}");
+            _log.LogInformation($"ARCHIVE DOWNLOAD HOST: {args.ArchiveDownloadHost}");
         }
 
         if (args.SshUser.HasValue())

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -442,10 +442,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
                 }
             }
 
-            if (ShouldDownloadArchive(args))
-            {
-                ValidateDownloadOptions(args);
-            }
+            ValidateDownloadOptions(args);
         }
         else
         {
@@ -478,7 +475,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
     private void ValidateDownloadOptions(MigrateRepoCommandArgs args)
     {
-        var sshArgs = new[] { args.ArchiveDownloadHost, args.SshUser, args.SshPrivateKey };
+        var sshArgs = new[] { args.SshUser, args.SshPrivateKey };
         var smbArgs = new[] { args.SmbUser, args.SmbPassword };
         var shouldUseSsh = sshArgs.Any(arg => arg.HasValue());
         var shouldUseSmb = smbArgs.Any(arg => arg.HasValue());
@@ -496,6 +493,11 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         if ((args.SmbUser.HasValue() && GetSmbPassword(args).IsNullOrWhiteSpace()) || (args.SmbPassword.HasValue() && args.SmbUser.IsNullOrWhiteSpace()))
         {
             throw new OctoshiftCliException("Both --smb-user and --smb-password (or SMB_PASSWORD env. variable) must be specified for SMB download.");
+        }
+
+        if (args.ArchiveDownloadHost.HasValue() && !shouldUseSsh && !shouldUseSmb)
+        {
+            throw new OctoshiftCliException("--archive-download-host can only be provided if SSH or SMB download options are provided.");
         }
     }
 

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -136,7 +136,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
     private bool ShouldDownloadArchive(MigrateRepoCommandArgs args)
     {
-        return args.SshUser.HasValue() || args.SmbUser.HasValue();
+        return args.SshUser.HasValue() || args.SmbUser.HasValue() || args.SshHost.HasValue();
     }
 
     private bool ShouldUploadArchive(MigrateRepoCommandArgs args)
@@ -311,6 +311,11 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         if (args.SshUser.HasValue())
         {
+            _log.LogInformation($"SSH HOST: {args.SshHost}");
+        }
+
+        if (args.SshUser.HasValue())
+        {
             _log.LogInformation($"SSH USER: {args.SshUser}");
         }
 
@@ -454,7 +459,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
                 throw new OctoshiftCliException("--no-ssl-verify can only be provided with --bbs-server-url.");
             }
 
-            if (new[] { args.SshUser, args.SshPrivateKey, args.SmbUser, args.SmbPassword, args.SmbDomain }.Any(obj => obj.HasValue()))
+            if (new[] { args.SshUser, args.SshPrivateKey, args.SshHost, args.SmbUser, args.SmbPassword, args.SmbDomain }.Any(obj => obj.HasValue()))
             {
                 throw new OctoshiftCliException("SSH or SMB download options can only be provided with --bbs-server-url.");
             }
@@ -473,7 +478,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
     private void ValidateDownloadOptions(MigrateRepoCommandArgs args)
     {
-        var sshArgs = new[] { args.SshUser, args.SshPrivateKey };
+        var sshArgs = new[] { args.SshHost, args.SshUser, args.SshPrivateKey };
         var smbArgs = new[] { args.SmbUser, args.SmbPassword };
         var shouldUseSsh = sshArgs.Any(arg => arg.HasValue());
         var shouldUseSmb = smbArgs.Any(arg => arg.HasValue());

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -136,7 +136,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
     private bool ShouldDownloadArchive(MigrateRepoCommandArgs args)
     {
-        return args.SshUser.HasValue() || args.SmbUser.HasValue() || args.SshHost.HasValue();
+        return args.SshUser.HasValue() || args.SmbUser.HasValue();
     }
 
     private bool ShouldUploadArchive(MigrateRepoCommandArgs args)
@@ -311,7 +311,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         if (args.SshUser.HasValue())
         {
-            _log.LogInformation($"SSH HOST: {args.SshHost}");
+            _log.LogInformation($"SSH HOST: {args.ArchiveDownloadHost}");
         }
 
         if (args.SshUser.HasValue())
@@ -459,7 +459,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
                 throw new OctoshiftCliException("--no-ssl-verify can only be provided with --bbs-server-url.");
             }
 
-            if (new[] { args.SshUser, args.SshPrivateKey, args.SshHost, args.SmbUser, args.SmbPassword, args.SmbDomain }.Any(obj => obj.HasValue()))
+            if (new[] { args.SshUser, args.SshPrivateKey, args.ArchiveDownloadHost, args.SmbUser, args.SmbPassword, args.SmbDomain }.Any(obj => obj.HasValue()))
             {
                 throw new OctoshiftCliException("SSH or SMB download options can only be provided with --bbs-server-url.");
             }
@@ -478,7 +478,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
     private void ValidateDownloadOptions(MigrateRepoCommandArgs args)
     {
-        var sshArgs = new[] { args.SshHost, args.SshUser, args.SshPrivateKey };
+        var sshArgs = new[] { args.ArchiveDownloadHost, args.SshUser, args.SshPrivateKey };
         var smbArgs = new[] { args.SmbUser, args.SmbPassword };
         var shouldUseSsh = sshArgs.Any(arg => arg.HasValue());
         var shouldUseSmb = smbArgs.Any(arg => arg.HasValue());


### PR DESCRIPTION
`gh bbs2gh` can automatically connect to a Bitbucket Server instance using SSH or SMB to download the migration archive generated using the Bitbucket Server REST API.

Currently, our code assumes that the same hostname should be used for the SSH/SMB connection as the HTTP(S) connection to the REST API. This may not be the case - for example, the Bitbucket Server's UI and REST API may be exposed through a reverse proxy.

This adds an explicit `--archive-download-host` option to allow the host for the SSH/SMB connection to be configured directly - though we will continue to default to the current behaviour of using the host from the `--bbs-server-url`. 

This argument is hidden from the help docs for now, and we can unhide it in future if it turns out that lots of customers ask about it, rather than just one.

This issue was reported by a customer who was unable to use the CLI due to this limitation.

Fixes https://github.com/github/gh-gei/issues/873.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->