### PR TITLE
Improve error message when `CreateMigrationSource` is called with insufficient permissions

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+* Improve error message when `migrate-repo` is used with a target personal access token (PAT) with insufficient permissions

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -221,9 +221,17 @@ namespace OctoshiftCLI
                 operationName = "createMigrationSource"
             };
 
-            var data = await _client.PostGraphQLAsync(url, payload);
+            try
+            {
+                var data = await _client.PostGraphQLAsync(url, payload);
+                return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
+            }
+            catch (OctoshiftCliException ex)
+            {
+                CheckForMissingPermissionsError(ex);
 
-            return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
+                throw;
+            }
         }
 
         public virtual async Task<string> CreateBbsMigrationSource(string orgId)
@@ -246,9 +254,17 @@ namespace OctoshiftCLI
                 operationName = "createMigrationSource"
             };
 
-            var data = await _client.PostGraphQLAsync(url, payload);
+            try
+            {
+                var data = await _client.PostGraphQLAsync(url, payload);
+                return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
+            }
+            catch (OctoshiftCliException ex)
+            {
+                CheckForMissingPermissionsError(ex);
 
-            return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
+                throw;
+            }
         }
 
         public virtual async Task<string> CreateGhecMigrationSource(string orgId)
@@ -271,9 +287,17 @@ namespace OctoshiftCLI
                 operationName = "createMigrationSource"
             };
 
-            var data = await _client.PostGraphQLAsync(url, payload);
+            try
+            {
+                var data = await _client.PostGraphQLAsync(url, payload);
+                return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
+            }
+            catch (OctoshiftCliException ex)
+            {
+                CheckForMissingPermissionsError(ex);
 
-            return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
+                throw;
+            }
         }
 
         public virtual async Task<string> StartMigration(string migrationSourceId, string sourceRepoUrl, string orgId, string repo, string sourceToken, string targetToken, string gitArchiveUrl = null, string metadataArchiveUrl = null, bool skipReleases = false, bool lockSource = false)
@@ -821,5 +845,13 @@ namespace OctoshiftCLI
                 EndColumn = (int)alertLocation["details"]["end_column"],
                 BlobSha = (string)alertLocation["details"]["blob_sha"],
             };
+
+        private void CheckForMissingPermissionsError(OctoshiftCliException exception)
+        {
+            if (exception.Message.Contains("not have the correct permissions to execute"))
+            {
+                throw new OctoshiftCliException(exception.Message + ". Please check that (a) you are an organization owner or you have been granted the migrator role and (b) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
+            }
+        }
     }
 }

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -18,6 +18,8 @@ namespace OctoshiftCLI
         private readonly string _apiUrl;
         private readonly RetryPolicy _retryPolicy;
 
+        private const string INSUFFICIENT_PERMISSIONS_HELP_MESSAGE = ". Please check that (a) you are an organization owner or you have been granted the migrator role and (b) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.";
+
         public GithubApi(GithubClient client, string apiUrl, RetryPolicy retryPolicy)
         {
             _client = client;
@@ -226,11 +228,9 @@ namespace OctoshiftCLI
                 var data = await _client.PostGraphQLAsync(url, payload);
                 return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
             }
-            catch (OctoshiftCliException ex)
+            catch (OctoshiftCliException ex) when (ex.Message.Contains("not have the correct permissions to execute"))
             {
-                CheckForMissingPermissionsError(ex);
-
-                throw;
+                throw new OctoshiftCliException(ex.Message + INSUFFICIENT_PERMISSIONS_HELP_MESSAGE, ex);
             }
         }
 
@@ -259,11 +259,9 @@ namespace OctoshiftCLI
                 var data = await _client.PostGraphQLAsync(url, payload);
                 return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
             }
-            catch (OctoshiftCliException ex)
+            catch (OctoshiftCliException ex) when (ex.Message.Contains("not have the correct permissions to execute"))
             {
-                CheckForMissingPermissionsError(ex);
-
-                throw;
+                throw new OctoshiftCliException(ex.Message + INSUFFICIENT_PERMISSIONS_HELP_MESSAGE, ex);
             }
         }
 
@@ -292,11 +290,9 @@ namespace OctoshiftCLI
                 var data = await _client.PostGraphQLAsync(url, payload);
                 return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
             }
-            catch (OctoshiftCliException ex)
+            catch (OctoshiftCliException ex) when (ex.Message.Contains("not have the correct permissions to execute"))
             {
-                CheckForMissingPermissionsError(ex);
-
-                throw;
+                throw new OctoshiftCliException(ex.Message + INSUFFICIENT_PERMISSIONS_HELP_MESSAGE, ex);
             }
         }
 
@@ -845,13 +841,5 @@ namespace OctoshiftCLI
                 EndColumn = (int)alertLocation["details"]["end_column"],
                 BlobSha = (string)alertLocation["details"]["blob_sha"],
             };
