### PR TITLE
Include the migration ID in the output filename by default when running `download-logs`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Include the migration ID in the default output filename when running `download-logs`

--- a/src/Octoshift/Commands/DownloadLogsCommandBase.cs
+++ b/src/Octoshift/Commands/DownloadLogsCommandBase.cs
@@ -41,7 +41,7 @@ public class DownloadLogsCommandBase : CommandBase<DownloadLogsCommandArgs, Down
 
     public virtual Option<string> MigrationLogFile { get; } = new("--migration-log-file")
     {
-        Description = "Local file to write migration log to (default: migration-log-ORG-REPO.log)."
+        Description = "Local file to write migration log to (default: migration-log-ORG-REPO-MIGRATION_ID.log)."
     };
 
     public virtual Option<bool> Overwrite { get; } = new("--overwrite")

--- a/src/Octoshift/Handlers/DownloadLogsCommandHandler.cs
+++ b/src/Octoshift/Handlers/DownloadLogsCommandHandler.cs
@@ -63,8 +63,6 @@ public class DownloadLogsCommandHandler : ICommandHandler<DownloadLogsCommandArg
             _log.LogInformation($"MIGRATION LOG FILE: {args.MigrationLogFile}");
         }
 
-        args.MigrationLogFile ??= $"migration-log-{args.GithubOrg}-{args.GithubRepo}.log";
-
         if (FileExists(args.MigrationLogFile))
         {
             if (!args.Overwrite)
@@ -75,20 +73,17 @@ public class DownloadLogsCommandHandler : ICommandHandler<DownloadLogsCommandArg
             _log.LogWarning($"Overwriting {args.MigrationLogFile} due to --overwrite option.");
         }
 
-        var result = await _retryPolicy.RetryOnResult(async () => await _githubApi.GetMigrationLogUrl(args.GithubOrg, args.GithubRepo), string.Empty,
+        var result = await _retryPolicy.RetryOnResult<(string MigrationLogURL, string MigrationID)>(async () => await _githubApi.GetMigrationLogUrl(args.GithubOrg, args.GithubRepo), result => string.IsNullOrEmpty(result.MigrationLogURL),
             "Waiting for migration log to populate...");
-
-        if (result.Outcome == OutcomeType.Successful && result.Result is null)
-        {
-            throw new OctoshiftCliException($"Migration for repository {args.GithubRepo} not found!");
-        }
 
         if (result.Outcome == OutcomeType.Failure)
         {
             throw new OctoshiftCliException($"Migration log for repository {args.GithubRepo} unavailable!");
         }
 
-        var logUrl = result.Result;
+        (var logUrl, var migrationId) = result.Result;
+
+        args.MigrationLogFile ??= $"migration-log-{args.GithubOrg}-{args.GithubRepo}-{migrationId}.log";
 
         _log.LogInformation($"Downloading log for repository {args.GithubRepo} to {args.MigrationLogFile}...");
         await _httpDownloadService.DownloadToFile(logUrl, args.MigrationLogFile);

--- a/src/Octoshift/Handlers/DownloadLogsCommandHandler.cs
+++ b/src/Octoshift/Handlers/DownloadLogsCommandHandler.cs
@@ -73,7 +73,7 @@ public class DownloadLogsCommandHandler : ICommandHandler<DownloadLogsCommandArg
             _log.LogWarning($"Overwriting {args.MigrationLogFile} due to --overwrite option.");
         }
 
-        var result = await _retryPolicy.RetryOnResult<(string MigrationLogUrl, string MigrationId)?>(async () => await _githubApi.GetMigrationLogUrl(args.GithubOrg, args.GithubRepo), null,
+        var result = await _retryPolicy.RetryOnResult<(string MigrationLogUrl, string MigrationId)?>(async () => await _githubApi.GetMigrationLogUrl(args.GithubOrg, args.GithubRepo), result => string.IsNullOrEmpty(result.Value.MigrationLogUrl),
             "Waiting for migration log to populate...");
 
         if (result.Outcome == OutcomeType.Failure)

--- a/src/Octoshift/Handlers/DownloadLogsCommandHandler.cs
+++ b/src/Octoshift/Handlers/DownloadLogsCommandHandler.cs
@@ -70,7 +70,7 @@ public class DownloadLogsCommandHandler : ICommandHandler<DownloadLogsCommandArg
             throw new OctoshiftCliException($"File {args.MigrationLogFile} already exists! Use --overwrite to overwrite this file.");
         }
 
-        var result = await _retryPolicy.RetryOnResult<(string MigrationLogUrl, string MigrationId)?>(async () => await _githubApi.GetMigrationLogUrl(args.GithubOrg, args.GithubRepo), r => r?.MigrationLogUrl.IsNullOrWhiteSpace() ?? false,
+        var result = await _retryPolicy.RetryOnResult(async () => await _githubApi.GetMigrationLogUrl(args.GithubOrg, args.GithubRepo), r => r?.MigrationLogUrl.IsNullOrWhiteSpace() ?? false,
             "Waiting for migration log to populate...");
 
         if (result.Outcome == OutcomeType.Successful && result.Result is null)

--- a/src/Octoshift/Handlers/DownloadLogsCommandHandler.cs
+++ b/src/Octoshift/Handlers/DownloadLogsCommandHandler.cs
@@ -63,15 +63,7 @@ public class DownloadLogsCommandHandler : ICommandHandler<DownloadLogsCommandArg
             _log.LogInformation($"MIGRATION LOG FILE: {args.MigrationLogFile}");
         }
 
