### PR TITLE
Add support for getting paginated Bitbucket data

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-- Add support for getting paginated Bitbucket API responses in `gh bbs2gh generate-script` command   
+- Update `gh bbs2gh generate-script` so it supports more than 25 projects/repos

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Add support for getting paginated Bitbucket API responses in `gh bbs2gh generate-script` command   

--- a/src/Octoshift/BbsApi.cs
+++ b/src/Octoshift/BbsApi.cs
@@ -67,18 +67,16 @@ public class BbsApi
     public virtual async Task<IEnumerable<(int Id, string Key, string Name)>> GetProjects()
     {
         var url = $"{_bbsBaseUrl}/rest/api/1.0/projects";
-        var content = await _client.GetAsync(url);
-        var data = JObject.Parse(content);
-
-        return data["values"].Select(x => ((int)x["id"], (string)x["key"], (string)x["name"])).ToList();
+        return await _client.GetAllAsync(url)
+            .Select(x => ((int)x["id"], (string)x["key"], (string)x["name"]))
+            .ToListAsync();
     }
 
     public virtual async Task<IEnumerable<(int Id, string Slug, string Name)>> GetRepos(string projectKey)
     {
         var url = $"{_bbsBaseUrl}/rest/api/1.0/projects/{projectKey}/repos";
-        var content = await _client.GetAsync(url);
-        var data = JObject.Parse(content);
-
-        return data["values"].Select(x => ((int)x["id"], (string)x["slug"], (string)x["name"])).ToList();
+        return await _client.GetAllAsync(url)
+            .Select(x => ((int)x["id"], (string)x["slug"], (string)x["name"]))
+            .ToListAsync();
     }
 }

--- a/src/Octoshift/BbsClient.cs
+++ b/src/Octoshift/BbsClient.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web;
+using Newtonsoft.Json.Linq;
 using OctoshiftCLI.Contracts;
 using OctoshiftCLI.Extensions;
 
@@ -10,6 +13,7 @@ namespace OctoshiftCLI;
 
 public class BbsClient
 {
+    private const int DEFAULT_PAGE_SIZE = 100;
     private readonly HttpClient _httpClient;
     private readonly OctoLogger _log;
     private readonly RetryPolicy _retryPolicy;
@@ -46,9 +50,30 @@ public class BbsClient
         return await _retryPolicy.HttpRetry(async () => await SendAsync(HttpMethod.Get, url), _ => true);
     }
 
+    public virtual async IAsyncEnumerable<JToken> GetAllAsync(string url)
+    {
+        var hasNextPage = true;
+        var nextPageStart = 0;
+        while (hasNextPage)
+        {
+            var response = await GetWithPagination(url, nextPageStart);
+            var jResponse = JObject.Parse(response);
+
+            foreach (var jToken in jResponse["values"]!)
+            {
+                yield return jToken;
+            }
+
+            hasNextPage = !jResponse["isLastPage"]?.ToObject<bool>() ?? false;
+            nextPageStart = jResponse["nextPageStart"]?.ToObject<int>() ?? 0;
+        }
+    }
+
     public virtual async Task<string> PostAsync(string url, object body) => await SendAsync(HttpMethod.Post, url, body);
 
     public virtual async Task<string> DeleteAsync(string url) => await SendAsync(HttpMethod.Delete, url);
+
+    private async Task<string> GetWithPagination(string url, int start = 0, int limit = DEFAULT_PAGE_SIZE) => await GetAsync(AddPaginationParams(url, start, limit));
 
     private async Task<string> SendAsync(HttpMethod httpMethod, string url, object body = null)
     {
@@ -76,5 +101,17 @@ public class BbsClient
 
         return content;
 
+    }
+
+    private string AddPaginationParams(string url, int start, int limit)
+    {
+        var uri = new Uri(url);
+        var path = uri.GetLeftPart(UriPartial.Path);
+        var queryParams = HttpUtility.ParseQueryString(uri.Query);
+
+        queryParams["start"] = start.ToString();
+        queryParams["limit"] = limit.ToString();
+
+        return $"{path}?{queryParams}";
     }
 }

