### PR TITLE
Display number of migration log warnings encountered after a migration completes

### DIFF
--- a/src/Octoshift/Handlers/WaitForMigrationCommandHandler.cs
+++ b/src/Octoshift/Handlers/WaitForMigrationCommandHandler.cs
@@ -95,7 +95,7 @@ public class WaitForMigrationCommandHandler : ICommandHandler<WaitForMigrationCo
 
     private async Task WaitForRepositoryMigration(string migrationId, string githubPat, GithubApi githubApi)
     {
-        var (state, repositoryName, failureReason, migrationLogUrl) = await githubApi.GetMigration(migrationId);
+        var (state, repositoryName, warningsCount, failureReason, migrationLogUrl) = await githubApi.GetMigration(migrationId);
 
         _log.LogInformation($"Waiting for {repositoryName} migration (ID: {migrationId}) to finish...");
 
@@ -124,7 +124,7 @@ public class WaitForMigrationCommandHandler : ICommandHandler<WaitForMigrationCo
             _log.LogInformation($"Waiting {WaitIntervalInSeconds} seconds...");
             await Task.Delay(WaitIntervalInSeconds * 1000);
 
-            (state, repositoryName, failureReason, migrationLogUrl) = await githubApi.GetMigration(migrationId);
+            (state, repositoryName, warningsCount, failureReason, migrationLogUrl) = await githubApi.GetMigration(migrationId);
         }
     }
 }

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -463,12 +463,26 @@ public class GithubApi
         );
     }
 
-    public virtual async Task<(string State, string RepositoryName, string FailureReason, string MigrationLogUrl)> GetMigration(string migrationId)
+    public virtual async Task<(string State, string RepositoryName, int WarningsCount, string FailureReason, string MigrationLogUrl)> GetMigration(string migrationId)
     {
         var url = $"{_apiUrl}/graphql";
 
         var query = "query($id: ID!)";
-        var gql = "node(id: $id) { ... on Migration { id, sourceUrl, migrationLogUrl, migrationSource { name }, state, failureReason, repositoryName } }";
+        var gql = @"
+                node(id: $id) {
+                    ... on Migration {
+                        id,
+                        sourceUrl,
+                        migrationLogUrl,
+                        migrationSource {
+                            name
+                        },
+                        state,
+                        warningsCount,
+                        failureReason,
+                        repositoryName
+                    }
+                }";
 
         var payload = new { query = $"{query} {{ {gql} }}", variables = new { id = migrationId } };
 
@@ -481,6 +495,7 @@ public class GithubApi
                 return (
                     State: (string)data["data"]["node"]["state"],
                     RepositoryName: (string)data["data"]["node"]["repositoryName"],
+                    WarningsCount: (int)data["data"]["node"]["warningsCount"],
                     FailureReason: (string)data["data"]["node"]["failureReason"],
                     MigrationLogUrl: (string)data["data"]["node"]["migrationLogUrl"]);
             });

