### PR TITLE
Add more helpful error message when BBS download archive is not found

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,6 @@
 - Improve error message when `migrate-repo` is used with a target personal access token (PAT) with insufficient permissions
 - Ensure `--no-ssl-verify` flag is honored when downloading archives from GHES
 - `--bbs-project` and `--bbs-repo` are now both required in `gh bbs2gh migrate-repo` command when `--bbs-server-url` is set
-* Added `--keep-archive` flag to `gh gei migrate-repo` and `gh gei generate-script`. When migrating from GHES this will skip the step where we delete the archive from your machine, leaving it around as a local file.
+- Added `--keep-archive` flag to `gh gei migrate-repo` and `gh gei generate-script`. When migrating from GHES this will skip the step where we delete the archive from your machine, leaving it around as a local file.
 - Continue to next mannequin mapping in `gh gei reclaim-mannequin --csv` if a username doesn't exist
+- Display more helpful message when the Bitbucket export archive is not found when using `gh bbs2gh migrate-repo`

--- a/src/bbs2gh/Services/BbsSmbArchiveDownloader.cs
+++ b/src/bbs2gh/Services/BbsSmbArchiveDownloader.cs
@@ -208,10 +208,8 @@ public sealed class BbsSmbArchiveDownloader : IBbsArchiveDownloader
             : throw new OctoshiftCliException(
                 $"Couldn't create SMB file handle for \"{sharedFilePath}\" (Status Code: {status})." +
                 (IsObjectPathNotFoundStatus(status) && BbsSharedHomeDirectory is BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_WINDOWS
-                    ? " This usually happens because the archive could not be found at the default Bitbucket's shared home " +
-                      $"which is located in \"{BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_LINUX}\" if Bitbucket is installed on a Linux machine " +
-                      $"or in \"{BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_WINDOWS}\" if installed on a Windows machine. " +
-                      "You can point to a non default shared directory by specifying the --bbs-shared-home option."
+                    ? "This most likely means that your Bitbucket instance uses a non-default Bitbucket shared home directory, so we couldn't find your archive. " +
+                      "You can point the CLI to a non-default shared directory by specifying the --bbs-shared-home option."
                     : ""));
     }
 

--- a/src/bbs2gh/Services/BbsSmbArchiveDownloader.cs
+++ b/src/bbs2gh/Services/BbsSmbArchiveDownloader.cs
@@ -205,7 +205,14 @@ public sealed class BbsSmbArchiveDownloader : IBbsArchiveDownloader
 
         return IsSuccessStatus(status)
             ? sharedFileHandle
-            : throw new OctoshiftCliException($"Couldn't create SMB file handle for \"{sharedFilePath}\" (Status Code: {status}).");
+            : throw new OctoshiftCliException(
+                $"Couldn't create SMB file handle for \"{sharedFilePath}\" (Status Code: {status})." +
+                (IsObjectPathNotFoundStatus(status) && BbsSharedHomeDirectory is BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_WINDOWS
+                    ? " This usually happens because the archive could not be found at the default Bitbucket's shared home " +
+                      $"which is located in \"{BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_LINUX}\" if Bitbucket is installed on a Linux machine " +
+                      $"or in \"{BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_WINDOWS}\" if installed on a Windows machine. " +
+                      "You can point to a non default shared directory by specifying the --bbs-shared-home option."
+                    : ""));
     }
 
     private long? GetFileSize(ISMBFileStore fileStore, object sharedFileHandle)
@@ -218,4 +225,6 @@ public sealed class BbsSmbArchiveDownloader : IBbsArchiveDownloader
     private bool IsSuccessStatus(NTStatus status) => status is NTStatus.STATUS_SUCCESS;
 
     private bool IsEndOfFileStatus(NTStatus status) => status is NTStatus.STATUS_END_OF_FILE;
+
+    private bool IsObjectPathNotFoundStatus(NTStatus status) => status is NTStatus.STATUS_OBJECT_PATH_NOT_FOUND;
 }

--- a/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
+++ b/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
@@ -91,7 +91,14 @@ public sealed class BbsSshArchiveDownloader : IBbsArchiveDownloader, IDisposable
 
         if (!_sftpClient.Exists(sourceExportArchiveFullPath))
         {
-            throw new OctoshiftCliException($"Source export archive ({sourceExportArchiveFullPath}) does not exist.");
+            throw new OctoshiftCliException(
+                $"Source export archive ({sourceExportArchiveFullPath}) does not exist." +
+                (BbsSharedHomeDirectory is BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_LINUX
+                    ? " This usually happens because the archive could not be found at the default Bitbucket's shared home " +
+                      $"which is located in \"{BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_LINUX}\" if Bitbucket is installed on a Linux machine " +
+                      $"or in \"{BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_WINDOWS}\" if installed on a Windows machine. " +
+                      "You can point to a non default shared directory by specifying the --bbs-shared-home option."
+                    : ""));
         }
 
         _fileSystemProvider.CreateDirectory(targetDirectory);

--- a/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
+++ b/src/bbs2gh/Services/BbsSshArchiveDownloader.cs
@@ -94,10 +94,8 @@ public sealed class BbsSshArchiveDownloader : IBbsArchiveDownloader, IDisposable
             throw new OctoshiftCliException(
                 $"Source export archive ({sourceExportArchiveFullPath}) does not exist." +
                 (BbsSharedHomeDirectory is BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_LINUX
-                    ? " This usually happens because the archive could not be found at the default Bitbucket's shared home " +
-                      $"which is located in \"{BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_LINUX}\" if Bitbucket is installed on a Linux machine " +
-                      $"or in \"{BbsSettings.DEFAULT_BBS_SHARED_HOME_DIRECTORY_WINDOWS}\" if installed on a Windows machine. " +
-                      "You can point to a non default shared directory by specifying the --bbs-shared-home option."
+                    ? "This most likely means that your Bitbucket instance uses a non-default Bitbucket shared home directory, so we couldn't find your archive. " +
+                      "You can point the CLI to a non-default shared directory by specifying the --bbs-shared-home option."
                     : ""));
         }
 


### PR DESCRIPTION
Closes #903 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

When the BBS download archive is not found (either because of wrong path or missing archive), we used to throw a generic error message. We realized that in most cases the problem is that the default BBS shared home is not the one we expect. In that case, if the user hasn't already specified the `--bbs-shared-home`, with these changes we are now going to display a more helpful error message and let them know that they can set the aforementioned arg. 