-        if (FileExists(args.MigrationLogFile))
-        {
-            if (!args.Overwrite)
-            {
-                throw new OctoshiftCliException($"File {args.MigrationLogFile} already exists!  Use --overwrite to overwrite this file.");
-            }
-
-            _log.LogWarning($"Overwriting {args.MigrationLogFile} due to --overwrite option.");
-        }
+        CheckIfOutputFileAlreadyExists(args.MigrationLogFile, args.Overwrite);
 
         var result = await _retryPolicy.RetryOnResult<(string MigrationLogUrl, string MigrationId)?>(async () => await _githubApi.GetMigrationLogUrl(args.GithubOrg, args.GithubRepo), result => string.IsNullOrEmpty(result.Value.MigrationLogUrl),
             "Waiting for migration log to populate...");
@@ -91,10 +83,30 @@ public class DownloadLogsCommandHandler : ICommandHandler<DownloadLogsCommandArg
 
             args.MigrationLogFile ??= $"migration-log-{args.GithubOrg}-{args.GithubRepo}-{migrationId}.log";
 
+            // We already checked if the file exists above for the case where the user explicitly picked their own
+            // filename. This handles the case where the filename has been set to the default based on the inputs
+            // and migration ID.
+            CheckIfOutputFileAlreadyExists(args.MigrationLogFile, args.Overwrite);
+
             _log.LogInformation($"Downloading log for repository {args.GithubRepo} to {args.MigrationLogFile}...");
             await _httpDownloadService.DownloadToFile(logUrl, args.MigrationLogFile);
 
             _log.LogSuccess($"Downloaded {args.GithubRepo} log to {args.MigrationLogFile}.");
+        }
+    }
+
+    private void CheckIfOutputFileAlreadyExists(string outputPath, bool shouldOverwrite)
+    {
+        if (FileExists(outputPath))
+        {
+            if (shouldOverwrite)
+            {
+                throw new OctoshiftCliException($"File {outputPath} already exists!  Use --overwrite to overwrite this file.");
+            }
+            else
+            {
+                _log.LogWarning($"Overwriting {outputPath} due to --overwrite option.");
+            }
         }
     }
 }

--- a/src/Octoshift/Handlers/DownloadLogsCommandHandler.cs
+++ b/src/Octoshift/Handlers/DownloadLogsCommandHandler.cs
@@ -68,31 +68,29 @@ public class DownloadLogsCommandHandler : ICommandHandler<DownloadLogsCommandArg
         var result = await _retryPolicy.RetryOnResult<(string MigrationLogUrl, string MigrationId)?>(async () => await _githubApi.GetMigrationLogUrl(args.GithubOrg, args.GithubRepo), result => string.IsNullOrEmpty(result.Value.MigrationLogUrl),
             "Waiting for migration log to populate...");
 
+        if (result.Outcome == OutcomeType.Successful && result.Result is null)
+        {
+            throw new OctoshiftCliException($"Migration for repository {args.GithubRepo} not found!");
+        }
+
         if (result.Outcome == OutcomeType.Failure)
         {
             throw new OctoshiftCliException($"Migration log for repository {args.GithubRepo} unavailable!");
         }
 
-        if (result.Outcome == OutcomeType.Successful && result.Result is null)
-        {
-            throw new OctoshiftCliException($"Migration for repository {args.GithubRepo} not found!");
-        }
-        else
-        {
-            var (logUrl, migrationId) = result.Result.Value;
+        var (logUrl, migrationId) = result.Result.Value;
 
-            args.MigrationLogFile ??= $"migration-log-{args.GithubOrg}-{args.GithubRepo}-{migrationId}.log";
+        args.MigrationLogFile ??= $"migration-log-{args.GithubOrg}-{args.GithubRepo}-{migrationId}.log";
 
-            // We already checked if the file exists above for the case where the user explicitly picked their own
-            // filename. This handles the case where the filename has been set to the default based on the inputs
-            // and migration ID.
-            CheckIfOutputFileAlreadyExists(args.MigrationLogFile, args.Overwrite);
+        // We already checked if the file exists above for the case where the user explicitly picked their own
+        // filename. This handles the case where the filename has been set to the default based on the inputs
+        // and migration ID.
+        CheckIfOutputFileAlreadyExists(args.MigrationLogFile, args.Overwrite);
 
-            _log.LogInformation($"Downloading log for repository {args.GithubRepo} to {args.MigrationLogFile}...");
-            await _httpDownloadService.DownloadToFile(logUrl, args.MigrationLogFile);
+        _log.LogInformation($"Downloading log for repository {args.GithubRepo} to {args.MigrationLogFile}...");
+        await _httpDownloadService.DownloadToFile(logUrl, args.MigrationLogFile);
 
-            _log.LogSuccess($"Downloaded {args.GithubRepo} log to {args.MigrationLogFile}.");
-        }
+        _log.LogSuccess($"Downloaded {args.GithubRepo} log to {args.MigrationLogFile}.");
     }
 
     private void CheckIfOutputFileAlreadyExists(string outputPath, bool shouldOverwrite)

