### PR TITLE
Optimize build for integration tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -151,7 +151,7 @@ jobs:
       fail-fast: false
       matrix:
         runner-os: [windows-latest, ubuntu-latest, macos-latest]
-        source-vcs: [Ado, Bbs, Ghes, Github]
+        source-vcs: [AdoBasic, AdoCsv, Bbs, Ghes, Github]
     runs-on: ${{ matrix.runner-os }}
     concurrency: integration-test-${{ matrix.source-vcs }}-${{ matrix.runner-os }}
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -129,6 +129,9 @@ jobs:
         SKIP_WINDOWS: "true"
         SKIP_LINUX: "true"
 
+    - name: Display structure of downloaded files
+      run: ls -lR
+
     - name: Upload Binaries
       uses: actions/upload-artifact@v2
       with:
@@ -169,7 +172,7 @@ jobs:
         path: dist
 
     - name: Display structure of downloaded files
-      run: ls -R
+      run: ls -lR
 
     - name: Copy binary to root (linux)
       if: matrix.runner-os == 'ubuntu-latest'
@@ -205,7 +208,7 @@ jobs:
       shell: pwsh
 
     - name: Display structure of downloaded files
-      run: ls -R
+      run: ls -lR
 
     - name: Install gh-gei extension
       run: gh extension install .

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -256,6 +256,7 @@ jobs:
       with:
         files: "**/*-tests.xml"
         check_name: "Integration Test Results - ${{ matrix.source-vcs }}"
+        comment_mode: off
     
     - name: Upload test logs
       uses: actions/upload-artifact@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -90,8 +90,63 @@ jobs:
         name: Event File
         path: ${{ github.event_path }}
 
+  build-for-integration-test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'github'
+    strategy:
+      fail-fast: false
+      matrix:
+        target-os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Build Artifacts (Linux)
+      if: matrix.target-os == 'ubuntu-latest'
+      run: ./publish.ps1
+      shell: pwsh
+      env:
+        SKIP_WINDOWS: "true"
+        SKIP_MACOS: "true"
+
+    - name: Build Artifacts (Windows)
+      if: matrix.target-os == 'windows-latest'
+      run: ./publish.ps1
+      shell: pwsh
+      env:
+        SKIP_LINUX: "true"
+        SKIP_MACOS: "true"
+
+    - name: Build Artifacts (MacOS)
+      if: matrix.target-os == 'macos-latest'
+      run: ./publish.ps1
+      shell: pwsh
+      env:
+        SKIP_WINDOWS: "true"
+        SKIP_LINUX: "true"
+
+    - name: Upload Binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: binaries-${{ matrix.target-os }}
+        path: |
+          dist/linux-x64/ado2gh-linux-amd64
+          dist/linux-x64/bbs2gh-linux-amd64
+          dist/linux-x64/gei-linux-amd64
+          dist/osx-x64/ado2gh-darwin-amd64
+          dist/osx-x64/bbs2gh-darwin-amd64
+          dist/osx-x64/gei-darwin-amd64
+          dist/win-x64/ado2gh-windows-amd64.exe
+          dist/win-x64/bbs2gh-windows-amd64.exe
+          dist/win-x64/gei-windows-amd64.exe
+
   integration-test:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'github'
+    needs: [ build-for-integration-test ]
     strategy:
       fail-fast: false
       matrix:
@@ -130,16 +185,6 @@ jobs:
       env:
         SKIP_WINDOWS: "true"
         SKIP_LINUX: "true"
