### PR TITLE
Added --keep-archive for GHES migrations

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,5 @@
 * Improve error message when `migrate-repo` is used with a target personal access token (PAT) with insufficient permissions
 * Ensure `--no-ssl-verify` flag is honored when downloading archives from GHES
 - `--bbs-project` and `--bbs-repo` are now both required in `gh bbs2gh migrate-repo` command when `--bbs-server-url` is set
+* Added `--keep-archive` flag to `gh gei migrate-repo` and `gh gei generate-script`. When migrating from GHES this will skip the step where we delete the archive from your machine, leaving it around as a local file.
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -38,7 +38,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var command = new GenerateScriptCommand();
             command.Should().NotBeNull();
             command.Name.Should().Be("generate-script");
-            command.Options.Count.Should().Be(17);
+            command.Options.Count.Should().Be(18);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-source-org", false);
             TestHelpers.VerifyCommandOption(command.Options, "ado-server-url", false, true);
@@ -57,6 +57,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
             TestHelpers.VerifyCommandOption(command.Options, "aws-bucket-name", false);
             TestHelpers.VerifyCommandOption(command.Options, "aws-region", false);
+            TestHelpers.VerifyCommandOption(command.Options, "keep-archive", false);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -13,7 +13,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             command.Should().NotBeNull();
             command.Name.Should().Be("migrate-repo");
-            command.Options.Count.Should().Be(25);
+            command.Options.Count.Should().Be(26);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-source-org", false);
             TestHelpers.VerifyCommandOption(command.Options, "ado-server-url", false, true);
@@ -39,6 +39,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false, true);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+            TestHelpers.VerifyCommandOption(command.Options, "keep-archive", false);
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Handlers/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Handlers/GenerateScriptCommandHandlerTests.cs
@@ -1434,6 +1434,39 @@ if ($Failed -ne 0) {
         }
 
         [Fact]
+        public async Task Sequential_Ghes_Single_Repo_Keep_Archive()
+        {
+            // Arrange
+            const string ghesApiUrl = "https://foo.com/api/v3";
+
+            _mockGithubApi
+                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .ReturnsAsync(new[] { REPO });
+
+            var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{REPO}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{REPO}\" --ghes-api-url \"{ghesApiUrl}\" --aws-bucket-name \"{AWS_BUCKET_NAME}\" --aws-region \"{AWS_REGION}\" --keep-archive --wait }}";
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                GithubTargetOrg = TARGET_ORG,
+                Output = new FileInfo("unit-test-output"),
+                GhesApiUrl = ghesApiUrl,
+                AwsBucketName = AWS_BUCKET_NAME,
+                AwsRegion = AWS_REGION,
+                Sequential = true,
+                KeepArchive = true
+            };
+            await _handler.Handle(args);
+
+            _script = TrimNonExecutableLines(_script);
+
+            // Assert
+            _script.Should().Be(expected);
+            _mockOctoLogger.Verify(m => m.LogInformation("KEEP ARCHIVE: true"));
+        }
+
+        [Fact]
         public async Task It_Throws_When_Aws_Bucket_Name_Is_Provided_But_Ghes_Api_Url_Is_Not()
         {
             // Arrange

--- a/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -1724,6 +1724,22 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         }
 
         [Fact]
+        public async Task Keep_Archive_Without_Ghes_Api_Url_Throws()
+        {
+            await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
+            {
+                SourceRepo = SOURCE_REPO,
+                GithubSourceOrg = SOURCE_ORG,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                KeepArchive = true
+            }))
+                .Should()
+                .ThrowAsync<OctoshiftCliException>()
+                .WithMessage("*--keep-archive*");
+        }
+
+        [Fact]
         public async Task Keep_Archive_Does_Not_Call_DeleteIfExists()
         {
             var githubOrgId = Guid.NewGuid().ToString();

--- a/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -1758,7 +1758,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     false,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, "", ""));
             _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
 
             _mockSourceGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);

--- a/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -1791,9 +1791,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             };
             await _handler.Handle(args);
 
-            _mockTargetGithubApi.Verify(x => x.GetMigration(migrationId));
-            _mockOctoLogger.Verify(x => x.LogInformation($"GHES API URL: {GHES_API_URL}"), Times.Once);
-            _mockOctoLogger.Verify(x => x.LogInformation("AZURE STORAGE CONNECTION STRING: ***"), Times.Once);
             _mockFileSystemProvider.Verify(x => x.DeleteIfExists(gitArchiveFilePath), Times.Never);
             _mockFileSystemProvider.Verify(x => x.DeleteIfExists(metadataArchiveFilePath), Times.Never);
         }

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -114,7 +114,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
         public Option<bool> KeepArchive { get; } = new("--keep-archive")
         {
-            Description = "Keeps the archive on the user machine after uploading to the storage account."
+            Description = "Keeps the archive on this machine after uploading to the blob storage account. Only applicable for migrations from GitHub Enterprise Server versions before 3.8.0."
         };
 
         public override GenerateScriptCommandHandler BuildHandler(GenerateScriptCommandArgs args, IServiceProvider sp)

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -37,7 +37,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(GithubSourcePat);
             AddOption(AdoPat);
             AddOption(Verbose);
