### PR TITLE
added env var validation to start of ado2gh script

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
 - Update `gh bbs2gh generate-script` so it supports more than 25 projects/repos
 - Rename `--bbs-project-key` to `--bbs-project` in `gh bbs2gh generate-script` for consistency
 - Fix a bug where `create-team` might not work due to a race condition
+- When using `gh ado2gh generate-script` the script will now validate that the necessary environment variables are set

--- a/src/OctoshiftCLI.Tests/ado2gh/Handlers/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Handlers/GenerateScriptCommandHandlerTests.cs
@@ -616,6 +616,20 @@ function ExecBatch {
         }
     }
 }");
+        expected.AppendLine(@"
+if (-not $env:ADO_PAT) {
+    Write-Error ""ADO_PAT environment variable must be set to a valid Azure DevOps Personal Access Token with the appropriate scopes. For more information see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer#personal-access-tokens-for-azure-devops""
+    exit 1
+} else {
+    Write-Host ""ADO_PAT environment variable is set and will be used to authenticate to Azure DevOps.""
+}
+
+if (-not $env:GH_PAT) {
+    Write-Error ""GH_PAT environment variable must be set to a valid GitHub Personal Access Token with the appropriate scopes. For more information see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer#creating-a-personal-access-token-for-github-enterprise-importer""
+    exit 1
+} else {
+    Write-Host ""GH_PAT environment variable is set and will be used to authenticate to GitHub.""
+}");
         expected.AppendLine();
         expected.AppendLine("$Succeeded = 0");
         expected.AppendLine("$Failed = 0");
@@ -712,6 +726,20 @@ function ExecBatch {
             $Global:LastBatchFailures++
         }
     }
+}");
+        expected.AppendLine(@"
+if (-not $env:ADO_PAT) {
+    Write-Error ""ADO_PAT environment variable must be set to a valid Azure DevOps Personal Access Token with the appropriate scopes. For more information see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer#personal-access-tokens-for-azure-devops""
+    exit 1
+} else {
+    Write-Host ""ADO_PAT environment variable is set and will be used to authenticate to Azure DevOps.""
+}
+
+if (-not $env:GH_PAT) {
+    Write-Error ""GH_PAT environment variable must be set to a valid GitHub Personal Access Token with the appropriate scopes. For more information see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer#creating-a-personal-access-token-for-github-enterprise-importer""
+    exit 1
+} else {
+    Write-Host ""GH_PAT environment variable is set and will be used to authenticate to GitHub.""
 }");
         expected.AppendLine();
         expected.AppendLine("$Succeeded = 0");
@@ -840,6 +868,20 @@ function ExecBatch {
             $Global:LastBatchFailures++
         }
     }
+}");
+        expected.AppendLine(@"
+if (-not $env:ADO_PAT) {
+    Write-Error ""ADO_PAT environment variable must be set to a valid Azure DevOps Personal Access Token with the appropriate scopes. For more information see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer#personal-access-tokens-for-azure-devops""
+    exit 1
+} else {
+    Write-Host ""ADO_PAT environment variable is set and will be used to authenticate to Azure DevOps.""
+}
+
+if (-not $env:GH_PAT) {
+    Write-Error ""GH_PAT environment variable must be set to a valid GitHub Personal Access Token with the appropriate scopes. For more information see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer#creating-a-personal-access-token-for-github-enterprise-importer""
+    exit 1
+} else {
+    Write-Host ""GH_PAT environment variable is set and will be used to authenticate to GitHub.""
 }");
         expected.AppendLine();
         expected.AppendLine("$Succeeded = 0");
@@ -982,6 +1024,20 @@ function ExecBatch {
         }
     }
 }");
