### PR TITLE
Fixed DoesOrgExist to not retry when org exists

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Fixed a bug when migrating from GHES where we would do a bunch of unnecessary retries at the start making things slower than they needed to be

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -125,12 +125,12 @@ public class GithubApi
         var url = $"{_apiUrl}/orgs/{org.EscapeDataString()}";
         try
         {
-            await _client.GetNonSuccessAsync(url, HttpStatusCode.NotFound);
-            return false;
-        }
-        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.OK)
-        {
+            await _client.GetAsync(url);
             return true;
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return false;
         }
     }
 

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -348,12 +348,12 @@ public class GithubApiTests
     }
 
     [Fact]
-    public async Task DoesTargetOrgExist_Returns_True_When_200()
+    public async Task DoesOrgExist_Returns_True_When_200()
     {
         // Arrange
         var url = $"https://api.github.com/orgs/{GITHUB_ORG}";
 
-        _githubClientMock.Setup(m => m.GetNonSuccessAsync(url, HttpStatusCode.NotFound)).ThrowsAsync(new HttpRequestException(null, null, HttpStatusCode.OK));
+        _githubClientMock.Setup(m => m.GetAsync(url, null)).ReturnsAsync("OK");
 
         // Act
         var result = await _githubApi.DoesOrgExist(GITHUB_ORG);
@@ -363,12 +363,12 @@ public class GithubApiTests
     }
 
     [Fact]
-    public async Task DoesTargetOrgExist_Returns_False_When_404()
+    public async Task DoesOrgExist_Returns_False_When_404()
     {
         // Arrange
         var url = $"https://api.github.com/orgs/{GITHUB_ORG}";
 
-        _githubClientMock.Setup(m => m.GetNonSuccessAsync(url, HttpStatusCode.NotFound)).ReturnsAsync("Not Found");
+        _githubClientMock.Setup(m => m.GetAsync(url, null)).ThrowsAsync(new HttpRequestException(null, null, HttpStatusCode.NotFound));
 
         // Act
         var result = await _githubApi.DoesOrgExist(GITHUB_ORG);
@@ -378,12 +378,12 @@ public class GithubApiTests
     }
 
     [Fact]
-    public async Task DoesTargetOrgExist_Throws_On_Unexpected_Response()
+    public async Task DoesOrgExist_Throws_On_Unexpected_Response()
     {
         // Arrange
         var url = $"https://api.github.com/orgs/{GITHUB_ORG}";
 
-        _githubClientMock.Setup(m => m.GetNonSuccessAsync(url, HttpStatusCode.NotFound)).ThrowsAsync(new HttpRequestException(null, null, HttpStatusCode.Unauthorized));
+        _githubClientMock.Setup(m => m.GetAsync(url, null)).ThrowsAsync(new HttpRequestException(null, null, HttpStatusCode.Unauthorized));
 
         // Act
         await FluentActions


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

Fixes #944 

`GithubApi.DoesOrgExist()` was working, but it was unnecessarily retrying 5 times when the org did exist before finally returning the correct response of `true`.

It was likely written this way because it was copied from the implementation of `DoesRepoExist()`.

The difference is when we check for the existence of the target repo we expect it to NOT exist (and if it does that API call will get retried 5 times probably unnecessarily, but should be rare enough that it's fine). But when checking for the target org we expect that it DOES exist, and don't want to retry in the case of success.

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->