### PR TITLE
Secret Scanning bug fix when secret values are longer in source/target

### DIFF
--- a/src/Octoshift/Services/SecretScanningAlertService.cs
+++ b/src/Octoshift/Services/SecretScanningAlertService.cs
@@ -89,7 +89,10 @@ public class SecretScanningAlertService
             }
 
             if (source.Alert.SecretType == target.Alert.SecretType
-                && source.Alert.Secret == target.Alert.Secret)
+                && (source.Alert.Secret.Contains(target.Alert.Secret) ||
+                    target.Alert.Secret.Contains(source.Alert.Secret)
+                   )
+                )
             {
                 _log.LogVerbose(
                     $"Secret type and value match between source:{source.Alert.Number} and target:{source.Alert.Number}");


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

This was originally submitted by @kyle-jones here: https://github.com/github/gh-gei/pull/848. But for some reason it won't let me push changes to his fork so I'm creating a new branch/PR here to get his change merged in.

It seems that sometimes the way secrets are matched it captures a bit more/less of the text containing the secret as the value, which causes problems when we try to match them up to migrate the metadata.

For example in the source repo (GHES) the secret value is:
`AccountName=vehordereastdevstorage;AccountKey=icsuWApIghSQcCQV/w2mLqd4MUV6o17pLjSK2VFXrP/1ACy0yT+vacorCpJQQLuh8nn/1jKRSajmnRStBaZDYw==`

However, for the same code file, the secret value in the target repo (GHEC) is ONLY the actual account key:
`icsuWApIghSQcCQV/w2mLqd4MUV6o17pLjSK2VFXrP/1ACy0yT+vacorCpJQQLuh8nn/1jKRSajmnRStBaZDYw==`

Our existing secret alert migration logic expects the secret values to be identical, and in this case it won't find a matching secret and won't migrate the alert metadata.

This PR improves the secret logic to see if the source secret CONTAINS the target secret (or vice versa) and if so considers it a match.