--- a/src/OctoshiftCLI.Tests/BbsApiTests.cs
+++ b/src/OctoshiftCLI.Tests/BbsApiTests.cs
@@ -110,35 +110,28 @@ public class BbsApiTests
         const string url = $"{BBS_SERVICE_URL}/rest/api/1.0/projects";
         var projectFoo = (Id: 1, Key: "PF", Name: "Foo");
         var projectBar = (Id: 2, Key: "PB", Name: "Bar");
-        var responsePayload = new
+        var response = new[]
         {
-            size = 2,
-            limit = 25,
-            isLastPage = true,
-            values = new[]
+            new
             {
-                new
-                {
-                    key = projectFoo.Key,
-                    id = projectFoo.Id,
-                    name = projectFoo.Name
-                },
-                new
-                {
-                    key = projectBar.Key,
-                    id = projectBar.Id,
-                    name = projectBar.Name
-                }
+                key = projectFoo.Key,
+                id = projectFoo.Id,
+                name = projectFoo.Name
             },
-            start = 0
-        };
-        _mockBbsClient.Setup(m => m.GetAsync(url)).ReturnsAsync(responsePayload.ToJson());
+            new
+            {
+                key = projectBar.Key,
+                id = projectBar.Id,
+                name = projectBar.Name
+            }
+        }.ToAsyncJTokenEnumerable();
+        _mockBbsClient.Setup(m => m.GetAllAsync(url)).Returns(response);
 
         // Act
-        var response = await _sut.GetProjects();
+        var result = await _sut.GetProjects();
 
         //Assert
-        response.Should().BeEquivalentTo(new[] { projectFoo, projectBar });
+        result.Should().BeEquivalentTo(new[] { projectFoo, projectBar });
     }
 
     [Fact]
@@ -149,34 +142,28 @@ public class BbsApiTests
         const string url = $"{BBS_SERVICE_URL}/rest/api/1.0/projects/{fooProjectKey}/repos";
         var fooRepo = (Id: 1, Slug: "foorepo", Name: "FooRepo");
         var barRepo = (Id: 2, Slug: "barrepo", Name: "BarRepo");
-        var responsePayload = new
+        var response = new[]
         {
-            size = 2,
-            limit = 25,
-            isLastPage = true,
-            values = new[]
+            new
             {
-                new
-                {
-                    slug = fooRepo.Slug,
-                    id = fooRepo.Id,
-                    name = fooRepo.Name
-                },
-                new
-                {
-                    slug = barRepo.Slug,
-                    id = barRepo.Id,
-                    name = barRepo.Name
-                }
+                slug = fooRepo.Slug,
+                id = fooRepo.Id,
+                name = fooRepo.Name
             },
-            start = 0
-        };
-        _mockBbsClient.Setup(m => m.GetAsync(url)).ReturnsAsync(responsePayload.ToJson());
+            new
+            {
+                slug = barRepo.Slug,
+                id = barRepo.Id,
+                name = barRepo.Name
+            }
+        }.ToAsyncJTokenEnumerable();
+
+        _mockBbsClient.Setup(m => m.GetAllAsync(It.Is<string>(x => x.StartsWith(url)))).Returns(response);
 
         // Act
-        var response = await _sut.GetRepos(fooProjectKey);
+        var result = await _sut.GetRepos(fooProjectKey);
 
         // Assert
-        response.Should().BeEquivalentTo(new[] { fooRepo, barRepo });
+        result.Should().BeEquivalentTo(new[] { fooRepo, barRepo });
     }
 }


### PR DESCRIPTION
Closes #912 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

This PR adds support for getting [paginated Bitbucket responses](https://developer.atlassian.com/server/bitbucket/rest/v808/intro/#paged-apis) to `BbsClient`. 

For `BbsClient` the following changes were made:
1. A `GetAllAsync` method were added to get all data leveraging Bitbucket's pagination.
2. The default page limit (the number of items getting returned per request) was set to 100 (The Bitbucket default is 25) in order to make less requests.

For `BbsApi` the `GetRepos` and `GetProjects`  methods are now using the `BbsClient#GetAllAsync()`.