### PR TITLE
Improve "insufficient permissions" error message to refer to a specific organization

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 - Add new '--skip-invitation' flag for `reclaim-mannequin` to allow EMU organizations to reclaim mannequins without an email invitation
+- Improve the error thrown when you have insufficient permissions for the target GitHub organization to explicitly mention the relevant organization

--- a/src/Octoshift/InsufficientPermissionsMessageGenerator.cs
+++ b/src/Octoshift/InsufficientPermissionsMessageGenerator.cs
@@ -3,6 +3,6 @@ public static class InsufficientPermissionsMessageGenerator
 {
     public static string Generate(string organizationLogin)
     {
-        return $". Please check that (a) you are a member of the `{organizationLogin}` organization, (b) you are an organization owner or you have been granted the migrator role and (c) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.";
+        return $". Please check that:\n  (a) you are a member of the `{organizationLogin}` organization,\n  (b) you are an organization owner or you have been granted the migrator role and\n  (c) your personal access token has the correct scopes.\nFor more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.";
     }
 }

--- a/src/Octoshift/InsufficientPermissionsMessageGenerator.cs
+++ b/src/Octoshift/InsufficientPermissionsMessageGenerator.cs
@@ -1,0 +1,8 @@
+namespace OctoshiftCLI;
+public static class InsufficientPermissionsMessageGenerator
+{
+    public static string Generate(string organizationLogin)
+    {
+        return $". Please check that (a) you are a member of the `{organizationLogin}` organization, (b) you are an organization owner or you have been granted the migrator role and (c) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.";
+    }
+}

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -17,8 +17,6 @@ public class GithubApi
     private readonly string _apiUrl;
     private readonly RetryPolicy _retryPolicy;
 
-    private const string INSUFFICIENT_PERMISSIONS_HELP_MESSAGE = ". Please check that (a) you are an organization owner or you have been granted the migrator role and (b) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.";
-
     public GithubApi(GithubClient client, string apiUrl, RetryPolicy retryPolicy)
     {
         _client = client;
@@ -228,15 +226,8 @@ public class GithubApi
             operationName = "createMigrationSource"
         };
 
-        try
-        {
-            var data = await _client.PostGraphQLAsync(url, payload);
-            return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
-        }
-        catch (OctoshiftCliException ex) when (ex.Message.Contains("not have the correct permissions to execute"))
-        {
-            throw new OctoshiftCliException(ex.Message + INSUFFICIENT_PERMISSIONS_HELP_MESSAGE, ex);
-        }
+        var data = await _client.PostGraphQLAsync(url, payload);
+        return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
     }
 
     public virtual async Task<string> CreateBbsMigrationSource(string orgId)
@@ -259,15 +250,8 @@ public class GithubApi
             operationName = "createMigrationSource"
         };
 
-        try
-        {
-            var data = await _client.PostGraphQLAsync(url, payload);
-            return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
-        }
-        catch (OctoshiftCliException ex) when (ex.Message.Contains("not have the correct permissions to execute"))
-        {
-            throw new OctoshiftCliException(ex.Message + INSUFFICIENT_PERMISSIONS_HELP_MESSAGE, ex);
-        }
+        var data = await _client.PostGraphQLAsync(url, payload);
+        return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
     }
 
     public virtual async Task<string> CreateGhecMigrationSource(string orgId)
@@ -290,15 +274,8 @@ public class GithubApi
             operationName = "createMigrationSource"
         };
 
-        try
-        {
-            var data = await _client.PostGraphQLAsync(url, payload);
-            return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
-        }
-        catch (OctoshiftCliException ex) when (ex.Message.Contains("not have the correct permissions to execute"))
-        {
-            throw new OctoshiftCliException(ex.Message + INSUFFICIENT_PERMISSIONS_HELP_MESSAGE, ex);
-        }
+        var data = await _client.PostGraphQLAsync(url, payload);
+        return (string)data["data"]["createMigrationSource"]["migrationSource"]["id"];
     }
 
     public virtual async Task<string> StartMigration(string migrationSourceId, string sourceRepoUrl, string orgId, string repo, string sourceToken, string targetToken, string gitArchiveUrl = null, string metadataArchiveUrl = null, bool skipReleases = false, string targetRepoVisibility = null, bool lockSource = false)