-
             AddOption(KeepArchive);
         }
         public Option<string> GithubSourceOrg { get; } = new("--github-source-org")

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -37,6 +37,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(GithubSourcePat);
             AddOption(AdoPat);
             AddOption(Verbose);
+
+            AddOption(KeepArchive);
         }
         public Option<string> GithubSourceOrg { get; } = new("--github-source-org")
         {
@@ -111,6 +113,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
         public Option<bool> Verbose { get; } = new("--verbose");
 
+        public Option<bool> KeepArchive { get; } = new("--keep-archive")
+        {
+            Description = "Keeps the archive on the user machine after uploading to the storage account."
+        };
+
         public override GenerateScriptCommandHandler BuildHandler(GenerateScriptCommandArgs args, IServiceProvider sp)
         {
             if (args is null)
@@ -165,5 +172,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         public string GithubSourcePat { get; set; }
         public string AdoPat { get; set; }
         public bool Verbose { get; set; }
+        public bool KeepArchive { get; set; }
     }
 }

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -151,7 +151,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
 
         public Option<bool> KeepArchive { get; } = new("--keep-archive")
         {
-            Description = "Keeps the archive on the user machine after uploading to the storage account."
+            Description = "Keeps the archive on this machine after uploading to the blob storage account. Only applicable for migrations from GitHub Enterprise Server versions before 3.8.0."
         };
 
         public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, IServiceProvider sp)

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -43,6 +43,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(GithubTargetPat);
             AddOption(AdoPat);
             AddOption(Verbose);
+
+            AddOption(KeepArchive);
         }
 
         public Option<string> GithubSourceOrg { get; } = new("--github-source-org")
@@ -148,6 +150,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         };
         public Option<bool> Verbose { get; } = new("--verbose");
 
+        public Option<bool> KeepArchive { get; } = new("--keep-archive")
+        {
+            Description = "Keeps the archive on the user machine after uploading to the storage account."
+        };
+
         public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, IServiceProvider sp)
         {
             if (args is null)
@@ -222,5 +229,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         public string GithubSourcePat { get; set; }
         public string GithubTargetPat { get; set; }
         public string AdoPat { get; set; }
+        public bool KeepArchive { get; set; }
     }
 }

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -43,7 +43,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(GithubTargetPat);
             AddOption(AdoPat);
             AddOption(Verbose);
-
             AddOption(KeepArchive);
         }
 

--- a/src/gei/Handlers/GenerateScriptCommandHandler.cs
+++ b/src/gei/Handlers/GenerateScriptCommandHandler.cs
@@ -59,7 +59,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
 
         var script = args.GithubSourceOrg.IsNullOrWhiteSpace() ?
             await InvokeAdo(args.AdoServerUrl, args.AdoSourceOrg, args.AdoTeamProject, args.GithubTargetOrg, args.Sequential, args.DownloadMigrationLogs) :
-            await InvokeGithub(args.GithubSourceOrg, args.GithubTargetOrg, args.GhesApiUrl, args.AwsBucketName, args.AwsRegion, args.NoSslVerify, args.Sequential, args.SkipReleases, args.LockSourceRepo, args.DownloadMigrationLogs);
+            await InvokeGithub(args.GithubSourceOrg, args.GithubTargetOrg, args.GhesApiUrl, args.AwsBucketName, args.AwsRegion, args.NoSslVerify, args.Sequential, args.SkipReleases, args.LockSourceRepo, args.DownloadMigrationLogs, args.KeepArchive);
 
         if (script.HasValue() && args.Output.HasValue())
         {
@@ -171,9 +171,14 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         {
             _log.LogInformation($"AWS REGION: {args.AwsRegion}");
         }
+
+        if (args.KeepArchive)
+        {
+            _log.LogInformation($"KEEP ARCHIVE: true");
+        }
     }
 
-    private async Task<string> InvokeGithub(string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool sequential, bool skipReleases, bool lockSourceRepo, bool downloadMigrationLogs)
+    private async Task<string> InvokeGithub(string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool sequential, bool skipReleases, bool lockSourceRepo, bool downloadMigrationLogs, bool keepArchive)
     {
         var repos = await GetGithubRepos(_sourceGithubApi, githubSourceOrg);
         if (!repos.Any())
@@ -183,8 +188,8 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         }
 
         return sequential
