### PR TITLE
Include team slug in returned values of GetTeams and CreateTeam

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - Update `gh bbs2gh generate-script` so it supports more than 25 projects/repos
 - Rename `--bbs-project-key` to `--bbs-project` in `gh bbs2gh generate-script` for consistency
+- Fix a bug where `create-team` might not work due to a race condition

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -65,7 +65,7 @@ namespace OctoshiftCLI
             await _client.DeleteAsync(url);
         }
 
-        public virtual async Task<string> CreateTeam(string org, string teamName)
+        public virtual async Task<(string Id, string Slug)> CreateTeam(string org, string teamName)
         {
             var url = $"{_apiUrl}/orgs/{org}/teams";
             var payload = new { name = teamName, privacy = "closed" };
@@ -73,15 +73,15 @@ namespace OctoshiftCLI
             var response = await _client.PostAsync(url, payload);
             var data = JObject.Parse(response);
 
-            return (string)data["id"];
+            return ((string)data["id"], (string)data["slug"]);
         }
 
-        public virtual async Task<IEnumerable<string>> GetTeams(string org)
+        public virtual async Task<IEnumerable<(string Name, string Slug)>> GetTeams(string org)
         {
             var url = $"{_apiUrl}/orgs/{org}/teams";
 
             return await _client.GetAllAsync(url)
-                .Select(t => (string)t["name"])
+                .Select(t => ((string)t["name"], (string)t["slug"]))
                 .ToListAsync();
         }
 

--- a/src/OctoshiftCLI.Tests/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubApiTests.cs
@@ -128,7 +128,7 @@ namespace OctoshiftCLI.Tests
         }
 
         [Fact]
-        public async Task CreateTeam_Returns_Created_Team_Id()
+        public async Task CreateTeam_Returns_Created_Team_Id_And_Slug()
         {
             // Arrange
             const string teamName = "TEAM_NAME";
@@ -137,7 +137,8 @@ namespace OctoshiftCLI.Tests
             var payload = new { name = teamName, privacy = "closed" };
 
             const string teamId = "TEAM_ID";
-            var response = $"{{\"id\": \"{teamId}\"}}";
+            const string teamSlug = "TEAM_SLUG";
+            var response = $"{{\"id\": \"{teamId}\", \"slug\": \"{teamSlug}\"}}";
 
             _githubClientMock
                 .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
@@ -147,7 +148,7 @@ namespace OctoshiftCLI.Tests
             var result = await _githubApi.CreateTeam(GITHUB_ORG, teamName);
 
             // Assert
-            result.Should().Be(teamId);
+            result.Should().Be((teamId, teamSlug));
         }
 
         [Fact]
@@ -156,17 +157,17 @@ namespace OctoshiftCLI.Tests
             // Arrange
             var url = $"https://api.github.com/orgs/{GITHUB_ORG}/teams";
 
-            const string team1 = "TEAM_1";
-            const string team2 = "TEAM_2";
-            const string team3 = "TEAM_3";
-            const string team4 = "TEAM_4";
+            var team1 = (Name: "TEAM_1", Slug: "SLUG_1");
+            var team2 = (Name: "TEAM_2", Slug: "SLUG_2");
+            var team3 = (Name: "TEAM_3", Slug: "SLUG_3");
+            var team4 = (Name: "TEAM_4", Slug: "SLUG_4");
 
             var teamsResult = new[]
             {
-                new { id = 1, name = team1 },
-                new { id = 2, name = team2 },
-                new { id = 3, name = team3 },
-                new { id = 4, name = team4 }
+                new { id = 1, name = team1.Name, slug = team1.Slug },
+                new { id = 2, name = team2.Name, slug = team2.Slug },
+                new { id = 3, name = team3.Name, slug = team3.Slug },
+                new { id = 4, name = team4.Name, slug = team4.Slug }
             }.ToAsyncJTokenEnumerable();
 
             _githubClientMock

--- a/src/OctoshiftCLI.Tests/Octoshift/Handlers/CreateTeamCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Handlers/CreateTeamCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Handlers;
@@ -31,8 +32,8 @@ public class CreateTeamCommandHandlerTests
     {
         _mockGithubApi.Setup(x => x.GetTeamMembers(GITHUB_ORG, TEAM_SLUG).Result).Returns(TEAM_MEMBERS);
         _mockGithubApi.Setup(x => x.GetIdpGroupId(GITHUB_ORG, IDP_GROUP).Result).Returns(IDP_GROUP_ID);
-        _mockGithubApi.Setup(x => x.GetTeamSlug(GITHUB_ORG, TEAM_NAME).Result).Returns(TEAM_SLUG);
-        _mockGithubApi.Setup(x => x.GetTeams(GITHUB_ORG).Result).Returns(new List<string>());
+        _mockGithubApi.Setup(x => x.CreateTeam(GITHUB_ORG, TEAM_NAME).Result).Returns(("1", TEAM_SLUG));
+        _mockGithubApi.Setup(x => x.GetTeams(GITHUB_ORG).Result).Returns(new List<(string, string)>());
 
         var args = new CreateTeamCommandArgs
         {
@@ -53,8 +54,7 @@ public class CreateTeamCommandHandlerTests
     {
         _mockGithubApi.Setup(x => x.GetTeamMembers(GITHUB_ORG, TEAM_SLUG).Result).Returns(TEAM_MEMBERS);
         _mockGithubApi.Setup(x => x.GetIdpGroupId(GITHUB_ORG, IDP_GROUP).Result).Returns(IDP_GROUP_ID);
-        _mockGithubApi.Setup(x => x.GetTeamSlug(GITHUB_ORG, TEAM_NAME).Result).Returns(TEAM_SLUG);
-        _mockGithubApi.Setup(x => x.GetTeams(GITHUB_ORG).Result).Returns(new List<string> { TEAM_NAME });
+        _mockGithubApi.Setup(x => x.GetTeams(GITHUB_ORG).Result).Returns(new List<(string, string)> { (TEAM_NAME, TEAM_SLUG) });
 
         var actualLogOutput = new List<string>();
         _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
@@ -72,6 +72,6 @@ public class CreateTeamCommandHandlerTests
         _mockGithubApi.Verify(x => x.RemoveTeamMember(GITHUB_ORG, TEAM_SLUG, TEAM_MEMBERS[0]));
         _mockGithubApi.Verify(x => x.RemoveTeamMember(GITHUB_ORG, TEAM_SLUG, TEAM_MEMBERS[1]));
         _mockGithubApi.Verify(x => x.AddEmuGroupToTeam(GITHUB_ORG, TEAM_SLUG, IDP_GROUP_ID));
-        actualLogOutput.Contains($"Team '{TEAM_NAME}' already exists. New team will not be created");
+        actualLogOutput.Should().Contain($"Team '{TEAM_NAME}' already exists. New team will not be created");
     }
 }


### PR DESCRIPTION
Closes #648 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

This PR fixes an error which was caused probably due to a race condition by trying to get the team slug right after it was created by removing the extra call to `GithubApi#GetTeamSlug()` and returning the `slug` as part of `CreateTeam()` and `GetTeams()` returned values. 