--- a/src/Octoshift/RetryPolicy.cs
+++ b/src/Octoshift/RetryPolicy.cs
@@ -29,9 +29,9 @@ namespace OctoshiftCLI
             return await policy.ExecuteAsync(func);
         }
 
-        public async Task<PolicyResult<T>> RetryOnResult<T>(Func<Task<T>> func, T resultFilter, string retryLogMessage = null)
+        public async Task<PolicyResult<T>> RetryOnResult<T>(Func<Task<T>> func, Func<T, bool> resultPredicate, string retryLogMessage = null)
         {
-            var policy = Policy.HandleResult(resultFilter)
+            var policy = Policy.HandleResult(resultPredicate)
                                .WaitAndRetryAsync(5, retry => retry * TimeSpan.FromMilliseconds(_retryInterval), (_, _) =>
                                {
                                    _log?.LogVerbose(retryLogMessage ?? "Retrying...");

--- a/src/Octoshift/RetryPolicy.cs
+++ b/src/Octoshift/RetryPolicy.cs
@@ -29,7 +29,7 @@ namespace OctoshiftCLI
             return await policy.ExecuteAsync(func);
         }
 
-        public async Task<PolicyResult<T>> RetryOnResult<T>(Func<Task<T>> func, T resultFilter, string retryLogMessage = null)
+        public async Task<PolicyResult<T>> RetryOnResult<T>(Func<Task<T>> func, Func<T, bool> resultFilter, string retryLogMessage = null)
         {
             var policy = Policy.HandleResult(resultFilter)
                                .WaitAndRetryAsync(5, retry => retry * TimeSpan.FromMilliseconds(_retryInterval), (_, _) =>

--- a/src/Octoshift/RetryPolicy.cs
+++ b/src/Octoshift/RetryPolicy.cs
@@ -29,7 +29,7 @@ namespace OctoshiftCLI
             return await policy.ExecuteAsync(func);
         }
 
-        public async Task<PolicyResult<T>> RetryOnResult<T>(Func<Task<T>> func, Func<T, bool> resultFilter, string retryLogMessage = null)
+        public async Task<PolicyResult<T>> RetryOnResult<T>(Func<Task<T>> func, T resultFilter, string retryLogMessage = null)
         {
             var policy = Policy.HandleResult(resultFilter)
                                .WaitAndRetryAsync(5, retry => retry * TimeSpan.FromMilliseconds(_retryInterval), (_, _) =>

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -491,7 +491,7 @@ public class GithubApi
         }
     }
 
-    public virtual async Task<(string MigrationLogURL, string MigrationID)> GetMigrationLogUrl(string org, string repo)
+    public virtual async Task<(string MigrationLogUrl, string MigrationId)?> GetMigrationLogUrl(string org, string repo)
     {
         var url = $"{_apiUrl}/graphql";
 
@@ -517,14 +517,8 @@ public class GithubApi
 
                 var nodes = (JArray)data["data"]["organization"]["repositoryMigrations"]["nodes"];
 
-                return nodes.Count == 0
-                    ? throw new OctoshiftCliException($"Migration for repository {repo} not found")
-                    : (MigrationLogURL: (string)nodes[0]["migrationLogUrl"], MigrationID: (string)nodes[0]["id"]);
+                return nodes.Count == 0 ? null : (MigrationLogUrl: (string)nodes[0]["migrationLogUrl"], MigrationId: (string)nodes[0]["id"]);
             });
-        }
-        catch (OctoshiftCliException)
-        {
-            throw;
         }
         catch (Exception ex)
         {

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -491,7 +491,7 @@ public class GithubApi
         }
     }
 
-    public virtual async Task<string> GetMigrationLogUrl(string org, string repo)
+    public virtual async Task<(string MigrationLogURL, string MigrationID)> GetMigrationLogUrl(string org, string repo)
     {
         var url = $"{_apiUrl}/graphql";
 
@@ -500,6 +500,7 @@ public class GithubApi
                 organization(login: $org) {
                     repositoryMigrations(last: 1, repositoryName: $repo) {
                         nodes {
+                            id
                             migrationLogUrl
                         }
                     }
@@ -516,8 +517,14 @@ public class GithubApi
 
                 var nodes = (JArray)data["data"]["organization"]["repositoryMigrations"]["nodes"];
 
-                return nodes.Count == 0 ? null : (string)nodes[0]["migrationLogUrl"];
+                return nodes.Count == 0
+                    ? throw new OctoshiftCliException($"Migration for repository {repo} not found")
+                    : (MigrationLogURL: (string)nodes[0]["migrationLogUrl"], MigrationID: (string)nodes[0]["id"]);
             });