-            ? GenerateSequentialGithubScript(repos, githubSourceOrg, githubTargetOrg, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, skipReleases, lockSourceRepo, downloadMigrationLogs)
-            : GenerateParallelGithubScript(repos, githubSourceOrg, githubTargetOrg, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, skipReleases, lockSourceRepo, downloadMigrationLogs);
+            ? GenerateSequentialGithubScript(repos, githubSourceOrg, githubTargetOrg, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, skipReleases, lockSourceRepo, downloadMigrationLogs, keepArchive)
+            : GenerateParallelGithubScript(repos, githubSourceOrg, githubTargetOrg, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, skipReleases, lockSourceRepo, downloadMigrationLogs, keepArchive);
     }
 
     private async Task<string> InvokeAdo(string adoServerUrl, string adoSourceOrg, string adoTeamProject, string githubTargetOrg, bool sequential, bool downloadMigrationLogs)
@@ -245,7 +250,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         return repos;
     }
 
-    private string GenerateSequentialGithubScript(IEnumerable<string> repos, string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool skipReleases, bool lockSourceRepo, bool downloadMigrationLogs)
+    private string GenerateSequentialGithubScript(IEnumerable<string> repos, string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool skipReleases, bool lockSourceRepo, bool downloadMigrationLogs, bool keepArchive)
     {
         var content = new StringBuilder();
 
@@ -258,7 +263,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
 
         foreach (var repo in repos)
         {
-            content.AppendLine(Exec(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, repo, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, true, skipReleases, lockSourceRepo)));
+            content.AppendLine(Exec(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, repo, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, true, skipReleases, lockSourceRepo, keepArchive)));
 
             if (downloadMigrationLogs)
             {
@@ -269,7 +274,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         return content.ToString();
     }
 
-    private string GenerateParallelGithubScript(IEnumerable<string> repos, string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool skipReleases, bool lockSourceRepo, bool downloadMigrationLogs)
+    private string GenerateParallelGithubScript(IEnumerable<string> repos, string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool skipReleases, bool lockSourceRepo, bool downloadMigrationLogs, bool keepArchive)
     {
         var content = new StringBuilder();
 
@@ -292,7 +297,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         // Queuing migrations
         foreach (var repo in repos)
         {
-            content.AppendLine($"$MigrationID = {ExecAndGetMigrationId(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, repo, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, false, skipReleases, lockSourceRepo))}");
+            content.AppendLine($"$MigrationID = {ExecAndGetMigrationId(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, repo, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, false, skipReleases, lockSourceRepo, keepArchive))}");
             content.AppendLine($"$RepoMigrations[\"{repo}\"] = $MigrationID");
             content.AppendLine();
         }
@@ -467,9 +472,9 @@ if ($Failed -ne 0) {
 
     private string GetGithubRepoName(string adoTeamProject, string repo) => $"{adoTeamProject}-{repo}".ReplaceInvalidCharactersWithDash();
 
-    private string MigrateGithubRepoScript(string githubSourceOrg, string githubTargetOrg, string repo, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool wait, bool skipReleases, bool lockSourceRepo)
+    private string MigrateGithubRepoScript(string githubSourceOrg, string githubTargetOrg, string repo, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool wait, bool skipReleases, bool lockSourceRepo, bool keepArchive)
     {
-        var ghesRepoOptions = ghesApiUrl.HasValue() ? GetGhesRepoOptions(ghesApiUrl, awsBucketName, awsRegion, noSslVerify) : null;
+        var ghesRepoOptions = ghesApiUrl.HasValue() ? GetGhesRepoOptions(ghesApiUrl, awsBucketName, awsRegion, noSslVerify, keepArchive) : null;
 
         return $"gh gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\"{(!string.IsNullOrEmpty(ghesRepoOptions) ? $" {ghesRepoOptions}" : string.Empty)}{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? " --wait" : string.Empty)}{(skipReleases ? " --skip-releases" : string.Empty)}{(lockSourceRepo ? " --lock-source-repo" : string.Empty)}";
     }
@@ -479,9 +484,9 @@ if ($Failed -ne 0) {
         return $"gh gei migrate-repo{(adoServerUrl.HasValue() ? $" --ado-server-url \"{adoServerUrl}\"" : string.Empty)} --ado-source-org \"{adoSourceOrg}\" --ado-team-project \"{teamProject}\" --source-repo \"{adoRepo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{githubRepo}\"{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? " --wait" : string.Empty)}";
     }
 
