### PR TITLE
Apply previous optimizations to integration-tests.yml

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,11 +8,65 @@ on:
         required: true
 
 jobs:
-  integration-test:
+  build-for-e2e-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        target-os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Build Artifacts (Linux)
+      if: matrix.target-os == 'ubuntu-latest'
+      run: ./publish.ps1
+      shell: pwsh
+      env:
+        SKIP_WINDOWS: "true"
+        SKIP_MACOS: "true"
+
+    - name: Build Artifacts (Windows)
+      if: matrix.target-os == 'windows-latest'
+      run: ./publish.ps1
+      shell: pwsh
+      env:
+        SKIP_LINUX: "true"
+        SKIP_MACOS: "true"
+
+    - name: Build Artifacts (MacOS)
+      if: matrix.target-os == 'macos-latest'
+      run: ./publish.ps1
+      shell: pwsh
+      env:
+        SKIP_WINDOWS: "true"
+        SKIP_LINUX: "true"
+
+    - name: Upload Binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: binaries-${{ matrix.target-os }}
+        path: |
+          dist/linux-x64/ado2gh-linux-amd64
+          dist/linux-x64/bbs2gh-linux-amd64
+          dist/linux-x64/gei-linux-amd64
+          dist/osx-x64/ado2gh-darwin-amd64
+          dist/osx-x64/bbs2gh-darwin-amd64
+          dist/osx-x64/gei-darwin-amd64
+          dist/win-x64/ado2gh-windows-amd64.exe
+          dist/win-x64/bbs2gh-windows-amd64.exe
+          dist/win-x64/gei-windows-amd64.exe
+
+  e2e-test:
+    needs: [ build-for-e2e-test ]
     strategy:
       matrix:
         runner-os: [windows-latest, ubuntu-latest, macos-latest]
-        source-vcs: [Ado, Bbs, Ghes, Github]
+        source-vcs: [AdoBasic, AdoCsv, Bbs, Ghes, Github]
     runs-on: ${{ matrix.runner-os }}
     concurrency: integration-test-${{ matrix.source-vcs }}-${{ matrix.runner-os }}
     steps:
@@ -33,39 +87,11 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
-    - name: Build Artifacts
-      if: matrix.runner-os == 'ubuntu-latest'
-      run: ./publish.ps1
-      shell: pwsh
-      env:
-        SKIP_WINDOWS: "true"
-        SKIP_MACOS: "true"
-
-    - name: Build Artifacts
-      if: matrix.runner-os == 'windows-latest'
-      run: ./publish.ps1
-      shell: pwsh
-      env:
-        SKIP_LINUX: "true"
-        SKIP_MACOS: "true"
-
-    - name: Build Artifacts
-      if: matrix.runner-os == 'macos-latest'
-      run: ./publish.ps1
-      shell: pwsh
-      env:
-        SKIP_WINDOWS: "true"
-        SKIP_LINUX: "true"
-
-    - name: Upload Binaries
-      uses: actions/upload-artifact@v2
-      if: matrix.runner-os == 'ubuntu-latest' && matrix.source-vcs == 'Ghec'
+    - name: Download Binaries
+      uses: actions/download-artifact@v3
       with:
-        name: publish-binaries
-        path: |
-          dist/
-          !dist/*.tar.gz
-          !dist/*.zip
+        name: binaries-${{ matrix.runner-os }}
+        path: dist
 
     - name: Copy binary to root (linux)
       if: matrix.runner-os == 'ubuntu-latest'
@@ -99,6 +125,12 @@ jobs:
         Copy-Item ./dist/osx-x64/ado2gh-darwin-amd64 ./gh-ado2gh/gh-ado2gh
         Copy-Item ./dist/osx-x64/bbs2gh-darwin-amd64 ./gh-bbs2gh/gh-bbs2gh
       shell: pwsh
+
+    - name: Set execute permissions
+      run: |
+        chmod +x ./gh-gei/gh-gei
+        chmod +x ./gh-ado2gh/gh-ado2gh
+        chmod +x ./gh-bbs2gh/gh-bbs2gh
 
     - name: Install gh-gei extension
       run: gh extension install .
@@ -143,13 +175,13 @@ jobs:
         LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:${{ github.workspace }}/src/OctoshiftCLI.IntegrationTests/bin/Debug/net6.0/runtimes/ubuntu.18.04-x64/native'
       run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --filter "${{ matrix.source-vcs }}ToGithub" --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
 
-
     - name: Publish Integration Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1
       if: always() && matrix.runner-os == 'ubuntu-latest'
       with:
         files: "**/*-tests.xml"
         check_name: "Integration Test Results - ${{ matrix.source-vcs }}"
+        comment_mode: off
         commit: ${{ env.PR_SHA }}
     
     - name: Upload test logs


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

In the previous PR #896 those changes should also have been applied to `integration-tests.yml` but I forgot. This PR fixes that.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->