+        }
+        catch (OctoshiftCliException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -517,7 +517,9 @@ public class GithubApi
 
                 var nodes = (JArray)data["data"]["organization"]["repositoryMigrations"]["nodes"];
 
-                return nodes.Count == 0 ? null : (MigrationLogUrl: (string)nodes[0]["migrationLogUrl"], MigrationId: (string)nodes[0]["id"]);
+                return nodes.Count == 0 || nodes[0]["migrationLogUrl"] is null
+                    ? ((string MigrationLogUrl, string MigrationId)?)null
+                    : (MigrationLogUrl: (string)nodes[0]["migrationLogUrl"], MigrationId: (string)nodes[0]["id"]);
             });
         }
         catch (Exception ex)

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -517,8 +517,10 @@ public class GithubApi
 
                 var nodes = (JArray)data["data"]["organization"]["repositoryMigrations"]["nodes"];
 
-                return nodes.Count == 0 || nodes[0]["migrationLogUrl"] is null
+                return nodes.Count == 0
+                    // No matching migration was found
                     ? ((string MigrationLogUrl, string MigrationId)?)null
+                    // A matching migration was found, which may or may not have a migration log URL. If there is no migration log, it's an empty string.
                     : (MigrationLogUrl: (string)nodes[0]["migrationLogUrl"], MigrationId: (string)nodes[0]["id"]);
             });
         }

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -695,8 +695,6 @@ steps:
 
             var logFiles = new DirectoryInfo(GetOsDistPath()).GetFiles("*.log");
 
-            _output.WriteLine(string.Join(", ", logFiles.Select(fi => fi.Name).ToArray()));
-
             var matchingLogFiles = logFiles.Where(fi => fi.Name.StartsWith($"migration-log-{githubOrg}-{repo}-") && fi.Name.EndsWith(".log"));
 
             matchingLogFiles.Any().Should().BeTrue();

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -695,7 +695,7 @@ steps:
 
             var logFiles = new DirectoryInfo(GetOsDistPath()).GetFiles("*.log");
 
-            _output.WriteLine(string.Join(", ", logFiles.Select(fi => fi.FullName).ToArray()));
+            _output.WriteLine(string.Join(", ", logFiles.Select(fi => fi.Name).ToArray()));
 
             var matchingLogFiles = logFiles.Where(fi => fi.Name.StartsWith($"migration-log-{githubOrg}-{repo}-") && fi.Name.EndsWith(".log"));
 

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -693,9 +693,13 @@ steps:
         {
             _output.WriteLine("Checking that the migration log was downloaded...");
 
-            var migrationLogFile = Path.Join(GetOsDistPath(), $"migration-log-{githubOrg}-{repo}.log");
+            var logFiles = new DirectoryInfo(GetOsDistPath()).GetFiles("*.log");
+            
+            _output.WriteLine(string.Join(", ", logFiles.Select(fi => fi.FullName).ToArray()));
+            
+            var matchingLogFiles = logFiles.Where(fi => fi.FullName.StartsWith($"migration-log-{githubOrg}-{repo}-") && fi.FullName.EndsWith(".log"));
 
-            File.Exists(migrationLogFile).Should().BeTrue();
+            matchingLogFiles.Any().Should().BeTrue();
         }
 
         public void AssertNoErrorInLogs(DateTime after)

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -694,9 +694,9 @@ steps:
             _output.WriteLine("Checking that the migration log was downloaded...");
 
             var logFiles = new DirectoryInfo(GetOsDistPath()).GetFiles("*.log");
-            
+
             _output.WriteLine(string.Join(", ", logFiles.Select(fi => fi.FullName).ToArray()));
-            
+
             var matchingLogFiles = logFiles.Where(fi => fi.FullName.StartsWith($"migration-log-{githubOrg}-{repo}-") && fi.FullName.EndsWith(".log"));
 
             matchingLogFiles.Any().Should().BeTrue();

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -697,7 +697,7 @@ steps:
 
             _output.WriteLine(string.Join(", ", logFiles.Select(fi => fi.FullName).ToArray()));
 
-            var matchingLogFiles = logFiles.Where(fi => fi.FullName.StartsWith($"migration-log-{githubOrg}-{repo}-") && fi.FullName.EndsWith(".log"));
+            var matchingLogFiles = logFiles.Where(fi => fi.Name.StartsWith($"migration-log-{githubOrg}-{repo}-") && fi.Name.EndsWith(".log"));
 
             matchingLogFiles.Any().Should().BeTrue();
         }

--- a/src/OctoshiftCLI.Tests/Octoshift/Handlers/DownloadLogsCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Handlers/DownloadLogsCommandHandlerTests.cs
@@ -265,8 +265,6 @@ public class DownloadLogsCommandHandlerTests
         const string githubOrg = "FooOrg";
         const string repo = "foo-repo";
 
