### PR TITLE
Add retries to GetAllAsync and GetNonSuccessAsync in GithubClient

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,3 +2,4 @@
 - Update `gh bbs2gh generate-script` so it supports more than 25 projects/repos
 - Rename `--bbs-project-key` to `--bbs-project` in `gh bbs2gh generate-script` for consistency
 - Fix a bug where `create-team` might not work due to a race condition
+- Make API calls to GitHub.com that require pagination more resilient by retrying on HTTP failures

--- a/src/Octoshift/Extensions/EnumerableExtensions.cs
+++ b/src/Octoshift/Extensions/EnumerableExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace OctoshiftCLI.Extensions
@@ -20,5 +21,7 @@ namespace OctoshiftCLI.Extensions
 
             return result;
         }
+
+        public static IEnumerable<T> ToEmptyEnumerableIfNull<T>(this IEnumerable<T> enumerable) => enumerable ?? Enumerable.Empty<T>();
     }
 }

--- a/src/OctoshiftCLI.Tests/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/GithubClientTests.cs
@@ -1255,7 +1255,7 @@ namespace OctoshiftCLI.Tests
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
             // Act
-            await foreach (var _ in githubClient.GetAllAsync(url)) { }
+            await githubClient.GetAllAsync(url).ToListAsync();
 
             // Assert
             _mockOctoLogger.Verify(m => m.LogVerbose(It.Is<string>(actual => actual == $"HTTP GET: {url}")));
@@ -1298,7 +1298,7 @@ namespace OctoshiftCLI.Tests
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
             // Act
-            await foreach (var _ in githubClient.GetAllAsync(url)) { }
+            await githubClient.GetAllAsync(url).ToListAsync();
 
             // Assert
             _mockOctoLogger.Verify(m => m.LogVerbose(It.Is<string>(actual => actual == $"GITHUB REQUEST ID: {firstGithubRequestId}")));
@@ -1339,7 +1339,7 @@ namespace OctoshiftCLI.Tests
             var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
             // Act
-            await foreach (var _ in githubClient.GetAllAsync(url)) { }
+            await githubClient.GetAllAsync(url).ToListAsync();
 
             // Assert
             _mockOctoLogger.Verify(m =>


### PR DESCRIPTION
Closes #713 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

This PR adds missing retries to `GithubClient#GetAllAsync()` and `GithubClient#GetNonSuccessAsync()`.

Notes: 
- When I was trying to fix the unit tests I uncovered a bug in our unit tests and decided to fix it once and for all. The way we were returning the `HttpResponseMessage` in the `HttpMessageHandler` was problematic and would cause object disposed exception in retry scenarios simply because after the first request was complete, the http response would be disposed immediately and since we were returning the same http response for all requests, all subsequent requests would fail with object disposed exception. The fix was to simply use a factory to create and return a new `HttpResponseMessage` from the mocked http message handler. I went ahead and updated/fixed all tests to use the factory instead of directory passing the response message and in the process of doing so also simplified some of them.
- After updating the unit tests, two tests raised `CA1506` compiler warning that I believe should be a false positive because we have more complicated tests with no warnings! but since it happened only for those two unit tests I decided to just disable the warning for them. 