### PR TITLE
fix regression in timestamps on arg logging

### DIFF
--- a/src/Octoshift/Commands/CommandArgs.cs
+++ b/src/Octoshift/Commands/CommandArgs.cs
@@ -21,7 +21,6 @@ namespace OctoshiftCLI.Commands
             }
 
             log.Verbose = Verbose;
-            var sb = new StringBuilder();
 
             foreach (var property in GetType().GetProperties())
             {
@@ -31,7 +30,7 @@ namespace OctoshiftCLI.Commands
                 {
                     if ((bool)property.GetValue(this))
                     {
-                        sb.AppendLine($"{logName}: true");
+                        log.LogInformation($"{logName}: true");
                     }
                 }
                 else
@@ -40,12 +39,10 @@ namespace OctoshiftCLI.Commands
 
                     if (propValue.HasValue() && propValue.ToString().HasValue())
                     {
-                        sb.AppendLine($"{logName}: {propValue}");
+                        log.LogInformation($"{logName}: {propValue}");
                     }
                 }
             }
-
-            log.LogInformation(sb.ToString());
         }
 
         private string GetLogName(string propertyName)

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/CommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/CommandArgsTests.cs
@@ -21,6 +21,7 @@ public class CommandArgsTests
     private readonly TestCommandArgs _args = new();
 
     private string _logOutput = string.Empty;
+    private int _logCallCount;
     private const string _secretValue = "password";
     private const string _multiWordArgValue = "foo";
     private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
@@ -32,7 +33,19 @@ public class CommandArgsTests
         _args.BooleanTrue = true;
         _args.BooleanFalse = false;
 
-        _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s => _logOutput = s);
+        _mockOctoLogger.Setup(m => m.LogInformation(It.IsAny<string>())).Callback<string>(s =>
+        {
+            _logOutput += $"{s}\n";
+            _logCallCount++;
+        });
+    }
+
+    [Fact]
+    public void Logs_Each_Property_Separately()
+    {
+        _args.Log(_mockOctoLogger.Object);
+
+        _logCallCount.Should().Be(3);
     }
 
     [Fact]


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

I noticed a regression in the log formatting introduced with #977 . Prior to that the args would be logged with a timestamp on each line, e.g.:
```
[2023-05-13 22:24:16] [INFO] ADO ORG: gei-e2e-testing-basic-linux
[2023-05-13 22:24:16] [INFO] ADO TEAM PROJECT: gei-e2e-2
[2023-05-13 22:24:16] [INFO] ADO REPO: gei-e2e-2
[2023-05-13 22:24:16] [INFO] GITHUB ORG: e2e-testing-ado-basic-linux
[2023-05-13 22:24:16] [INFO] GITHUB REPO: gei-e2e-2-gei-e2e-2
[2023-05-13 22:24:16] [INFO] QUEUE ONLY: true
[2023-05-13 22:24:16] [INFO] TARGET REPO VISIBILITY: private
```

But now only the first line has the timestamp:
```
[2023-05-16 23:50:54] [INFO] ADO ORG: gei-e2e-testing-basic-linux
ADO TEAM PROJECT: gei-e2e-2
ADO REPO: gei-e2e-2
GITHUB ORG: e2e-testing-ado-basic-linux
GITHUB REPO: gei-e2e-2-gei-e2e-2
QUEUE ONLY: true
TARGET REPO VISIBILITY: private
```

This looks wrong, and is an unintended regression from the previous behavior.

This happens because we were passing a multi-line string to `OctoLogger` instead of calling `LogInformation` separately for each log line.

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->