-        //_mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(null);
-
         // Assert
         var args = new DownloadLogsCommandArgs
         {

--- a/src/OctoshiftCLI.Tests/Octoshift/Handlers/DownloadLogsCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Handlers/DownloadLogsCommandHandlerTests.cs
@@ -31,9 +31,10 @@ public class DownloadLogsCommandHandlerTests
         const string githubOrg = "FooOrg";
         const string repo = "foo-repo";
         const string logUrl = "some-url";
-        const string defaultFileName = $"migration-log-{githubOrg}-{repo}.log";
+        const string migrationId = "RM123";
+        const string defaultFileName = $"migration-log-{githubOrg}-{repo}-{migrationId}.log";
 
-        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(logUrl);
+        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((logUrl, migrationId));
         _mockHttpDownloadService.Setup(m => m.DownloadToFile(It.IsAny<string>(), It.IsAny<string>()));
 
         // Act
@@ -55,8 +56,9 @@ public class DownloadLogsCommandHandlerTests
         const string githubOrg = "FooOrg";
         const string repo = "foo-repo";
         const string logUrl = "some-url";
+        const string migrationId = "RM123";
 
-        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(logUrl);
+        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((logUrl, migrationId));
         _mockHttpDownloadService.Setup(m => m.DownloadToFile(It.IsAny<string>(), It.IsAny<string>()));
 
         // Act
@@ -78,9 +80,10 @@ public class DownloadLogsCommandHandlerTests
         const string githubOrg = "FooOrg";
         const string repo = "foo-repo";
         const string logUrl = "some-url";
+        const string migrationId = "RM123";
         const string migrationLogFile = "migration-log-file";
 
-        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(logUrl);
+        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((logUrl, migrationId));
         _mockHttpDownloadService.Setup(m => m.DownloadToFile(It.IsAny<string>(), It.IsAny<string>()));
 
         // Act
@@ -104,15 +107,16 @@ public class DownloadLogsCommandHandlerTests
         const string repo = "foo-repo";
         const string logUrlEmpty = "";
         const string logUrlPopulated = "some-url";
-        const string defaultFileName = $"migration-log-{githubOrg}-{repo}.log";
+        const string migrationId = "RM123";
+        const string defaultFileName = $"migration-log-{githubOrg}-{repo}-{migrationId}.log";
 
         _mockGithubApi.SetupSequence(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(logUrlEmpty)
-            .ReturnsAsync(logUrlEmpty)
-            .ReturnsAsync(logUrlEmpty)
-            .ReturnsAsync(logUrlEmpty)
-            .ReturnsAsync(logUrlEmpty)
-            .ReturnsAsync(logUrlPopulated);
+            .ReturnsAsync((logUrlEmpty, migrationId))
+            .ReturnsAsync((logUrlEmpty, migrationId))
+            .ReturnsAsync((logUrlEmpty, migrationId))
+            .ReturnsAsync((logUrlEmpty, migrationId))
+            .ReturnsAsync((logUrlEmpty, migrationId))
+            .ReturnsAsync((logUrlPopulated, migrationId));
 
         _mockHttpDownloadService.Setup(m => m.DownloadToFile(It.IsAny<string>(), It.IsAny<string>()));
 
@@ -136,9 +140,10 @@ public class DownloadLogsCommandHandlerTests
         const string githubOrg = "FooOrg";
         const string repo = "foo-repo";
         const string logUrl = "some-url";
+        const string migrationId = "RM123";
         const bool overwrite = true;
 
-        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(logUrl);
+        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((logUrl, migrationId));
         _mockHttpDownloadService.Setup(m => m.DownloadToFile(It.IsAny<string>(), It.IsAny<string>()));
 
         // Act
@@ -182,8 +187,9 @@ public class DownloadLogsCommandHandlerTests
         const string githubOrg = "FooOrg";
         const string repo = "foo-repo";
         const string logUrl = null;
+        const string migrationId = "RM123";
 
-        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(logUrl);
+        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((logUrl, migrationId));
 
         // Assert
         var args = new DownloadLogsCommandArgs
@@ -203,8 +209,9 @@ public class DownloadLogsCommandHandlerTests
         const string githubOrg = "FooOrg";
         const string repo = "foo-repo";
         const string logUrl = "";
+        const string migrationId = "RM123";
 
-        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(logUrl);
+        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((logUrl, migrationId));
         _mockHttpDownloadService.Setup(m => m.DownloadToFile(It.IsAny<string>(), It.IsAny<string>()));
 
         // Act

--- a/src/OctoshiftCLI.Tests/Octoshift/Handlers/DownloadLogsCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Handlers/DownloadLogsCommandHandlerTests.cs
@@ -110,11 +110,11 @@ public class DownloadLogsCommandHandlerTests
         const string defaultFileName = $"migration-log-{githubOrg}-{repo}-{migrationId}.log";
 
         _mockGithubApi.SetupSequence(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)("", migrationId))
-            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)("", migrationId))
-            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)("", migrationId))
-            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)("", migrationId))
-            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)("", migrationId))
+            .ReturnsAsync(("", migrationId))
+            .ReturnsAsync(("", migrationId))
+            .ReturnsAsync(("", migrationId))
+            .ReturnsAsync(("", migrationId))
+            .ReturnsAsync(("", migrationId))
             .ReturnsAsync((logUrlPopulated, migrationId));
 
         _mockHttpDownloadService.Setup(m => m.DownloadToFile(It.IsAny<string>(), It.IsAny<string>()));