-
-        private void CheckForMissingPermissionsError(OctoshiftCliException exception)
-        {
-            if (exception.Message.Contains("not have the correct permissions to execute"))
-            {
-                throw new OctoshiftCliException(exception.Message + ". Please check that (a) you are an organization owner or you have been granted the migrator role and (b) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
-            }
-        }
     }
 }

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -704,6 +704,29 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task CreateAdoMigrationSource_Decorates_Missing_Permissions_Error()
+        {
+            // Arrange
+            const string url = "https://api.github.com/graphql";
+            const string orgId = "ORG_ID";
+            const string adoServerUrl = "https://ado.contoso.com";
+            var payload =
+                "{\"query\":\"mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $type: MigrationSourceType!) " +
+                "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, type: $type}) { migrationSource { id, name, url, type } } }\"" +
+                $",\"variables\":{{\"name\":\"Azure DevOps Source\",\"url\":\"{adoServerUrl}\",\"ownerId\":\"{orgId}\",\"type\":\"AZURE_DEVOPS\"}},\"operationName\":\"createMigrationSource\"}}";
+
+            _githubClientMock
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Throws(new OctoshiftCliException("monalisa does not have the correct permissions to execute `CreateMigrationSource`"));
+
+            // Act
+            await _githubApi.Invoking(api => api.CreateAdoMigrationSource(orgId, adoServerUrl))
+                .Should()
+                .ThrowExactlyAsync<OctoshiftCliException>()
+                .WithMessage("monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that (a) you are an organization owner or you have been granted the migrator role and (b) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
+        }
+
+        [Fact]
         public async Task CreateBbsMigrationSource_Returns_New_Migration_Source_Id()
         {
             // Arrange
@@ -740,6 +763,28 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
+        public async Task CreateBbsMigrationSource_Decorates_Missing_Permissions_Error()
+        {
+            // Arrange
+            const string url = "https://api.github.com/graphql";
+            const string orgId = "ORG_ID";
+            var payload =
+                "{\"query\":\"mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $type: MigrationSourceType!) " +
+                "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, type: $type}) { migrationSource { id, name, url, type } } }\"" +
+                $",\"variables\":{{\"name\":\"Bitbucket Server Source\",\"url\":\"https://not-used\",\"ownerId\":\"{orgId}\",\"type\":\"BITBUCKET_SERVER\"}},\"operationName\":\"createMigrationSource\"}}";
+
+            _githubClientMock
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Throws(new OctoshiftCliException("monalisa does not have the correct permissions to execute `CreateMigrationSource`"));
+
+            // Act
+            await _githubApi.Invoking(api => api.CreateBbsMigrationSource(orgId))
+                .Should()
+                .ThrowExactlyAsync<OctoshiftCliException>()
+                .WithMessage("monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that (a) you are an organization owner or you have been granted the migrator role and (b) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
+        }
+
+        [Fact]
         public async Task CreateGhecMigrationSource_Returns_New_Migration_Source_Id()
         {
             // Arrange
@@ -773,6 +818,28 @@ namespace OctoshiftCLI.Tests
 
             // Assert
             expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
+        }
+
+        [Fact]
+        public async Task CreateGhecMigrationSource_Decorates_Missing_Permissions_Error()
+        {
+            // Arrange
+            const string url = "https://api.github.com/graphql";
+            const string orgId = "ORG_ID";
+            var payload =
+                "{\"query\":\"mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $type: MigrationSourceType!) " +
+                "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, type: $type}) { migrationSource { id, name, url, type } } }\"" +
+                $",\"variables\":{{\"name\":\"GHEC Source\",\"url\":\"https://github.com\",\"ownerId\":\"{orgId}\",\"type\":\"GITHUB_ARCHIVE\"}},\"operationName\":\"createMigrationSource\"}}";
+
+            _githubClientMock
+                .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+                .Throws(new OctoshiftCliException("monalisa does not have the correct permissions to execute `CreateMigrationSource`"));
+
+            // Act
+            await _githubApi.Invoking(api => api.CreateGhecMigrationSource(orgId))
+                .Should()
+                .ThrowExactlyAsync<OctoshiftCliException>()
+                .WithMessage("monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that (a) you are an organization owner or you have been granted the migrator role and (b) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
         }
 
         [Fact]


### PR DESCRIPTION
When using the `migrate-repo` command, under the hood, we call the `CreateMigrationSource` GraphQL mutation. If your target PAT doesn't have the correct permissions, the API returns an error like this:

> timrogers does not have the correct permissions to execute `CreateMigrationSource`

This error isn't very helpful, as it doesn't tell you what you should do to fix it. It would be great to have a more instructive error message that guides the customer on where they've gone wrong.

It isn't trivial for us to change the actual error returned by the API because it is part of GitHub's shared GraphQL logic. This takes a different approach: catching the specific error and decorating the message with some more helpful guidance on what to do next.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->