+        expected.AppendLine(@"
+if (-not $env:ADO_PAT) {
+    Write-Error ""ADO_PAT environment variable must be set to a valid Azure DevOps Personal Access Token with the appropriate scopes. For more information see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer#personal-access-tokens-for-azure-devops""
+    exit 1
+} else {
+    Write-Host ""ADO_PAT environment variable is set and will be used to authenticate to Azure DevOps.""
+}
+
+if (-not $env:GH_PAT) {
+    Write-Error ""GH_PAT environment variable must be set to a valid GitHub Personal Access Token with the appropriate scopes. For more information see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer#creating-a-personal-access-token-for-github-enterprise-importer""
+    exit 1
+} else {
+    Write-Host ""GH_PAT environment variable is set and will be used to authenticate to GitHub.""
+}");
         expected.AppendLine();
         expected.AppendLine("$Succeeded = 0");
         expected.AppendLine("$Failed = 0");
@@ -1084,7 +1140,7 @@ if ($Failed -ne 0) {
         };
         await _handler.Handle(args);
 
-        _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+        _scriptOutput = TrimNonExecutableLines(_scriptOutput, 47, 6);
 
         // Assert
         _scriptOutput.Should().Be(expected.ToString());
@@ -1129,7 +1185,7 @@ if ($Failed -ne 0) {
         };
         await _handler.Handle(args);
 
-        _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+        _scriptOutput = TrimNonExecutableLines(_scriptOutput, 47, 6);
 
         // Assert
         _scriptOutput.Should().Be(expected.ToString());
@@ -1169,7 +1225,7 @@ if ($Failed -ne 0) {
         };
         await _handler.Handle(args);
 
-        _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+        _scriptOutput = TrimNonExecutableLines(_scriptOutput, 47, 6);
 
         // Assert
         _scriptOutput.Should().Be(expected.ToString());
@@ -1211,7 +1267,7 @@ if ($Failed -ne 0) {
         };
         await _handler.Handle(args);
 
-        _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+        _scriptOutput = TrimNonExecutableLines(_scriptOutput, 47, 6);
 
         // Assert
         _scriptOutput.Should().Be(expected.ToString());
@@ -1254,7 +1310,7 @@ if ($Failed -ne 0) {
         };
         await _handler.Handle(args);
 
-        _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+        _scriptOutput = TrimNonExecutableLines(_scriptOutput, 47, 6);
 
         // Assert
         _scriptOutput.Should().Be(expected.ToString());
@@ -1301,13 +1357,13 @@ if ($Failed -ne 0) {
         };
         await _handler.Handle(args);
 
-        _scriptOutput = TrimNonExecutableLines(_scriptOutput, 35, 6);
+        _scriptOutput = TrimNonExecutableLines(_scriptOutput, 47, 6);
 
         // Assert
         _scriptOutput.Should().Be(expected.ToString());
     }
 
-    private string TrimNonExecutableLines(string script, int skipFirst = 9, int skipLast = 0)
+    private string TrimNonExecutableLines(string script, int skipFirst = 21, int skipLast = 0)
     {
         var lines = script.Split(new[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries).AsEnumerable();
 

--- a/src/ado2gh/Handlers/GenerateScriptCommandHandler.cs
+++ b/src/ado2gh/Handlers/GenerateScriptCommandHandler.cs
@@ -139,6 +139,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         AppendLine(content);
         AppendLine(content, VersionComment);
         AppendLine(content, EXEC_FUNCTION_BLOCK);
+        AppendLine(content, VALIDATE_ENV_VARS);
 
         foreach (var adoOrg in await _adoInspectorService.GetOrgs())
         {
@@ -203,6 +204,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         AppendLine(content, EXEC_FUNCTION_BLOCK);
         AppendLine(content, EXEC_AND_GET_MIGRATION_ID_FUNCTION_BLOCK);
         AppendLine(content, EXEC_BATCH_FUNCTION_BLOCK);
+        AppendLine(content, VALIDATE_ENV_VARS);
 
         AppendLine(content);
         AppendLine(content, "$Succeeded = 0");
@@ -524,5 +526,19 @@ function ExecBatch {
             $Global:LastBatchFailures++
         }
     }
+}";
+    private const string VALIDATE_ENV_VARS = @"
+if (-not $env:ADO_PAT) {
+    Write-Error ""ADO_PAT environment variable must be set to a valid Azure DevOps Personal Access Token with the appropriate scopes. For more information see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer#personal-access-tokens-for-azure-devops""
+    exit 1
+} else {
+    Write-Host ""ADO_PAT environment variable is set and will be used to authenticate to Azure DevOps.""
+}
+
+if (-not $env:GH_PAT) {
+    Write-Error ""GH_PAT environment variable must be set to a valid GitHub Personal Access Token with the appropriate scopes. For more information see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer#creating-a-personal-access-token-for-github-enterprise-importer""
+    exit 1
+} else {
+    Write-Host ""GH_PAT environment variable is set and will be used to authenticate to GitHub.""
 }";
 }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Implements part of #629 

Added a bit of extra powershell to the start of every generated ado2gh script:

```
if (-not $env:ADO_PAT) {
    Write-Error "ADO_PAT environment variable must be set to a valid Azure DevOps Personal Access Token with the appropriate scopes. For more information see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer#personal-access-tokens-for-azure-devops"
    exit 1
} else {
    Write-Host "ADO_PAT environment variable is set and will be used to authenticate to Azure DevOps."
}

if (-not $env:GH_PAT) {
    Write-Error "GH_PAT environment variable must be set to a valid GitHub Personal Access Token with the appropriate scopes. For more information see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer#creating-a-personal-access-token-for-github-enterprise-importer"
    exit 1
} else {
    Write-Host "GH_PAT environment variable is set and will be used to authenticate to GitHub."
}
```

This validates that the `ADO_PAT` and `GH_PAT` environment variables are set and not null/empty.

I plan to tackle `gei` and `bbs2gh` scripts in separate PR's.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->