@@ -207,7 +207,7 @@ public class DownloadLogsCommandHandlerTests
         const string repo = "foo-repo";
         const string migrationId = "RM123";
 
-        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)("", migrationId));
+        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(("", migrationId));
         _mockHttpDownloadService.Setup(m => m.DownloadToFile(It.IsAny<string>(), It.IsAny<string>()));
 
         // Act

--- a/src/OctoshiftCLI.Tests/Octoshift/Handlers/DownloadLogsCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Handlers/DownloadLogsCommandHandlerTests.cs
@@ -110,11 +110,11 @@ public class DownloadLogsCommandHandlerTests
         const string defaultFileName = $"migration-log-{githubOrg}-{repo}-{migrationId}.log";
 
         _mockGithubApi.SetupSequence(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)null)
-            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)null)
-            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)null)
-            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)null)
-            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)null)
+            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)("", migrationId))
+            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)("", migrationId))
+            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)("", migrationId))
+            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)("", migrationId))
+            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)("", migrationId))
             .ReturnsAsync((logUrlPopulated, migrationId));
 
         _mockHttpDownloadService.Setup(m => m.DownloadToFile(It.IsAny<string>(), It.IsAny<string>()));
@@ -205,8 +205,9 @@ public class DownloadLogsCommandHandlerTests
         // Arrange
         const string githubOrg = "FooOrg";
         const string repo = "foo-repo";
+        const string migrationId = "RM123";
 
-        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)null);
+        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)("", migrationId));
         _mockHttpDownloadService.Setup(m => m.DownloadToFile(It.IsAny<string>(), It.IsAny<string>()));
 
         // Act

--- a/src/OctoshiftCLI.Tests/Octoshift/Handlers/DownloadLogsCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Handlers/DownloadLogsCommandHandlerTests.cs
@@ -105,17 +105,16 @@ public class DownloadLogsCommandHandlerTests
         // Arrange
         const string githubOrg = "FooOrg";
         const string repo = "foo-repo";
-        const string logUrlEmpty = "";
         const string logUrlPopulated = "some-url";
         const string migrationId = "RM123";
         const string defaultFileName = $"migration-log-{githubOrg}-{repo}-{migrationId}.log";
 
         _mockGithubApi.SetupSequence(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((logUrlEmpty, migrationId))
-            .ReturnsAsync((logUrlEmpty, migrationId))
-            .ReturnsAsync((logUrlEmpty, migrationId))
-            .ReturnsAsync((logUrlEmpty, migrationId))
-            .ReturnsAsync((logUrlEmpty, migrationId))
+            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)null)
+            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)null)
+            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)null)
+            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)null)
+            .ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)null)
             .ReturnsAsync((logUrlPopulated, migrationId));
 
         _mockHttpDownloadService.Setup(m => m.DownloadToFile(It.IsAny<string>(), It.IsAny<string>()));
@@ -186,10 +185,8 @@ public class DownloadLogsCommandHandlerTests
         // Arrange
         const string githubOrg = "FooOrg";
         const string repo = "foo-repo";
-        const string logUrl = null;
-        const string migrationId = "RM123";
 
-        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((logUrl, migrationId));
+        //_mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(null);
 
         // Assert
         var args = new DownloadLogsCommandArgs
@@ -208,10 +205,8 @@ public class DownloadLogsCommandHandlerTests
         // Arrange
         const string githubOrg = "FooOrg";
         const string repo = "foo-repo";
-        const string logUrl = "";
-        const string migrationId = "RM123";
 