--- a/src/OctoshiftCLI.Tests/InsufficientPermissionsMessageGeneratorTest.cs
+++ b/src/OctoshiftCLI.Tests/InsufficientPermissionsMessageGeneratorTest.cs
@@ -8,7 +8,7 @@ namespace OctoshiftCLI.Tests
         [Fact]
         public void Generate_Returns_Message_With_Interpolated_Login()
         {
-            InsufficientPermissionsMessageGenerator.Generate("monalisa-corp").Should().Be(". Please check that (a) you are a member of the `monalisa-corp` organization, (b) you are an organization owner or you have been granted the migrator role and (c) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
+            InsufficientPermissionsMessageGenerator.Generate("monalisa-corp").Should().Be(". Please check that:\n  (a) you are a member of the `monalisa-corp` organization,\n  (b) you are an organization owner or you have been granted the migrator role and\n  (c) your personal access token has the correct scopes.\nFor more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/InsufficientPermissionsMessageGeneratorTest.cs
+++ b/src/OctoshiftCLI.Tests/InsufficientPermissionsMessageGeneratorTest.cs
@@ -1,0 +1,14 @@
+using FluentAssertions;
+using Xunit;
+
+namespace OctoshiftCLI.Tests
+{
+    public class InsufficientPermissionsMessageGeneratorTest
+    {
+        [Fact]
+        public void Generate_Returns_Message_With_Interpolated_Login()
+        {
+            InsufficientPermissionsMessageGenerator.Generate("monalisa-corp").Should().Be(". Please check that (a) you are a member of the `monalisa-corp` organization, (b) you are an organization owner or you have been granted the migrator role and (c) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
+        }
+    }
+}

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -685,29 +685,6 @@ public class GithubApiTests
     }
 
     [Fact]
-    public async Task CreateAdoMigrationSource_Decorates_Missing_Permissions_Error()
-    {
-        // Arrange
-        const string url = "https://api.github.com/graphql";
-        const string orgId = "ORG_ID";
-        const string adoServerUrl = "https://ado.contoso.com";
-        var payload =
-            "{\"query\":\"mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $type: MigrationSourceType!) " +
-            "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, type: $type}) { migrationSource { id, name, url, type } } }\"" +
-            $",\"variables\":{{\"name\":\"Azure DevOps Source\",\"url\":\"{adoServerUrl}\",\"ownerId\":\"{orgId}\",\"type\":\"AZURE_DEVOPS\"}},\"operationName\":\"createMigrationSource\"}}";
-
-        _githubClientMock
-            .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
-            .Throws(new OctoshiftCliException("monalisa does not have the correct permissions to execute `CreateMigrationSource`"));
-
-        // Act
-        await _githubApi.Invoking(api => api.CreateAdoMigrationSource(orgId, adoServerUrl))
-            .Should()
-            .ThrowExactlyAsync<OctoshiftCliException>()
-            .WithMessage("monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that (a) you are an organization owner or you have been granted the migrator role and (b) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
-    }
-
-    [Fact]
     public async Task CreateBbsMigrationSource_Returns_New_Migration_Source_Id()
     {
         // Arrange
@@ -744,28 +721,6 @@ public class GithubApiTests
     }
 
     [Fact]
-    public async Task CreateBbsMigrationSource_Decorates_Missing_Permissions_Error()
-    {
-        // Arrange
-        const string url = "https://api.github.com/graphql";
-        const string orgId = "ORG_ID";
-        var payload =
-            "{\"query\":\"mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $type: MigrationSourceType!) " +
-            "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, type: $type}) { migrationSource { id, name, url, type } } }\"" +
-            $",\"variables\":{{\"name\":\"Bitbucket Server Source\",\"url\":\"https://not-used\",\"ownerId\":\"{orgId}\",\"type\":\"BITBUCKET_SERVER\"}},\"operationName\":\"createMigrationSource\"}}";
-
-        _githubClientMock
-            .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
-            .Throws(new OctoshiftCliException("monalisa does not have the correct permissions to execute `CreateMigrationSource`"));
-
-        // Act
-        await _githubApi.Invoking(api => api.CreateBbsMigrationSource(orgId))
-            .Should()
-            .ThrowExactlyAsync<OctoshiftCliException>()
-            .WithMessage("monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that (a) you are an organization owner or you have been granted the migrator role and (b) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
-    }
-
-    [Fact]
     public async Task CreateGhecMigrationSource_Returns_New_Migration_Source_Id()
     {
         // Arrange
@@ -799,28 +754,6 @@ public class GithubApiTests
 
         // Assert
         expectedMigrationSourceId.Should().Be(actualMigrationSourceId);
-    }
-
-    [Fact]
-    public async Task CreateGhecMigrationSource_Decorates_Missing_Permissions_Error()
-    {
-        // Arrange
-        const string url = "https://api.github.com/graphql";
-        const string orgId = "ORG_ID";
-        var payload =
-            "{\"query\":\"mutation createMigrationSource($name: String!, $url: String!, $ownerId: ID!, $type: MigrationSourceType!) " +
-            "{ createMigrationSource(input: {name: $name, url: $url, ownerId: $ownerId, type: $type}) { migrationSource { id, name, url, type } } }\"" +
-            $",\"variables\":{{\"name\":\"GHEC Source\",\"url\":\"https://github.com\",\"ownerId\":\"{orgId}\",\"type\":\"GITHUB_ARCHIVE\"}},\"operationName\":\"createMigrationSource\"}}";
-
-        _githubClientMock
-            .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
-            .Throws(new OctoshiftCliException("monalisa does not have the correct permissions to execute `CreateMigrationSource`"));
-
-        // Act
-        await _githubApi.Invoking(api => api.CreateGhecMigrationSource(orgId))
-            .Should()
-            .ThrowExactlyAsync<OctoshiftCliException>()
-            .WithMessage("monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that (a) you are an organization owner or you have been granted the migrator role and (b) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -216,7 +216,7 @@ public class MigrateRepoCommandHandlerTests
         }))
             .Should()
             .ThrowAsync<OctoshiftCliException>()
-            .WithMessage($"monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that (a) you are a member of the `{GITHUB_ORG}` organization, (b) you are an organization owner or you have been granted the migrator role and (c) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
+            .WithMessage($"monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that:\n  (a) you are a member of the `{GITHUB_ORG}` organization,\n  (b) you are an organization owner or you have been granted the migrator role and\n  (c) your personal access token has the correct scopes.\nFor more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -189,6 +189,37 @@ public class MigrateRepoCommandHandlerTests
     }
 
     [Fact]
+    public async Task Throws_Decorated_Error_When_Create_Migration_Source_Fails_With_Permissions_Error()
+    {
+        // Arrange
+        _mockEnvironmentVariableProvider
+           .Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>()))
+           .Returns(GITHUB_TOKEN);
+        _mockEnvironmentVariableProvider
+            .Setup(m => m.AdoPersonalAccessToken(It.IsAny<bool>()))
+            .Returns(ADO_TOKEN);
+
+        _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
+        _mockGithubApi
+            .Setup(x => x.CreateAdoMigrationSource(GITHUB_ORG_ID, null).Result)
+            .Throws(new OctoshiftCliException("monalisa does not have the correct permissions to execute `CreateMigrationSource`"));
+
+        // Act
+        await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
+        {
+            AdoOrg = ADO_ORG,
+            AdoTeamProject = ADO_TEAM_PROJECT,
+            AdoRepo = ADO_REPO,
+            GithubOrg = GITHUB_ORG,
+            GithubRepo = GITHUB_REPO,
+            Wait = true,
+        }))
+            .Should()
+            .ThrowAsync<OctoshiftCliException>()
+            .WithMessage($"monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that (a) you are a member of the `{GITHUB_ORG}` organization, (b) you are an organization owner or you have been granted the migrator role and (c) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
+    }
+
+    [Fact]
     public async Task It_Falls_Back_To_Ado_And_Github_Pats_From_Environment_When_Not_Provided()
     {
         _mockGithubApi.Setup(x => x.GetRepos(GITHUB_ORG).Result).Returns(new List<(string Name, string Visibility)>());

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -502,7 +502,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
-                .WithMessage($"monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that (a) you are a member of the `{GITHUB_ORG}` organization, (b) you are an organization owner or you have been granted the migrator role and (c) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
+                .WithMessage($"monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that:\n  (a) you are a member of the `{GITHUB_ORG}` organization,\n  (b) you are an organization owner or you have been granted the migrator role and\n  (c) your personal access token has the correct scopes.\nFor more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -482,6 +482,30 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
         }
 
         [Fact]
+        public async Task Throws_Decorated_Error_When_Create_Migration_Source_Fails_With_Permissions_Error()
+        {
+            // Arrange
+            _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(GITHUB_PAT);
+
+            _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
+            _mockGithubApi
+                .Setup(x => x.CreateBbsMigrationSource(GITHUB_ORG_ID).Result)
+                .Throws(new OctoshiftCliException("monalisa does not have the correct permissions to execute `CreateMigrationSource`"));
+
+            // Act
+            await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
+            {
+                ArchiveUrl = ARCHIVE_URL,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                QueueOnly = true,
+            }))
+                .Should()
+                .ThrowAsync<OctoshiftCliException>()
+                .WithMessage($"monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that (a) you are a member of the `{GITHUB_ORG}` organization, (b) you are an organization owner or you have been granted the migrator role and (c) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
+        }
+
+        [Fact]
         public async Task Throws_An_Error_If_Export_Fails()
         {
             // Arrange

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -249,7 +249,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             }))
                 .Should()
                 .ThrowAsync<OctoshiftCliException>()
-                .WithMessage($"monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that (a) you are a member of the `{TARGET_ORG}` organization, (b) you are an organization owner or you have been granted the migrator role and (c) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
+                .WithMessage($"monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that:\n  (a) you are a member of the `{TARGET_ORG}` organization,\n  (b) you are an organization owner or you have been granted the migrator role and\n  (c) your personal access token has the correct scopes.\nFor more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -222,6 +222,37 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
         }
 
         [Fact]
+        public async Task Throws_Decorated_Error_When_Create_Migration_Source_Fails_With_Permissions_Error()
+        {
+            // Arrange
+            var githubOrgId = Guid.NewGuid().ToString();
+            var sourceGithubPat = Guid.NewGuid().ToString();
+            var targetGithubPat = Guid.NewGuid().ToString();
+
+            _mockTargetGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
+            _mockTargetGithubApi
+                .Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result)
+                .Throws(new OctoshiftCliException("monalisa does not have the correct permissions to execute `CreateMigrationSource`"));
+
+            _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken(It.IsAny<bool>())).Returns(sourceGithubPat);
+            _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
+
+            // Act
+            await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                TargetApiUrl = TARGET_API_URL,
+                QueueOnly = true,
+            }))
+                .Should()
+                .ThrowAsync<OctoshiftCliException>()
+                .WithMessage($"monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that (a) you are a member of the `{TARGET_ORG}` organization, (b) you are an organization owner or you have been granted the migrator role and (c) your personal access token has the correct scopes. For more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
+        }
+
+        [Fact]
         public async Task Happy_Path_AdoSource()
         {
             var adoTeamProject = "foo-team-project";

--- a/src/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -34,7 +34,19 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         args.AdoPat ??= _environmentVariableProvider.AdoPersonalAccessToken();
         var githubOrgId = await _githubApi.GetOrganizationId(args.GithubOrg);
-        var migrationSourceId = await _githubApi.CreateAdoMigrationSource(githubOrgId, null);
+
+        string migrationSourceId;
+
+        try
+        {
+            migrationSourceId = await _githubApi.CreateAdoMigrationSource(githubOrgId, null);
+        }
+        catch (OctoshiftCliException ex) when (ex.Message.Contains("not have the correct permissions to execute"))
+        {
+            var insufficientPermissionsMessage = InsufficientPermissionsMessageGenerator.Generate(args.GithubOrg);
+            var message = $"{ex.Message}{insufficientPermissionsMessage}";
+            throw new OctoshiftCliException(message, ex);
+        }
 
         string migrationId;
 

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -103,9 +103,21 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         var sourceRepoUrl = GetSourceRepoUrl(args);
         var sourceToken = GetSourceToken(args);
         var targetToken = args.GithubTargetPat ?? _environmentVariableProvider.TargetGithubPersonalAccessToken();
-        var migrationSourceId = args.GithubSourceOrg.HasValue()
+
+        string migrationSourceId;
+
+        try
+        {
+            migrationSourceId = args.GithubSourceOrg.HasValue()
             ? await _targetGithubApi.CreateGhecMigrationSource(githubOrgId)
             : await _targetGithubApi.CreateAdoMigrationSource(githubOrgId, args.AdoServerUrl);
+        }
+        catch (OctoshiftCliException ex) when (ex.Message.Contains("not have the correct permissions to execute"))
+        {
+            var insufficientPermissionsMessage = InsufficientPermissionsMessageGenerator.Generate(args.GithubTargetOrg);
+            var message = $"{ex.Message}{insufficientPermissionsMessage}";
+            throw new OctoshiftCliException(message, ex);
+        }
 
         string migrationId;
 


### PR DESCRIPTION
When we try to call the `createMigrationSource` mutation and we get a permissions error, we already decorate the error message returned from the GraphQL API to be more specific on what you should do to solve it.

Following feedback from customers, this improves that error message to be extremely explicit about what organization you need to have permissions for, so there is no room for doubt.

Ideally, we wouldn't have to make a change like this in the CLI, but the error message we are improving is part of GitHub's core GraphQL API code, so it's non-trivial to change. Improving it in the client layer is the right step to give the best CLI experience possible.

We did experience with alternatives implementations of this change which were more abstract and reusable, but this felt like the right approach with the right level of complexity when we don't know how many other errors we'll want to augment.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->