-    private string GetGhesRepoOptions(string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify)
+    private string GetGhesRepoOptions(string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool keepArchive)
     {
-        return $"--ghes-api-url \"{ghesApiUrl}\"{(awsBucketName.HasValue() ? $" --aws-bucket-name \"{awsBucketName}\"" : "")}{(awsRegion.HasValue() ? $" --aws-region \"{awsRegion}\"" : "")}{(noSslVerify ? " --no-ssl-verify" : string.Empty)}";
+        return $"--ghes-api-url \"{ghesApiUrl}\"{(awsBucketName.HasValue() ? $" --aws-bucket-name \"{awsBucketName}\"" : "")}{(awsRegion.HasValue() ? $" --aws-region \"{awsRegion}\"" : "")}{(noSslVerify ? " --no-ssl-verify" : string.Empty)}{(keepArchive ? " --keep-archive" : string.Empty)}";
     }
 
     private string WaitForMigrationScript(string repoMigrationKey = null) => $"gh gei wait-for-migration --migration-id $RepoMigrations[\"{repoMigrationKey}\"]";

--- a/src/gei/Handlers/GenerateScriptCommandHandler.cs
+++ b/src/gei/Handlers/GenerateScriptCommandHandler.cs
@@ -174,7 +174,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
 
         if (args.KeepArchive)
         {
-            _log.LogInformation($"KEEP ARCHIVE: true");
+            _log.LogInformation("KEEP ARCHIVE: true");
         }
     }
 

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -238,7 +238,9 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
     private void DeleteArchive(string path, bool keepArchive)
     {
         if(keepArchive)
+        {
             return;
+        }
 
         try
         {

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -237,7 +237,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
     private void DeleteArchive(string path, bool keepArchive)
     {
-        if(keepArchive)
+        if (keepArchive)
         {
             return;
         }

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -416,6 +416,11 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             _log.LogInformation("LOCK SOURCE REPO: true");
         }
 
+        if (args.KeepArchive)
+        {
+            _log.LogInformation("KEEP ARCHIVE: true");
+        }
+
         LogAwsOptions(args);
     }
 

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -80,7 +80,8 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
               args.AwsBucketName,
               args.SkipReleases,
               args.LockSourceRepo,
-              blobCredentialsRequired
+              blobCredentialsRequired,
+              args.KeepArchive
             );
 
             if (blobCredentialsRequired)
@@ -184,7 +185,8 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
       string awsBucketName,
       bool skipReleases,
       bool lockSourceRepo,
-      bool blobCredentialsRequired)
+      bool blobCredentialsRequired,
+      bool keepArchive)
     {
         var gitDataArchiveId = await _sourceGithubApi.StartGitArchiveGeneration(githubSourceOrg, sourceRepo);
         _log.LogInformation($"Archive generation of git data started with id: {gitDataArchiveId}");
@@ -228,13 +230,16 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         }
         finally
         {
-            DeleteArchive(gitArchiveFilePath);
-            DeleteArchive(metadataArchiveFilePath);
+            DeleteArchive(gitArchiveFilePath, keepArchive);
+            DeleteArchive(metadataArchiveFilePath, keepArchive);
         }
     }
 
-    private void DeleteArchive(string path)
+    private void DeleteArchive(string path, bool keepArchive)
     {
+        if(keepArchive)
+            return;
+
         try
         {
             _fileSystemProvider.DeleteIfExists(path);

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -506,7 +506,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
                 if (args.KeepArchive)
                 {
-                    _log.LogWarning("GHES version is 3.8.0 or later, there is no archive to keep on the user machine.");
+                    _log.LogWarning("Ignoring --keep-archive option because there is no downloaded archive to keep");
                 }
 
                 return;
@@ -585,6 +585,11 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             if (args.NoSslVerify)
             {
                 throw new OctoshiftCliException("--ghes-api-url must be specified when --no-ssl-verify is specified.");
+            }
+
+            if (args.KeepArchive)
+            {
+                throw new OctoshiftCliException("--ghes-api-url must be specified when --keep-archive is specified.");
             }
         }
     }

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -230,18 +230,16 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         }
         finally
         {
-            DeleteArchive(gitArchiveFilePath, keepArchive);
-            DeleteArchive(metadataArchiveFilePath, keepArchive);
+            if (!keepArchive)
+            {
+                DeleteArchive(gitArchiveFilePath);
+                DeleteArchive(metadataArchiveFilePath);
+            }
         }
     }
 
-    private void DeleteArchive(string path, bool keepArchive)
+    private void DeleteArchive(string path)
     {
-        if (keepArchive)
-        {
-            return;
-        }
-
         try
         {
             _fileSystemProvider.DeleteIfExists(path);

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -503,6 +503,12 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
                 {
                     _log.LogInformation("GHES version is 3.8.0 or later, no need to set cloud storage options here, please set in GHES admin UI.");
                 }
+
+                if (args.KeepArchive)
+                {
+                    _log.LogWarning("GHES version is 3.8.0 or later, there is no archive to keep on the user machine.");
+                }
+
                 return;
             }
 


### PR DESCRIPTION
Solved #831
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->