-
-    - name: Upload Binaries
-      uses: actions/upload-artifact@v2
-      if: matrix.runner-os == 'ubuntu-latest' && matrix.source-vcs == 'Ghec'
-      with:
-        name: publish-binaries
-        path: |
-          dist/
-          !dist/*.tar.gz
-          !dist/*.zip
 
     - name: Copy binary to root (linux)
       if: matrix.runner-os == 'ubuntu-latest'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -204,6 +204,9 @@ jobs:
         Copy-Item ./dist/osx-x64/bbs2gh-darwin-amd64 ./gh-bbs2gh/gh-bbs2gh
       shell: pwsh
 
+    - name: Display structure of downloaded files
+      run: ls -R
+
     - name: Install gh-gei extension
       run: gh extension install .
       shell: pwsh
@@ -224,6 +227,12 @@ jobs:
       working-directory: ./gh-bbs2gh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+    - name: debug gh extension list
+      run: gh extension list
+
+    - name: debug gh gei
+      run: gh gei --help
 
     - name: Integration Test
       env: 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -129,9 +129,6 @@ jobs:
         SKIP_WINDOWS: "true"
         SKIP_LINUX: "true"
 
-    - name: Display structure of downloaded files
-      run: ls -lR
-
     - name: Upload Binaries
       uses: actions/upload-artifact@v2
       with:
@@ -170,9 +167,6 @@ jobs:
       with:
         name: binaries-${{ matrix.runner-os }}
         path: dist
-
-    - name: Display structure of downloaded files
-      run: ls -lR
 
     - name: Copy binary to root (linux)
       if: matrix.runner-os == 'ubuntu-latest'
@@ -213,9 +207,6 @@ jobs:
         chmod +x ./gh-ado2gh/gh-ado2gh
         chmod +x ./gh-bbs2gh/gh-bbs2gh
 
-    - name: Display structure of downloaded files
-      run: ls -lR
-
     - name: Install gh-gei extension
       run: gh extension install .
       shell: pwsh
@@ -237,16 +228,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-    - name: debug gh extension list
-      run: gh extension list
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: debug gh gei
-      run: gh gei --help
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Integration Test
       env: 
         ADO_PAT: ${{ secrets.ADO_PAT }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -162,29 +162,14 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
-    - name: Build Artifacts (Linux)
-      if: matrix.runner-os == 'ubuntu-latest'
-      run: ./publish.ps1
-      shell: pwsh
-      env:
-        SKIP_WINDOWS: "true"
-        SKIP_MACOS: "true"
+    - name: Download Binaries
+      uses: actions/download-artifact@v3
+      with:
+        name: binaries-${{ matrix.runner-os }}
+        path: dist
 
-    - name: Build Artifacts (Windows)
-      if: matrix.runner-os == 'windows-latest'
-      run: ./publish.ps1
-      shell: pwsh
-      env:
-        SKIP_LINUX: "true"
-        SKIP_MACOS: "true"
-
-    - name: Build Artifacts (MacOS)
-      if: matrix.runner-os == 'macos-latest'
-      run: ./publish.ps1
-      shell: pwsh
-      env:
-        SKIP_WINDOWS: "true"
-        SKIP_LINUX: "true"
+    - name: Display structure of downloaded files
+      run: ls -R
 
     - name: Copy binary to root (linux)
       if: matrix.runner-os == 'ubuntu-latest'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -230,9 +230,13 @@ jobs:
       
     - name: debug gh extension list
       run: gh extension list
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: debug gh gei
       run: gh gei --help
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Integration Test
       env: 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -90,7 +90,7 @@ jobs:
         name: Event File
         path: ${{ github.event_path }}
 
-  build-for-integration-test:
+  build-for-e2e-test:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'github'
     strategy:
       fail-fast: false
@@ -144,9 +144,9 @@ jobs:
           dist/win-x64/bbs2gh-windows-amd64.exe
           dist/win-x64/gei-windows-amd64.exe
 
-  integration-test:
+  e2e-test:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'github'
-    needs: [ build-for-integration-test ]
+    needs: [ build-for-e2e-test ]
     strategy:
       fail-fast: false
       matrix:
@@ -279,7 +279,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [ build, integration-test ]
+    needs: [ build, e2e-test ]
     environment: PUBLISH_RELEASE
 
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -227,7 +227,7 @@ jobs:
       working-directory: ./gh-bbs2gh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
     - name: Integration Test
       env: 
         ADO_PAT: ${{ secrets.ADO_PAT }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -207,6 +207,12 @@ jobs:
         Copy-Item ./dist/osx-x64/bbs2gh-darwin-amd64 ./gh-bbs2gh/gh-bbs2gh
       shell: pwsh
 
+    - name: Set execute permissions
+      run: |
+        chmod +x ./gh-gei/gh-gei
+        chmod +x ./gh-ado2gh/gh-ado2gh
+        chmod +x ./gh-bbs2gh/gh-bbs2gh
+
     - name: Display structure of downloaded files
       run: ls -lR
 

--- a/src/OctoshiftCLI.IntegrationTests/AdoBasicToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoBasicToGithub.cs
@@ -27,52 +27,52 @@ namespace OctoshiftCLI.IntegrationTests
 
             await retryPolicy.Retry(async () =>
             {
-                await _helper.ResetAdoTestEnvironment(adoOrg);
-                await _helper.ResetGithubTestEnvironment(githubOrg);
+                await Helper.ResetAdoTestEnvironment(adoOrg);
+                await Helper.ResetGithubTestEnvironment(githubOrg);
 
-                await _helper.CreateTeamProject(adoOrg, teamProject1);
-                var commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject1, adoRepo1);
-                await _helper.CreatePipeline(adoOrg, teamProject1, adoRepo1, pipeline1, commitId);
+                await Helper.CreateTeamProject(adoOrg, teamProject1);
+                var commitId = await Helper.InitializeAdoRepo(adoOrg, teamProject1, adoRepo1);
+                await Helper.CreatePipeline(adoOrg, teamProject1, adoRepo1, pipeline1, commitId);
 
-                await _helper.CreateTeamProject(adoOrg, teamProject2);
-                commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject2, adoRepo2);
-                await _helper.CreatePipeline(adoOrg, teamProject2, adoRepo2, pipeline2, commitId);
+                await Helper.CreateTeamProject(adoOrg, teamProject2);
+                commitId = await Helper.InitializeAdoRepo(adoOrg, teamProject2, adoRepo2);
+                await Helper.CreatePipeline(adoOrg, teamProject2, adoRepo2, pipeline2, commitId);
             });
 
-            await _helper.RunAdoToGithubCliMigration($"generate-script --github-org {githubOrg} --ado-org {adoOrg} --all", _tokens);
+            await Helper.RunAdoToGithubCliMigration($"generate-script --github-org {githubOrg} --ado-org {adoOrg} --all", Tokens);
 
-            _helper.AssertNoErrorInLogs(_startTime);
+            Helper.AssertNoErrorInLogs(StartTime);
 
-            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject1}-{teamProject1}", $"https://dev.azure.com/{adoOrg}/{teamProject1}/_workitems/edit/<num>/");
-            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject2}-{teamProject2}", $"https://dev.azure.com/{adoOrg}/{teamProject2}/_workitems/edit/<num>/");
-            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject1, adoRepo1);
-            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject2, adoRepo2);
-            await _helper.AssertAdoRepoLocked(adoOrg, teamProject1, adoRepo1);
-            await _helper.AssertAdoRepoLocked(adoOrg, teamProject2, adoRepo2);
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Maintainers");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Admins");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Maintainers");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Admins");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-Maintainers");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-Admins");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-Maintainers");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-Admins");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-{teamProject1}", "maintain");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-{teamProject1}", "admin");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-{teamProject2}", "maintain");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-{teamProject2}", "admin");
-            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject1);
-            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject2);
-            await _helper.AssertPipelineRewired(adoOrg, teamProject1, pipeline1, githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertPipelineRewired(adoOrg, teamProject2, pipeline2, githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject1);
-            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject2);
-            _helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject1}-{teamProject1}");
-            _helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject2}-{teamProject2}");
+            await Helper.AssertGithubRepoExists(githubOrg, $"{teamProject1}-{teamProject1}");
+            await Helper.AssertGithubRepoExists(githubOrg, $"{teamProject2}-{teamProject2}");
+            await Helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject1}-{teamProject1}");
+            await Helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject2}-{teamProject2}");
+            await Helper.AssertAutolinkConfigured(githubOrg, $"{teamProject1}-{teamProject1}", $"https://dev.azure.com/{adoOrg}/{teamProject1}/_workitems/edit/<num>/");
+            await Helper.AssertAutolinkConfigured(githubOrg, $"{teamProject2}-{teamProject2}", $"https://dev.azure.com/{adoOrg}/{teamProject2}/_workitems/edit/<num>/");
+            await Helper.AssertAdoRepoDisabled(adoOrg, teamProject1, adoRepo1);
+            await Helper.AssertAdoRepoDisabled(adoOrg, teamProject2, adoRepo2);
+            await Helper.AssertAdoRepoLocked(adoOrg, teamProject1, adoRepo1);
+            await Helper.AssertAdoRepoLocked(adoOrg, teamProject2, adoRepo2);
+            await Helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Maintainers");
+            await Helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Admins");
+            await Helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Maintainers");
+            await Helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Admins");
+            await Helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-Maintainers");
+            await Helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-Admins");
+            await Helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-Maintainers");
+            await Helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-Admins");
+            await Helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-{teamProject1}", "maintain");
+            await Helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-{teamProject1}", "admin");
+            await Helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-{teamProject2}", "maintain");
+            await Helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-{teamProject2}", "admin");
+            await Helper.AssertServiceConnectionWasShared(adoOrg, teamProject1);
+            await Helper.AssertServiceConnectionWasShared(adoOrg, teamProject2);
+            await Helper.AssertPipelineRewired(adoOrg, teamProject1, pipeline1, githubOrg, $"{teamProject1}-{teamProject1}");
+            await Helper.AssertPipelineRewired(adoOrg, teamProject2, pipeline2, githubOrg, $"{teamProject2}-{teamProject2}");
+            await Helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject1);
+            await Helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject2);
+            Helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject1}-{teamProject1}");
+            Helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject2}-{teamProject2}");
         }
     }
 }

--- a/src/OctoshiftCLI.IntegrationTests/AdoBasicToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoBasicToGithub.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/OctoshiftCLI.IntegrationTests/AdoBasicToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoBasicToGithub.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OctoshiftCLI.IntegrationTests
+{
+    [Collection("Integration Tests")]
+    public class AdoBasicToGithub : AdoToGithub
+    {
+        public AdoBasicToGithub(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Basic()
+        {
+            var adoOrg = $"gei-e2e-testing-basic-{TestHelper.GetOsName()}";
+            var githubOrg = $"e2e-testing-ado-basic-{TestHelper.GetOsName()}";
+            var teamProject1 = "gei-e2e-1";
+            var teamProject2 = "gei-e2e-2";
+            var adoRepo1 = teamProject1;
+            var adoRepo2 = teamProject2;
+            var pipeline1 = "pipeline1";
+            var pipeline2 = "pipeline2";
+
+            var retryPolicy = new RetryPolicy(null);
+
+            await retryPolicy.Retry(async () =>
+            {
+                await _helper.ResetAdoTestEnvironment(adoOrg);
+                await _helper.ResetGithubTestEnvironment(githubOrg);
+
+                await _helper.CreateTeamProject(adoOrg, teamProject1);
+                var commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject1, adoRepo1);
+                await _helper.CreatePipeline(adoOrg, teamProject1, adoRepo1, pipeline1, commitId);
+
+                await _helper.CreateTeamProject(adoOrg, teamProject2);
+                commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject2, adoRepo2);
+                await _helper.CreatePipeline(adoOrg, teamProject2, adoRepo2, pipeline2, commitId);
+            });
+
+            await _helper.RunAdoToGithubCliMigration($"generate-script --github-org {githubOrg} --ado-org {adoOrg} --all", _tokens);
+
+            _helper.AssertNoErrorInLogs(_startTime);
+
+            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject1}-{teamProject1}");
+            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject2}-{teamProject2}");
+            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject1}-{teamProject1}");
+            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject2}-{teamProject2}");
+            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject1}-{teamProject1}", $"https://dev.azure.com/{adoOrg}/{teamProject1}/_workitems/edit/<num>/");
+            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject2}-{teamProject2}", $"https://dev.azure.com/{adoOrg}/{teamProject2}/_workitems/edit/<num>/");
+            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject1, adoRepo1);
+            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject2, adoRepo2);
+            await _helper.AssertAdoRepoLocked(adoOrg, teamProject1, adoRepo1);
+            await _helper.AssertAdoRepoLocked(adoOrg, teamProject2, adoRepo2);
+            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Maintainers");
+            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Admins");
+            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Maintainers");
+            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Admins");
+            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-Maintainers");
+            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-Admins");
+            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-Maintainers");
+            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-Admins");
+            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-{teamProject1}", "maintain");
+            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-{teamProject1}", "admin");
+            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-{teamProject2}", "maintain");
+            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-{teamProject2}", "admin");
+            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject1);
+            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject2);
+            await _helper.AssertPipelineRewired(adoOrg, teamProject1, pipeline1, githubOrg, $"{teamProject1}-{teamProject1}");
+            await _helper.AssertPipelineRewired(adoOrg, teamProject2, pipeline2, githubOrg, $"{teamProject2}-{teamProject2}");
+            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject1);
+            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject2);
+            _helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject1}-{teamProject1}");
+            _helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject2}-{teamProject2}");
+        }
+    }
+}

--- a/src/OctoshiftCLI.IntegrationTests/AdoCsvToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoCsvToGithub.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 namespace OctoshiftCLI.IntegrationTests
 {
     [Collection("Integration Tests")]
-    public class AdoCsvToGithub : IDisposable
+    public class AdoCsvToGithub : AdoToGithub
     {
         public AdoCsvToGithub(ITestOutputHelper output) : base(output)
         {

--- a/src/OctoshiftCLI.IntegrationTests/AdoCsvToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoCsvToGithub.cs
@@ -27,53 +27,53 @@ namespace OctoshiftCLI.IntegrationTests
 
             await retryPolicy.Retry(async () =>
             {
-                await _helper.ResetAdoTestEnvironment(adoOrg);
-                await _helper.ResetGithubTestEnvironment(githubOrg);
+                await Helper.ResetAdoTestEnvironment(adoOrg);
+                await Helper.ResetGithubTestEnvironment(githubOrg);
 
-                await _helper.CreateTeamProject(adoOrg, teamProject1);
-                var commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject1, adoRepo1);
-                await _helper.CreatePipeline(adoOrg, teamProject1, adoRepo1, pipeline1, commitId);
+                await Helper.CreateTeamProject(adoOrg, teamProject1);
+                var commitId = await Helper.InitializeAdoRepo(adoOrg, teamProject1, adoRepo1);
+                await Helper.CreatePipeline(adoOrg, teamProject1, adoRepo1, pipeline1, commitId);
 
-                await _helper.CreateTeamProject(adoOrg, teamProject2);
-                commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject2, adoRepo2);
-                await _helper.CreatePipeline(adoOrg, teamProject2, adoRepo2, pipeline2, commitId);
+                await Helper.CreateTeamProject(adoOrg, teamProject2);
+                commitId = await Helper.InitializeAdoRepo(adoOrg, teamProject2, adoRepo2);
+                await Helper.CreatePipeline(adoOrg, teamProject2, adoRepo2, pipeline2, commitId);
             });
 
-            await _helper.RunCliCommand($"ado2gh inventory-report --ado-org {adoOrg}", "gh", _tokens);
-            await _helper.RunAdoToGithubCliMigration($"generate-script --github-org {githubOrg} --ado-org {adoOrg} --all --repo-list repos.csv", _tokens);
+            await Helper.RunCliCommand($"ado2gh inventory-report --ado-org {adoOrg}", "gh", Tokens);
+            await Helper.RunAdoToGithubCliMigration($"generate-script --github-org {githubOrg} --ado-org {adoOrg} --all --repo-list repos.csv", Tokens);
 
-            _helper.AssertNoErrorInLogs(_startTime);
+            Helper.AssertNoErrorInLogs(StartTime);
 
-            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject1}-{teamProject1}", $"https://dev.azure.com/{adoOrg}/{teamProject1}/_workitems/edit/<num>/");
-            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject2}-{teamProject2}", $"https://dev.azure.com/{adoOrg}/{teamProject2}/_workitems/edit/<num>/");
-            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject1, adoRepo1);
-            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject2, adoRepo2);
-            await _helper.AssertAdoRepoLocked(adoOrg, teamProject1, adoRepo1);
-            await _helper.AssertAdoRepoLocked(adoOrg, teamProject2, adoRepo2);
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Maintainers");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Admins");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Maintainers");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Admins");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-Maintainers");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-Admins");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-Maintainers");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-Admins");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-{teamProject1}", "maintain");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-{teamProject1}", "admin");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-{teamProject2}", "maintain");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-{teamProject2}", "admin");
-            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject1);
-            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject2);
-            await _helper.AssertPipelineRewired(adoOrg, teamProject1, pipeline1, githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertPipelineRewired(adoOrg, teamProject2, pipeline2, githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject1);
-            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject2);
-            _helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject1}-{teamProject1}");
-            _helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject2}-{teamProject2}");
+            await Helper.AssertGithubRepoExists(githubOrg, $"{teamProject1}-{teamProject1}");
+            await Helper.AssertGithubRepoExists(githubOrg, $"{teamProject2}-{teamProject2}");
+            await Helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject1}-{teamProject1}");
+            await Helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject2}-{teamProject2}");
+            await Helper.AssertAutolinkConfigured(githubOrg, $"{teamProject1}-{teamProject1}", $"https://dev.azure.com/{adoOrg}/{teamProject1}/_workitems/edit/<num>/");
+            await Helper.AssertAutolinkConfigured(githubOrg, $"{teamProject2}-{teamProject2}", $"https://dev.azure.com/{adoOrg}/{teamProject2}/_workitems/edit/<num>/");
+            await Helper.AssertAdoRepoDisabled(adoOrg, teamProject1, adoRepo1);
+            await Helper.AssertAdoRepoDisabled(adoOrg, teamProject2, adoRepo2);
+            await Helper.AssertAdoRepoLocked(adoOrg, teamProject1, adoRepo1);
+            await Helper.AssertAdoRepoLocked(adoOrg, teamProject2, adoRepo2);
+            await Helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Maintainers");
+            await Helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Admins");
+            await Helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Maintainers");
+            await Helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Admins");
+            await Helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-Maintainers");
+            await Helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-Admins");
+            await Helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-Maintainers");
+            await Helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-Admins");
+            await Helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-{teamProject1}", "maintain");
+            await Helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-{teamProject1}", "admin");
+            await Helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-{teamProject2}", "maintain");
+            await Helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-{teamProject2}", "admin");
+            await Helper.AssertServiceConnectionWasShared(adoOrg, teamProject1);
+            await Helper.AssertServiceConnectionWasShared(adoOrg, teamProject2);
+            await Helper.AssertPipelineRewired(adoOrg, teamProject1, pipeline1, githubOrg, $"{teamProject1}-{teamProject1}");
+            await Helper.AssertPipelineRewired(adoOrg, teamProject2, pipeline2, githubOrg, $"{teamProject2}-{teamProject2}");
+            await Helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject1);
+            await Helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject2);
+            Helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject1}-{teamProject1}");
+            Helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject2}-{teamProject2}");
         }
     }
 }

--- a/src/OctoshiftCLI.IntegrationTests/AdoCsvToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoCsvToGithub.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/OctoshiftCLI.IntegrationTests/AdoCsvToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoCsvToGithub.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OctoshiftCLI.IntegrationTests
+{
+    [Collection("Integration Tests")]
+    public class AdoCsvToGithub : IDisposable
+    {
+        public AdoCsvToGithub(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task With_Inventory_Report_Csv()
+        {
+            var adoOrg = $"gei-e2e-testing-csv-{TestHelper.GetOsName()}";
+            var githubOrg = $"e2e-testing-ado-csv-{TestHelper.GetOsName()}";
+            var teamProject1 = "gei-e2e-1";
+            var teamProject2 = "gei-e2e-2";
+            var adoRepo1 = teamProject1;
+            var adoRepo2 = teamProject2;
+            var pipeline1 = "pipeline1";
+            var pipeline2 = "pipeline2";
+
+            var retryPolicy = new RetryPolicy(null);
+
+            await retryPolicy.Retry(async () =>
+            {
+                await _helper.ResetAdoTestEnvironment(adoOrg);
+                await _helper.ResetGithubTestEnvironment(githubOrg);
+
+                await _helper.CreateTeamProject(adoOrg, teamProject1);
+                var commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject1, adoRepo1);
+                await _helper.CreatePipeline(adoOrg, teamProject1, adoRepo1, pipeline1, commitId);
+
+                await _helper.CreateTeamProject(adoOrg, teamProject2);
+                commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject2, adoRepo2);
+                await _helper.CreatePipeline(adoOrg, teamProject2, adoRepo2, pipeline2, commitId);
+            });
+
+            await _helper.RunCliCommand($"ado2gh inventory-report --ado-org {adoOrg}", "gh", _tokens);
+            await _helper.RunAdoToGithubCliMigration($"generate-script --github-org {githubOrg} --ado-org {adoOrg} --all --repo-list repos.csv", _tokens);
+
+            _helper.AssertNoErrorInLogs(_startTime);
+
+            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject1}-{teamProject1}");
+            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject2}-{teamProject2}");
+            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject1}-{teamProject1}");
+            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject2}-{teamProject2}");
+            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject1}-{teamProject1}", $"https://dev.azure.com/{adoOrg}/{teamProject1}/_workitems/edit/<num>/");
+            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject2}-{teamProject2}", $"https://dev.azure.com/{adoOrg}/{teamProject2}/_workitems/edit/<num>/");
+            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject1, adoRepo1);
+            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject2, adoRepo2);
+            await _helper.AssertAdoRepoLocked(adoOrg, teamProject1, adoRepo1);
+            await _helper.AssertAdoRepoLocked(adoOrg, teamProject2, adoRepo2);
+            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Maintainers");
+            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Admins");
+            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Maintainers");
+            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Admins");
+            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-Maintainers");
+            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-Admins");
+            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-Maintainers");
+            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-Admins");
+            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-{teamProject1}", "maintain");
+            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-{teamProject1}", "admin");
+            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-{teamProject2}", "maintain");
+            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-{teamProject2}", "admin");
+            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject1);
+            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject2);
+            await _helper.AssertPipelineRewired(adoOrg, teamProject1, pipeline1, githubOrg, $"{teamProject1}-{teamProject1}");
+            await _helper.AssertPipelineRewired(adoOrg, teamProject2, pipeline2, githubOrg, $"{teamProject2}-{teamProject2}");
+            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject1);
+            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject2);
+            _helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject1}-{teamProject1}");
+            _helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject2}-{teamProject2}");
+        }
+    }
+}

--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -13,13 +13,13 @@ namespace OctoshiftCLI.IntegrationTests
         private readonly HttpClient _versionClient;
         private bool disposedValue;
 
-        protected TestHelper _helper { get; }
-        protected Dictionary<string, string> _tokens { get; }
-        protected DateTime _startTime { get; }
+        protected TestHelper Helper { get; }
+        protected Dictionary<string, string> Tokens { get; }
+        protected DateTime StartTime { get; }
 
         protected AdoToGithub(ITestOutputHelper output)
         {
-            _startTime = DateTime.Now;
+            StartTime = DateTime.Now;
             _output = output;
 
             var logger = new OctoLogger(x => { }, x => _output.WriteLine(x), x => { }, x => { });
@@ -36,13 +36,13 @@ namespace OctoshiftCLI.IntegrationTests
             var githubClient = new GithubClient(logger, _githubHttpClient, new VersionChecker(_versionClient, logger), new RetryPolicy(logger), new DateTimeProvider(), githubToken);
             var githubApi = new GithubApi(githubClient, "https://api.github.com", new RetryPolicy(logger));
 
-            _tokens = new Dictionary<string, string>
+            Tokens = new Dictionary<string, string>
             {
                 ["GH_PAT"] = githubToken,
                 ["ADO_PAT"] = adoToken
             };
 
-            _helper = new TestHelper(_output, adoApi, githubApi, adoClient, githubClient);
+            Helper = new TestHelper(_output, adoApi, githubApi, adoClient, githubClient);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -7,18 +7,17 @@ using Xunit.Abstractions;
 
 namespace OctoshiftCLI.IntegrationTests
 {
-    [Collection("Integration Tests")]
-    public class AdoToGithub : IDisposable
+    public abstract class AdoToGithub : IDisposable
     {
-        private readonly ITestOutputHelper _output;
-        private readonly TestHelper _helper;
+        protected readonly ITestOutputHelper _output;
+        protected readonly TestHelper _helper;
 
-        private readonly HttpClient _adoHttpClient;
-        private readonly HttpClient _githubHttpClient;
-        private readonly HttpClient _versionClient;
-        private bool disposedValue;
-        private readonly Dictionary<string, string> _tokens;
-        private readonly DateTime _startTime;
+        protected readonly HttpClient _adoHttpClient;
+        protected readonly HttpClient _githubHttpClient;
+        protected readonly HttpClient _versionClient;
+        protected bool disposedValue;
+        protected readonly Dictionary<string, string> _tokens;
+        protected readonly DateTime _startTime;
 
         public AdoToGithub(ITestOutputHelper output)
         {
@@ -46,135 +45,6 @@ namespace OctoshiftCLI.IntegrationTests
             };
 
             _helper = new TestHelper(_output, adoApi, githubApi, adoClient, githubClient);
-        }
-
-        [Fact]
-        public async Task With_Inventory_Report_Csv()
-        {
-            var adoOrg = $"gei-e2e-testing-{TestHelper.GetOsName()}";
-            var githubOrg = $"e2e-testing-ado-{TestHelper.GetOsName()}";
-            var teamProject1 = "gei-e2e-1";
-            var teamProject2 = "gei-e2e-2";
-            var adoRepo1 = teamProject1;
-            var adoRepo2 = teamProject2;
-            var pipeline1 = "pipeline1";
-            var pipeline2 = "pipeline2";
-
-            var retryPolicy = new RetryPolicy(null);
-
-            await retryPolicy.Retry(async () =>
-            {
-                await _helper.ResetAdoTestEnvironment(adoOrg);
-                await _helper.ResetGithubTestEnvironment(githubOrg);
-
-                await _helper.CreateTeamProject(adoOrg, teamProject1);
-                var commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject1, adoRepo1);
-                await _helper.CreatePipeline(adoOrg, teamProject1, adoRepo1, pipeline1, commitId);
-
-                await _helper.CreateTeamProject(adoOrg, teamProject2);
-                commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject2, adoRepo2);
-                await _helper.CreatePipeline(adoOrg, teamProject2, adoRepo2, pipeline2, commitId);
-            });
-
-            await _helper.RunCliCommand($"ado2gh inventory-report --ado-org {adoOrg}", "gh", _tokens);
-            await _helper.RunAdoToGithubCliMigration($"generate-script --github-org {githubOrg} --ado-org {adoOrg} --all --repo-list repos.csv", _tokens);
-
-            _helper.AssertNoErrorInLogs(_startTime);
-
-            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject1}-{teamProject1}", $"https://dev.azure.com/{adoOrg}/{teamProject1}/_workitems/edit/<num>/");
-            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject2}-{teamProject2}", $"https://dev.azure.com/{adoOrg}/{teamProject2}/_workitems/edit/<num>/");
-            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject1, adoRepo1);
-            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject2, adoRepo2);
-            await _helper.AssertAdoRepoLocked(adoOrg, teamProject1, adoRepo1);
-            await _helper.AssertAdoRepoLocked(adoOrg, teamProject2, adoRepo2);
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Maintainers");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Admins");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Maintainers");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Admins");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-Maintainers");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-Admins");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-Maintainers");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-Admins");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-{teamProject1}", "maintain");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-{teamProject1}", "admin");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-{teamProject2}", "maintain");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-{teamProject2}", "admin");
-            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject1);
-            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject2);
-            await _helper.AssertPipelineRewired(adoOrg, teamProject1, pipeline1, githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertPipelineRewired(adoOrg, teamProject2, pipeline2, githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject1);
-            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject2);
-            _helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject1}-{teamProject1}");
-            _helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject2}-{teamProject2}");
-        }
-
-        [Fact]
-        public async Task Basic()
-        {
-            var adoOrg = $"gei-e2e-testing-{TestHelper.GetOsName()}";
-            var githubOrg = $"e2e-testing-ado-{TestHelper.GetOsName()}";
-            var teamProject1 = "gei-e2e-1";
-            var teamProject2 = "gei-e2e-2";
-            var adoRepo1 = teamProject1;
-            var adoRepo2 = teamProject2;
-            var pipeline1 = "pipeline1";
-            var pipeline2 = "pipeline2";
-
-            var retryPolicy = new RetryPolicy(null);
-
-            await retryPolicy.Retry(async () =>
-            {
-                await _helper.ResetAdoTestEnvironment(adoOrg);
-                await _helper.ResetGithubTestEnvironment(githubOrg);
-
-                await _helper.CreateTeamProject(adoOrg, teamProject1);
-                var commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject1, adoRepo1);
-                await _helper.CreatePipeline(adoOrg, teamProject1, adoRepo1, pipeline1, commitId);
-
-                await _helper.CreateTeamProject(adoOrg, teamProject2);
-                commitId = await _helper.InitializeAdoRepo(adoOrg, teamProject2, adoRepo2);
-                await _helper.CreatePipeline(adoOrg, teamProject2, adoRepo2, pipeline2, commitId);
-            });
-
-            await _helper.RunAdoToGithubCliMigration($"generate-script --github-org {githubOrg} --ado-org {adoOrg} --all", _tokens);
-
-            _helper.AssertNoErrorInLogs(_startTime);
-
-            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertGithubRepoExists(githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertGithubRepoInitialized(githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject1}-{teamProject1}", $"https://dev.azure.com/{adoOrg}/{teamProject1}/_workitems/edit/<num>/");
-            await _helper.AssertAutolinkConfigured(githubOrg, $"{teamProject2}-{teamProject2}", $"https://dev.azure.com/{adoOrg}/{teamProject2}/_workitems/edit/<num>/");
-            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject1, adoRepo1);
-            await _helper.AssertAdoRepoDisabled(adoOrg, teamProject2, adoRepo2);
-            await _helper.AssertAdoRepoLocked(adoOrg, teamProject1, adoRepo1);
-            await _helper.AssertAdoRepoLocked(adoOrg, teamProject2, adoRepo2);
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Maintainers");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject1}-Admins");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Maintainers");
-            await _helper.AssertGithubTeamCreated(githubOrg, $"{teamProject2}-Admins");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-Maintainers");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-Admins");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-Maintainers");
-            await _helper.AssertGithubTeamIdpLinked(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-Admins");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Maintainers", $"{teamProject1}-{teamProject1}", "maintain");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject1}-Admins", $"{teamProject1}-{teamProject1}", "admin");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Maintainers", $"{teamProject2}-{teamProject2}", "maintain");
-            await _helper.AssertGithubTeamHasRepoRole(githubOrg, $"{teamProject2}-Admins", $"{teamProject2}-{teamProject2}", "admin");
-            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject1);
-            await _helper.AssertServiceConnectionWasShared(adoOrg, teamProject2);
-            await _helper.AssertPipelineRewired(adoOrg, teamProject1, pipeline1, githubOrg, $"{teamProject1}-{teamProject1}");
-            await _helper.AssertPipelineRewired(adoOrg, teamProject2, pipeline2, githubOrg, $"{teamProject2}-{teamProject2}");
-            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject1);
-            await _helper.AssertBoardsIntegrationConfigured(adoOrg, teamProject2);
-            _helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject1}-{teamProject1}");
-            _helper.AssertMigrationLogFileExists(githubOrg, $"{teamProject2}-{teamProject2}");
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoToGithub.cs
@@ -1,25 +1,23 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Threading.Tasks;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace OctoshiftCLI.IntegrationTests
 {
     public abstract class AdoToGithub : IDisposable
     {
-        protected readonly ITestOutputHelper _output;
-        protected readonly TestHelper _helper;
+        private readonly ITestOutputHelper _output;
+        private readonly HttpClient _adoHttpClient;
+        private readonly HttpClient _githubHttpClient;
+        private readonly HttpClient _versionClient;
+        private bool disposedValue;
 
-        protected readonly HttpClient _adoHttpClient;
-        protected readonly HttpClient _githubHttpClient;
-        protected readonly HttpClient _versionClient;
-        protected bool disposedValue;
-        protected readonly Dictionary<string, string> _tokens;
-        protected readonly DateTime _startTime;
+        protected TestHelper _helper { get; }
+        protected Dictionary<string, string> _tokens { get; }
+        protected DateTime _startTime { get; }
 
-        public AdoToGithub(ITestOutputHelper output)
+        protected AdoToGithub(ITestOutputHelper output)
         {
             _startTime = DateTime.Now;
             _output = output;


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Related to #714 

Did a couple of things to improve the speed of the build:

1. Instead of compiling in every one of the (now) 15 integration test jobs, we'll have another set of 3 jobs run right before them that will compile for all 3 targets (win/linux/mac) but they will all be compiled ON ubuntu (where the compilation runs WAY faster than trying to compile on macos). We'll store the compiled binaries as build artifacts and the integration test jobs will download the binaries they need.

2. The ADO tests were the slowest of the bunch, and conveniently we have 2 completely independent ADO integration tests that take roughly equal amounts of run time. I sliced them up so it runs each of the 2 ADO tests in parallel. This required setting up a handful of new ADO/GH orgs so each test has it's own environment(s).

I also turned off the option to create PR comments with integration test results. When it was just one comment for all INT tests it was nice, but now it will be 5 separate comments for each "slice" of tests that we run. If we want to know the status of integration tests we can look in the build/checks associated with the PR.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->