### PR TITLE
Continue execution of `gh gei reclaim-mannequin --csv` if a username doesn't exist

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,3 @@
 * Improve error message when `migrate-repo` is used with a target personal access token (PAT) with insufficient permissions
 * Ensure `--no-ssl-verify` flag is honored when downloading archives from GHES
-- `--bbs-project` and `--bbs-repo` are now both required in `gh bbs2gh migrate-repo` command when `--bbs-server-url` is set
-
+* `--bbs-project` and `--bbs-repo` are now both required in `gh bbs2gh migrate-repo` command when `--bbs-server-url` is set

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,4 @@
-* Improve error message when `migrate-repo` is used with a target personal access token (PAT) with insufficient permissions
-* Ensure `--no-ssl-verify` flag is honored when downloading archives from GHES
-* `--bbs-project` and `--bbs-repo` are now both required in `gh bbs2gh migrate-repo` command when `--bbs-server-url` is set
-* Continue to next mannequin mapping in `gh gei reclaim-mannequin --csv` if a username doesn't exist
+- Improve error message when `migrate-repo` is used with a target personal access token (PAT) with insufficient permissions
+- Ensure `--no-ssl-verify` flag is honored when downloading archives from GHES
+- `--bbs-project` and `--bbs-repo` are now both required in `gh bbs2gh migrate-repo` command when `--bbs-server-url` is set
+- Continue to next mannequin mapping in `gh gei reclaim-mannequin --csv` if a username doesn't exist

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
 * Improve error message when `migrate-repo` is used with a target personal access token (PAT) with insufficient permissions
 * Ensure `--no-ssl-verify` flag is honored when downloading archives from GHES
 * `--bbs-project` and `--bbs-repo` are now both required in `gh bbs2gh migrate-repo` command when `--bbs-server-url` is set
+* Continue to next mannequin mapping in `gh gei reclaim-mannequin --csv` if a username doesn't exist

--- a/src/Octoshift/ReclaimService.cs
+++ b/src/Octoshift/ReclaimService.cs
@@ -162,9 +162,13 @@ namespace Octoshift
                     continue;
                 }
 
-                var claimantId = await _githubApi.GetUserId(claimantLogin);
+                string claimantId;
 
-                if (claimantId == null)
+                try
+                {
+                    claimantId = await _githubApi.GetUserId(claimantLogin);
+                }
+                catch (OctoshiftCliException ex) when (ex.Message.Contains("Could not resolve to a User with the login"))
                 {
                     _log.LogError($"Claimant \"{claimantLogin}\" not found. Will ignore it.");
                     continue;

--- a/src/OctoshiftCLI.Tests/Octoshift/ReclaimServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/ReclaimServiceTests.cs
@@ -437,7 +437,7 @@ namespace OctoshiftCLI.Tests.Octoshift
 
             _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
             _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
-            _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN)).Returns(Task.FromResult<string>(null));
+            _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN)).Throws(new OctoshiftCliException($"Could not resolve to a User with the login of '{MANNEQUIN_LOGIN}'."));
 
             var csvContent = new string[] {
                 HEADER,


### PR DESCRIPTION
Since https://github.com/github/gh-gei/pull/868, the `gh gei reclaim-mannequin` command with the `--csv` option now exits if it is given a username that doesn't exist, rather than printing a warning and continuing to the next mapping in the CSV.

This fixes that behaviour, handling the `OctoshiftCliException` thrown by `GithubApi` and printing a warning instead of exiting.

Fixes https://github.com/github/gh-gei/issues/897.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->