--- a/src/OctoshiftCLI.Tests/Octoshift/Handlers/WaitForMigrationCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Handlers/WaitForMigrationCommandHandlerTests.cs
@@ -35,9 +35,9 @@ public class WaitForMigrationCommandHandlerTests
     {
         // Arrange
         _mockGithubApi.SetupSequence(x => x.GetMigration(REPO_MIGRATION_ID).Result)
-            .Returns((State: RepositoryMigrationStatus.InProgress, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
-            .Returns((State: RepositoryMigrationStatus.InProgress, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
-            .Returns((State: RepositoryMigrationStatus.Succeeded, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL));
+            .Returns((State: RepositoryMigrationStatus.InProgress, RepositoryName: TARGET_REPO, WarningsCount: 0, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
+            .Returns((State: RepositoryMigrationStatus.InProgress, RepositoryName: TARGET_REPO, WarningsCount: 0, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
+            .Returns((State: RepositoryMigrationStatus.Succeeded, RepositoryName: TARGET_REPO, WarningsCount: 0, FailureReason: null, MigrationLogUrl: MIGRATION_URL));
         _mockGithubApi.Setup(x => x.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((MIGRATION_URL, REPO_MIGRATION_ID));
 
         var actualLogOutput = new List<string>();
@@ -80,9 +80,9 @@ public class WaitForMigrationCommandHandlerTests
         const string failureReason = "FAILURE_REASON";
 
         _mockGithubApi.SetupSequence(x => x.GetMigration(REPO_MIGRATION_ID).Result)
-            .Returns((State: RepositoryMigrationStatus.InProgress, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
-            .Returns((State: RepositoryMigrationStatus.InProgress, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
-            .Returns((State: RepositoryMigrationStatus.Failed, RepositoryName: TARGET_REPO, FailureReason: failureReason, MigrationLogUrl: MIGRATION_URL));
+            .Returns((State: RepositoryMigrationStatus.InProgress, RepositoryName: TARGET_REPO, WarningsCount: 0, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
+            .Returns((State: RepositoryMigrationStatus.InProgress, RepositoryName: TARGET_REPO, WarningsCount: 0, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
+            .Returns((State: RepositoryMigrationStatus.Failed, RepositoryName: TARGET_REPO, WarningsCount: 0, FailureReason: failureReason, MigrationLogUrl: MIGRATION_URL));
         _mockGithubApi.Setup(x => x.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((MIGRATION_URL, REPO_MIGRATION_ID));
 
         var actualLogOutput = new List<string>();
@@ -129,9 +129,9 @@ public class WaitForMigrationCommandHandlerTests
         const string failureReason = "FAILURE_REASON";
 
         _mockGithubApi.SetupSequence(x => x.GetMigration(REPO_MIGRATION_ID).Result)
-            .Returns((State: RepositoryMigrationStatus.PendingValidation, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
-            .Returns((State: RepositoryMigrationStatus.PendingValidation, RepositoryName: TARGET_REPO, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
-            .Returns((State: RepositoryMigrationStatus.FailedValidation, RepositoryName: TARGET_REPO, FailureReason: failureReason, MigrationLogUrl: MIGRATION_URL));
+            .Returns((State: RepositoryMigrationStatus.PendingValidation, RepositoryName: TARGET_REPO, WarningsCount: 0, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
+            .Returns((State: RepositoryMigrationStatus.PendingValidation, RepositoryName: TARGET_REPO, WarningsCount: 0, FailureReason: null, MigrationLogUrl: MIGRATION_URL))
+            .Returns((State: RepositoryMigrationStatus.FailedValidation, RepositoryName: TARGET_REPO, WarningsCount: 0, FailureReason: failureReason, MigrationLogUrl: MIGRATION_URL));
         _mockGithubApi.Setup(x => x.GetMigrationLogUrl(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((MIGRATION_URL, REPO_MIGRATION_ID));
 
         var actualLogOutput = new List<string>();

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -1091,6 +1091,7 @@ public class GithubApiTests
                             ""name"": ""GHEC Archive Source""
                         }},
                         ""state"": ""{actualMigrationState}"",
+                        ""warningsCount"": 0,
                         ""failureReason"": """",
                         ""repositoryName"": ""{GITHUB_REPO}"",
                         ""migrationLogUrl"": ""{LOG_URL}""
@@ -1103,11 +1104,12 @@ public class GithubApiTests
             .ReturnsAsync(response);
 
         // Act
-        var (expectedMigrationState, expectedRepositoryName, expectedFailureReason, migrationLogUrl) = await _githubApi.GetMigration(migrationId);
+        var (expectedMigrationState, expectedRepositoryName, expectedWarningsCount, expectedFailureReason, migrationLogUrl) = await _githubApi.GetMigration(migrationId);
 
         // Assert
         expectedMigrationState.Should().Be(actualMigrationState);
         expectedRepositoryName.Should().Be(GITHUB_REPO);
+        expectedWarningsCount.Should().Be(0);
         expectedFailureReason.Should().BeEmpty();
         migrationLogUrl.Should().Be(LOG_URL);
     }
@@ -1146,7 +1148,7 @@ public class GithubApiTests
             .ReturnsAsync(response);
 
         // Act
-        var (expectedMigrationState, _, _, _) = await _githubApi.GetMigration(migrationId);
+        var (expectedMigrationState, _, _, _, _) = await _githubApi.GetMigration(migrationId);
 
         // Assert
         expectedMigrationState.Should().Be(actualMigrationState);
@@ -1187,7 +1189,7 @@ public class GithubApiTests
             .ReturnsAsync(response);
 
         // Act
-        var (expectedMigrationState, _, _, _) = await _githubApi.GetMigration(migrationId);
+        var (expectedMigrationState, _, _, _, _) = await _githubApi.GetMigration(migrationId);
 
         // Assert
         expectedMigrationState.Should().Be(actualMigrationState);
@@ -1226,7 +1228,7 @@ public class GithubApiTests
             .ReturnsAsync(response);
 
         // Act
-        var (_, _, expectedFailureReason, _) = await _githubApi.GetMigration(migrationId);
+        var (_, _, _, expectedFailureReason, _) = await _githubApi.GetMigration(migrationId);
 
         // Assert
         expectedFailureReason.Should().Be(actualFailureReason);

--- a/src/OctoshiftCLI.Tests/ado2gh/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -55,7 +55,7 @@ public class MigrateRepoCommandHandlerTests
                 null,
                 false).Result)
             .Returns(MIGRATION_ID);
-        _mockGithubApi.Setup(x => x.GetMigration(MIGRATION_ID).Result).Returns((State: RepositoryMigrationStatus.Succeeded, GITHUB_REPO, null, null));
+        _mockGithubApi.Setup(x => x.GetMigration(MIGRATION_ID).Result).Returns((State: RepositoryMigrationStatus.Succeeded, GITHUB_REPO, 0, null, null));
 
         _mockEnvironmentVariableProvider
             .Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>()))
@@ -172,7 +172,7 @@ public class MigrateRepoCommandHandlerTests
                     null,
                     false).Result)
             .Returns(MIGRATION_ID);
-        _mockGithubApi.Setup(x => x.GetMigration(MIGRATION_ID).Result).Returns((State: RepositoryMigrationStatus.Succeeded, GITHUB_REPO, null, null));
+        _mockGithubApi.Setup(x => x.GetMigration(MIGRATION_ID).Result).Returns((State: RepositoryMigrationStatus.Succeeded, GITHUB_REPO, 0, null, null));
 
         _mockEnvironmentVariableProvider
             .Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>()))
@@ -199,7 +199,7 @@ public class MigrateRepoCommandHandlerTests
     public async Task It_Falls_Back_To_Ado_And_Github_Pats_From_Environment_When_Not_Provided()
     {
         _mockGithubApi.Setup(x => x.GetRepos(GITHUB_ORG).Result).Returns(new List<(string Name, string Visibility)>());
-        _mockGithubApi.Setup(x => x.GetMigration(It.IsAny<string>()).Result).Returns((State: RepositoryMigrationStatus.Succeeded, GITHUB_REPO, null, null));
+        _mockGithubApi.Setup(x => x.GetMigration(It.IsAny<string>()).Result).Returns((State: RepositoryMigrationStatus.Succeeded, GITHUB_REPO, 0, null, null));
 
         _mockEnvironmentVariableProvider
             .Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>()))

--- a/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Handlers/MigrateRepoCommandHandlerTests.cs
@@ -209,7 +209,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null, null));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, null, null));
 
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken(It.IsAny<bool>())).Returns(sourceGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
@@ -256,7 +256,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null, null));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, null, null));
 
             _mockEnvironmentVariableProvider.Setup(m => m.AdoPersonalAccessToken(It.IsAny<bool>())).Returns(sourceAdoPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
@@ -305,7 +305,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null, null));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, null, null));
 
             _mockEnvironmentVariableProvider.Setup(m => m.AdoPersonalAccessToken(It.IsAny<bool>())).Returns(sourceAdoPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
@@ -360,7 +360,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null, null));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, null, null));
             _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
 
             _mockSourceGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
@@ -447,7 +447,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null, null));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, null, null));
 
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken(It.IsAny<bool>())).Returns(sourceGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
@@ -542,7 +542,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, SOURCE_REPO, null, null));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, SOURCE_REPO, 0, null, null));
 
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken(It.IsAny<bool>())).Returns(sourceGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
@@ -610,7 +610,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null, null));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, null, null));
             _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
 
             _mockSourceGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
@@ -676,7 +676,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null, null));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, null, null));
             _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
 
             _mockSourceGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
@@ -742,7 +742,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null, null));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, null, null));
             _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
 
             _mockSourceGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
@@ -836,7 +836,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null, null));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, null, null));
             _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
 
             _mockSourceGithubApi
@@ -1400,7 +1400,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, null, null));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, null, null));
             _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
 
             _mockSourceGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
@@ -1527,7 +1527,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, "", ""));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, "", ""));
             _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
 
             _mockSourceGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
@@ -1635,7 +1635,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, "", ""));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, "", ""));
             _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
 
             _mockSourceGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
@@ -1873,7 +1873,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     null,
                     false).Result)
                 .Returns(migrationId);
-            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, "", ""));
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, "", ""));
             _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
 
             _mockSourceGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);

--- a/src/ado2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/ado2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -105,13 +105,13 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             return;
         }
 
-        var (migrationState, _, failureReason, migrationLogUrl) = await _githubApi.GetMigration(migrationId);
+        var (migrationState, _, warningsCount, failureReason, migrationLogUrl) = await _githubApi.GetMigration(migrationId);
 
         while (RepositoryMigrationStatus.IsPending(migrationState))
         {
             _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. Waiting 10 seconds...");
             await Task.Delay(10000);
-            (migrationState, _, failureReason, migrationLogUrl) = await _githubApi.GetMigration(migrationId);
+            (migrationState, _, warningsCount, failureReason, migrationLogUrl) = await _githubApi.GetMigration(migrationId);
         }
 
         if (RepositoryMigrationStatus.IsFailed(migrationState))

--- a/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Handlers/MigrateRepoCommandHandler.cs
@@ -238,13 +238,13 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             return;
         }
 
-        var (migrationState, _, failureReason, migrationLogUrl) = await _githubApi.GetMigration(migrationId);
+        var (migrationState, _, warningsCount, failureReason, migrationLogUrl) = await _githubApi.GetMigration(migrationId);
 
         while (RepositoryMigrationStatus.IsPending(migrationState))
         {
             _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. Waiting 10 seconds...");
             await Task.Delay(CHECK_STATUS_DELAY_IN_MILLISECONDS);
-            (migrationState, _, failureReason, migrationLogUrl) = await _githubApi.GetMigration(migrationId);
+            (migrationState, _, warningsCount, failureReason, migrationLogUrl) = await _githubApi.GetMigration(migrationId);
         }
 
         if (RepositoryMigrationStatus.IsFailed(migrationState))

--- a/src/gei/Handlers/MigrateRepoCommandHandler.cs
+++ b/src/gei/Handlers/MigrateRepoCommandHandler.cs
@@ -148,13 +148,13 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             return;
         }
 
-        var (migrationState, _, failureReason, migrationLogUrl) = await _targetGithubApi.GetMigration(migrationId);
+        var (migrationState, _, warningsCount, failureReason, migrationLogUrl) = await _targetGithubApi.GetMigration(migrationId);
 
         while (RepositoryMigrationStatus.IsPending(migrationState))
         {
             _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. Waiting 10 seconds...");
             await Task.Delay(10000);
-            (migrationState, _, failureReason, migrationLogUrl) = await _targetGithubApi.GetMigration(migrationId);
+            (migrationState, _, warningsCount, failureReason, migrationLogUrl) = await _targetGithubApi.GetMigration(migrationId);
         }
 
         if (RepositoryMigrationStatus.IsFailed(migrationState))


### PR DESCRIPTION
Closes https://github.com/github/octoshift/issues/6948!

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->