### PR TITLE
Unhide the `--archive-download-host` option for `gh bbs2gh migrate-repo` and `generate-script`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
 - Include the migration ID in the default output filename when running `download-logs`
 - Include the date with the timestamp when writing to the log
 - When blob storage credentials are provided to the CLI but will not be used for a GHES migration, log a clear warning, not an info message
+- Unhide the `--archive-download-host` argument in the documentation for `gh bbs2gh migrate-repo` and `gh bbs2gh generate-script`

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
@@ -44,7 +44,7 @@ public class GenerateScriptCommandTests
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-password", false);
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-project", false);
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-shared-home", false);
-        TestHelpers.VerifyCommandOption(_command.Options, "archive-download-host", false, false);
+        TestHelpers.VerifyCommandOption(_command.Options, "archive-download-host", false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-user", false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-private-key", false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-port", false);

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScriptCommandTests.cs
@@ -44,7 +44,7 @@ public class GenerateScriptCommandTests
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-password", false);
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-project", false);
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-shared-home", false);
-        TestHelpers.VerifyCommandOption(_command.Options, "archive-download-host", false, true);
+        TestHelpers.VerifyCommandOption(_command.Options, "archive-download-host", false, false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-user", false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-private-key", false);
         TestHelpers.VerifyCommandOption(_command.Options, "ssh-port", false);

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
@@ -72,7 +72,7 @@ public class MigrateRepoCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "github-org", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-repo", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
-        TestHelpers.VerifyCommandOption(command.Options, "archive-download-host", false, true);
+        TestHelpers.VerifyCommandOption(command.Options, "archive-download-host", false, false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-user", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-private-key", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-port", false);

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepoCommandTests.cs
@@ -72,7 +72,7 @@ public class MigrateRepoCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "github-org", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-repo", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
-        TestHelpers.VerifyCommandOption(command.Options, "archive-download-host", false, false);
+        TestHelpers.VerifyCommandOption(command.Options, "archive-download-host", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-user", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-private-key", false);
         TestHelpers.VerifyCommandOption(command.Options, "ssh-port", false);

--- a/src/bbs2gh/Commands/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScriptCommand.cs
@@ -63,8 +63,7 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
 
     public Option<string> ArchiveDownloadHost { get; } = new(
         name: "--archive-download-host",
-        description: "The host to use to connect to the Bitbucket Server/Data Center instance via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).")
-    { IsHidden = true };
+        description: "The host to use to connect to the Bitbucket Server/Data Center instance via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).");
 
     public Option<string> SshUser { get; } = new(
         name: "--ssh-user",

--- a/src/bbs2gh/Commands/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepoCommand.cs
@@ -117,8 +117,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
 
     public Option<string> ArchiveDownloadHost { get; } = new(
         name: "--archive-download-host",
-        description: "The host to use to connect to the Bitbucket Server/Data Center instance via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).")
-    { IsHidden = true };
+        description: "The host to use to connect to the Bitbucket Server/Data Center instance via SSH or SMB. Defaults to the host from the Bitbucket Server URL (--bbs-server-url).");
 
     public Option<string> SshUser { get; } = new(
         name: "--ssh-user",


### PR DESCRIPTION
When we introduced the `--archive-download-host` argument to customize the host used for archive downloads in Bitbucket Server migrations, we marked the option as hidden.

We made this decision because we didn't know how useful this option would be and how many people would need it.

Based on feedback from numerous customers, I'm confident that there are many people who need to customize this option. This unhides it the `migrate-repo` and `generate-script` commands' documentation to make it more discoverable.

Fixes https://github.com/github/gh-gei/issues/972.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->