### PR TITLE
Rename `--bbs-project-key` to `--bbs-project` in `bbs2gh generate-script`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 - Update `gh bbs2gh generate-script` so it supports more than 25 projects/repos
+- Rename `--bbs-project-key` to `--bbs-project` in `gh bbs2gh generate-script` for consistency

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -118,7 +118,7 @@ public sealed class BbsToGithub : IDisposable
         }
 
         await _targetHelper.RunBbsCliMigration(
-            $"generate-script --github-org {githubTargetOrg} --bbs-server-url {bbsServer} --bbs-project-key {bbsProjectKey}{archiveDownloadOptions}{archiveUploadOptions}", _tokens);
+            $"generate-script --github-org {githubTargetOrg} --bbs-server-url {bbsServer} --bbs-project {bbsProjectKey}{archiveDownloadOptions}{archiveUploadOptions}", _tokens);
 
         _targetHelper.AssertNoErrorInLogs(_startTime);
 

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
@@ -41,7 +41,7 @@ public class GenerateScriptCommandTests
         TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-username", false);
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-password", false);
-        TestHelpers.VerifyCommandOption(_command.Options, "bbs-project-key", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "bbs-project", false);
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-shared-home", false);
         TestHelpers.VerifyCommandOption(_command.Options, "archive-download-host", false, true);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-user", false);

--- a/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Handlers/GenerateScriptCommandHandlerTests.cs
@@ -188,7 +188,7 @@ public class GenerateScriptCommandHandlerTests
             GithubOrg = GITHUB_ORG,
             BbsUsername = BBS_USERNAME,
             BbsPassword = BBS_PASSWORD,
-            BbsProjectKey = BBS_FOO_PROJECT_KEY,
+            BbsProject = BBS_FOO_PROJECT_KEY,
             BbsSharedHome = BBS_SHARED_HOME,
             ArchiveDownloadHost = ARCHIVE_DOWNLOAD_HOST,
             SshUser = SSH_USER,

--- a/src/bbs2gh/Commands/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScriptCommand.cs
@@ -18,7 +18,7 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
         AddOption(GithubOrg);
         AddOption(BbsUsername);
         AddOption(BbsPassword);
-        AddOption(BbsProjectKey);
+        AddOption(BbsProject);
         AddOption(BbsSharedHome);
         AddOption(SshUser);
         AddOption(SshPrivateKey);
@@ -50,8 +50,8 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
                       $"{Environment.NewLine}" +
                       "Note: The password will not get included in the generated script and it has to be set as an env variable before running the script.");
 
-    public Option<string> BbsProjectKey { get; } = new(
-        name: "--bbs-project-key",
+    public Option<string> BbsProject { get; } = new(
+        name: "--bbs-project",
         description: "The Bitbucket project to migrate. If not set will migrate all projects.");
 
     public Option<string> BbsSharedHome { get; } = new(
@@ -152,7 +152,7 @@ public class GenerateScriptCommandArgs
     public string GithubOrg { get; set; }
     public string BbsUsername { get; set; }
     public string BbsPassword { get; set; }
-    public string BbsProjectKey { get; set; }
+    public string BbsProject { get; set; }
     public string BbsSharedHome { get; set; }
     public string ArchiveDownloadHost { get; set; }
     public string SshUser { get; set; }

--- a/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
+++ b/src/bbs2gh/Handlers/GenerateScriptCommandHandler.cs
@@ -64,8 +64,8 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         content.AppendLine(VersionComment);
         content.AppendLine(EXEC_FUNCTION_BLOCK);
 
-        var projects = args.BbsProjectKey.HasValue()
-            ? new List<string>() { args.BbsProjectKey }
+        var projects = args.BbsProject.HasValue()
+            ? new List<string>() { args.BbsProject }
             : (await _bbsApi.GetProjects()).Select(x => x.Key);
 
         foreach (var projectKey in projects)
@@ -148,9 +148,9 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
             _log.LogInformation("BBS PASSWORD: ***");
         }
 
-        if (args.BbsProjectKey.HasValue())
+        if (args.BbsProject.HasValue())
         {
-            _log.LogInformation($"BBS PROJECT KEY: {args.BbsProjectKey}");
+            _log.LogInformation($"BBS PROJECT: {args.BbsProject}");
         }
 
         if (args.ArchiveDownloadHost.HasValue())


### PR DESCRIPTION
Fixes #913 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

This PR renames the `--bbs-project-key` option in `bbs2gh generate-script` command to `--bbs-project` to be consistent with the same option name in `bbs2gh migrate-repo` command. 