-        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((logUrl, migrationId));
+        _mockGithubApi.Setup(m => m.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(((string MigrationLogUrl, string MigrationId)?)null);
         _mockHttpDownloadService.Setup(m => m.DownloadToFile(It.IsAny<string>(), It.IsAny<string>()));
 
         // Act

--- a/src/OctoshiftCLI.Tests/Octoshift/Handlers/WaitForMigrationCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Handlers/WaitForMigrationCommandHandlerTests.cs
@@ -38,7 +38,7 @@ public class WaitForMigrationCommandHandlerTests
             .Returns((State: RepositoryMigrationStatus.InProgress, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
             .Returns((State: RepositoryMigrationStatus.InProgress, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
             .Returns((State: RepositoryMigrationStatus.Succeeded, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL));
-        _mockGithubApi.Setup(x => x.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(MIGRATION_URL);
+        _mockGithubApi.Setup(x => x.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((MIGRATION_URL, REPO_MIGRATION_ID));
 
         var actualLogOutput = new List<string>();
         _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
@@ -83,7 +83,7 @@ public class WaitForMigrationCommandHandlerTests
             .Returns((State: RepositoryMigrationStatus.InProgress, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
             .Returns((State: RepositoryMigrationStatus.InProgress, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
             .Returns((State: RepositoryMigrationStatus.Failed, RepositoryName: TARGET_REPO, FailureReason: failureReason, MigrationLogUrl: MIGRATION_URL));
-        _mockGithubApi.Setup(x => x.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(MIGRATION_URL);
+        _mockGithubApi.Setup(x => x.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((MIGRATION_URL, REPO_MIGRATION_ID));
 
         var actualLogOutput = new List<string>();
         _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));
@@ -132,7 +132,7 @@ public class WaitForMigrationCommandHandlerTests
             .Returns((State: RepositoryMigrationStatus.PendingValidation, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
             .Returns((State: RepositoryMigrationStatus.PendingValidation, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
             .Returns((State: RepositoryMigrationStatus.FailedValidation, RepositoryName: TARGET_REPO, FailureReason: failureReason, MigrationLogUrl: MIGRATION_URL));
-        _mockGithubApi.Setup(x => x.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(MIGRATION_URL);
+        _mockGithubApi.Setup(x => x.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((MIGRATION_URL, REPO_MIGRATION_ID));
 
         var actualLogOutput = new List<string>();
         _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => actualLogOutput.Add(s));

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -1443,55 +1443,6 @@ public class GithubApiTests
     }
 
     [Fact]
-    public async Task GetMigrationLogUrl_Returns_Empty_String_Migration_Log_URL_If_Returned_From_The_API()
-    {
-        // Arrange
-        const string url = "https://api.github.com/graphql";
-
-        var query = "query ($org: String!, $repo: String!)";
-        var gql = @"
-                organization(login: $org) {
-                    repositoryMigrations(last: 1, repositoryName: $repo) {
-                        nodes {
-                            id
-                            migrationLogUrl
-                        }
-                    }
-                }
-            ";
-
-        var payload = new { query = $"{query} {{ {gql} }}", variables = new { org = GITHUB_ORG, repo = GITHUB_REPO } };
-
-        const string migrationLogUrl = "";
-        const string migrationId = "MIGRATION_ID";
-        var response = JObject.Parse($@"
-            {{
-                ""data"": {{
-                    ""organization"": {{
-                        ""repositoryMigrations"": {{
-                            ""nodes"": [
-                                {{
-                                    ""id"": ""{migrationId}"",
-                                    ""migrationLogUrl"": ""{migrationLogUrl}""
-                                }}
-                            ]
-                        }}
-                    }}
-                }}
-            }}");
-
-        _githubClientMock
-            .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
-            .ReturnsAsync(response);
-
-        // Act
-        var expectedMigrationLog = await _githubApi.GetMigrationLogUrl(GITHUB_ORG, GITHUB_REPO);
-
-        // Assert
-        expectedMigrationLog.Should().Be((migrationLogUrl, migrationId));
-    }
-
-    [Fact]
     public async Task GetMigrationLogUrl_Retries_On_GQL_Error()
     {
         // Arrange

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -1494,7 +1494,7 @@ public class GithubApiTests
     }
 
     [Fact]
-    public async Task GetMigrationLogUrl_Throws_Error_When_No_Migration()
+    public async Task GetMigrationLogUrl_Returns_Null_When_No_Migration()
     {
         // Arrange
         const string url = "https://api.github.com/graphql";
@@ -1528,10 +1528,9 @@ public class GithubApiTests
             .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
             .ReturnsAsync(response);
 
-        await _githubApi.Invoking(api => api.GetMigrationLogUrl(GITHUB_ORG, GITHUB_REPO))
-            .Should()
-            .ThrowExactlyAsync<OctoshiftCliException>()
-            .WithMessage("Migration for repository REPOSITORY_NAME not found");
+        var result = await _githubApi.GetMigrationLogUrl(GITHUB_ORG, GITHUB_REPO);
+
+        result.Should().BeNull();
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -1443,6 +1443,55 @@ public class GithubApiTests
     }
 
     [Fact]
+    public async Task GetMigrationLogUrl_Returns_Empty_String_Migration_Log_URL_If_Returned_From_The_API()
+    {
+        // Arrange
+        const string url = "https://api.github.com/graphql";
+
+        var query = "query ($org: String!, $repo: String!)";
+        var gql = @"
+                organization(login: $org) {
+                    repositoryMigrations(last: 1, repositoryName: $repo) {
+                        nodes {
+                            id
+                            migrationLogUrl
+                        }
+                    }
+                }
+            ";
+
+        var payload = new { query = $"{query} {{ {gql} }}", variables = new { org = GITHUB_ORG, repo = GITHUB_REPO } };
+
+        const string migrationLogUrl = "";
+        const string migrationId = "MIGRATION_ID";
+        var response = JObject.Parse($@"
+            {{
+                ""data"": {{
+                    ""organization"": {{
+                        ""repositoryMigrations"": {{
+                            ""nodes"": [
+                                {{
+                                    ""id"": ""{migrationId}"",
+                                    ""migrationLogUrl"": ""{migrationLogUrl}""
+                                }}
+                            ]
+                        }}
+                    }}
+                }}
+            }}");
+
+        _githubClientMock
+            .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
+            .ReturnsAsync(response);
+
+        // Act
+        var expectedMigrationLog = await _githubApi.GetMigrationLogUrl(GITHUB_ORG, GITHUB_REPO);
+
+        // Assert
+        expectedMigrationLog.Should().Be((migrationLogUrl, migrationId));
+    }
+
+    [Fact]
     public async Task GetMigrationLogUrl_Retries_On_GQL_Error()
     {
         // Arrange

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -1394,7 +1394,7 @@ public class GithubApiTests
     }
 
     [Fact]
-    public async Task GetMigrationLogUrl_Returns_The_Migration_Log_URL()
+    public async Task GetMigrationLogUrl_Returns_The_Migration_Log_URL_And_Migration_ID()
     {
         // Arrange
         const string url = "https://api.github.com/graphql";
@@ -1404,6 +1404,7 @@ public class GithubApiTests
                 organization(login: $org) {
                     repositoryMigrations(last: 1, repositoryName: $repo) {
                         nodes {
+                            id
                             migrationLogUrl
                         }
                     }
@@ -1413,6 +1414,7 @@ public class GithubApiTests
         var payload = new { query = $"{query} {{ {gql} }}", variables = new { org = GITHUB_ORG, repo = GITHUB_REPO } };
 
         const string migrationLogUrl = "MIGRATION_LOG_URL";
+        const string migrationId = "MIGRATION_ID";
         var response = JObject.Parse($@"
             {{
                 ""data"": {{
@@ -1420,6 +1422,7 @@ public class GithubApiTests
                         ""repositoryMigrations"": {{
                             ""nodes"": [
                                 {{
+                                    ""id"": ""{migrationId}"",
                                     ""migrationLogUrl"": ""{migrationLogUrl}""
                                 }}
                             ]
@@ -1436,7 +1439,7 @@ public class GithubApiTests
         var expectedMigrationLog = await _githubApi.GetMigrationLogUrl(GITHUB_ORG, GITHUB_REPO);
 
         // Assert
-        expectedMigrationLog.Should().Be(migrationLogUrl);
+        expectedMigrationLog.Should().Be((migrationLogUrl, migrationId));
     }
 
     [Fact]
@@ -1450,6 +1453,7 @@ public class GithubApiTests
                 organization(login: $org) {
                     repositoryMigrations(last: 1, repositoryName: $repo) {
                         nodes {
+                            id
                             migrationLogUrl
                         }
                     }
@@ -1459,6 +1463,7 @@ public class GithubApiTests
         var payload = new { query = $"{query} {{ {gql} }}", variables = new { org = GITHUB_ORG, repo = GITHUB_REPO } };
 
         const string migrationLogUrl = "MIGRATION_LOG_URL";
+        const string migrationId = "MIGRATION_ID";
         var response = JObject.Parse($@"
             {{
                 ""data"": {{
@@ -1466,6 +1471,7 @@ public class GithubApiTests
                         ""repositoryMigrations"": {{
                             ""nodes"": [
                                 {{
+                                    ""id"": ""{migrationId}"",
                                     ""migrationLogUrl"": ""{migrationLogUrl}""
                                 }}
                             ]
@@ -1484,11 +1490,11 @@ public class GithubApiTests
         var expectedMigrationLog = await _githubApi.GetMigrationLogUrl(GITHUB_ORG, GITHUB_REPO);
 
         // Assert
-        expectedMigrationLog.Should().Be(migrationLogUrl);
+        expectedMigrationLog.Should().Be((migrationLogUrl, migrationId));
     }
 
     [Fact]
-    public async Task GetMigrationLogUrl_Returns_Null_When_No_Migration()
+    public async Task GetMigrationLogUrl_Throws_Error_When_No_Migration()
     {
         // Arrange
         const string url = "https://api.github.com/graphql";
@@ -1498,6 +1504,7 @@ public class GithubApiTests
                 organization(login: $org) {
                     repositoryMigrations(last: 1, repositoryName: $repo) {
                         nodes {
+                            id
                             migrationLogUrl
                         }
                     }
@@ -1521,11 +1528,10 @@ public class GithubApiTests
             .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload.ToJson()), null))
             .ReturnsAsync(response);
 
-        // Act
-        var expectedMigrationLog = await _githubApi.GetMigrationLogUrl(GITHUB_ORG, GITHUB_REPO);
-
-        // Assert
-        expectedMigrationLog.Should().Be(null);
+        await _githubApi.Invoking(api => api.GetMigrationLogUrl(GITHUB_ORG, GITHUB_REPO))
+            .Should()
+            .ThrowExactlyAsync<OctoshiftCliException>()
+            .WithMessage("Migration for repository REPOSITORY_NAME not found");
     }
 
     [Fact]


### PR DESCRIPTION
Following customer feedback, this updates the shared `download-logs` command available across our CLIs to include the migration ID in the filename by default - although this can, of course, be overridden.

This means that migration logs where you dry-run the same repo multiple times won't try to overwrite one another, and will always have a unique filename.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)