### PR TITLE
Properly migrate forks by passing BBS repo URL to GEI

### DIFF
--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -446,11 +446,11 @@ public class GithubApi
         }
     }
 
-    public virtual async Task<string> StartBbsMigration(string migrationSourceId, string orgId, string repo, string targetToken, string archiveUrl, string targetRepoVisibility = null)
+    public virtual async Task<string> StartBbsMigration(string migrationSourceId, string bbsRepoUrl, string orgId, string repo, string targetToken, string archiveUrl, string targetRepoVisibility = null)
     {
         return await StartMigration(
             migrationSourceId,
-            "https://not-used",  // source repository URL
+            bbsRepoUrl,  // source repository URL
             orgId,
             repo,
             "not-used",  // source access token

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -935,12 +935,12 @@ public class GithubApiTests
     {
         // Arrange
         const string migrationSourceId = "MIGRATION_SOURCE_ID";
+        const string sourceRepoUrl = "https://our-bbs-server.com/projects/BBS-PROJECT/repos/bbs-repo/browse";
         const string orgId = "ORG_ID";
         const string url = "https://api.github.com/graphql";
         const string gitArchiveUrl = "GIT_ARCHIVE_URL";
         const string targetToken = "TARGET_TOKEN";
 
-        const string unusedSourceRepoUrl = "https://not-used";
         const string unusedSourceToken = "not-used";
         const string unusedMetadataArchiveUrl = "https://not-used";
 
@@ -994,7 +994,7 @@ public class GithubApiTests
             {
                 sourceId = migrationSourceId,
                 ownerId = orgId,
-                sourceRepositoryUrl = unusedSourceRepoUrl,
+                sourceRepositoryUrl = sourceRepoUrl,
                 repositoryName = GITHUB_REPO,
                 continueOnError = true,
                 gitArchiveUrl,
@@ -1032,7 +1032,7 @@ public class GithubApiTests
             .ReturnsAsync(response);
 
         // Act
-        var expectedRepositoryMigrationId = await _githubApi.StartBbsMigration(migrationSourceId, orgId, GITHUB_REPO, targetToken, gitArchiveUrl);
+        var expectedRepositoryMigrationId = await _githubApi.StartBbsMigration(migrationSourceId, sourceRepoUrl, orgId, GITHUB_REPO, targetToken, gitArchiveUrl);
 
         // Assert
         expectedRepositoryMigrationId.Should().Be(actualRepositoryMigrationId);

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -44,6 +44,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
         private const string BBS_PASSWORD = "bbs-password";
         private const string BBS_PROJECT = "bbs-project";
         private const string BBS_REPO = "bbs-repo";
+        private const string BBS_REPO_URL = $"{BBS_HOST}/projects/{BBS_PROJECT}/repos/{BBS_REPO}/browse";
         private const string SSH_USER = "ssh-user";
         private const string PRIVATE_KEY = "private-key";
         private const string SMB_USER = "smb-user";
@@ -139,6 +140,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             // Assert
             _mockGithubApi.Verify(m => m.StartBbsMigration(
                 MIGRATION_SOURCE_ID,
+                BBS_REPO_URL,
                 GITHUB_ORG_ID,
                 GITHUB_REPO,
                 GITHUB_PAT,
@@ -180,6 +182,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             // Assert
             _mockGithubApi.Verify(m => m.StartBbsMigration(
                 MIGRATION_SOURCE_ID,
+                BBS_REPO_URL,
                 GITHUB_ORG_ID,
                 GITHUB_REPO,
                 GITHUB_PAT,
@@ -222,6 +225,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             // Assert
             _mockGithubApi.Verify(m => m.StartBbsMigration(
                 MIGRATION_SOURCE_ID,
+                BBS_REPO_URL,
                 GITHUB_ORG_ID,
                 GITHUB_REPO,
                 GITHUB_PAT,
@@ -276,6 +280,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
 
             _mockGithubApi.Verify(m => m.StartBbsMigration(
                 MIGRATION_SOURCE_ID,
+                BBS_REPO_URL,
                 GITHUB_ORG_ID,
                 GITHUB_REPO,
                 GITHUB_PAT,
@@ -317,6 +322,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             // Assert
             _mockGithubApi.Verify(m => m.StartBbsMigration(
                 MIGRATION_SOURCE_ID,
+                BBS_REPO_URL,
                 GITHUB_ORG_ID,
                 GITHUB_REPO,
                 GITHUB_PAT,
@@ -430,7 +436,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
             _mockGithubApi.Setup(x => x.CreateBbsMigrationSource(GITHUB_ORG_ID).Result).Returns(MIGRATION_SOURCE_ID);
             _mockGithubApi
-                .Setup(x => x.StartBbsMigration(MIGRATION_SOURCE_ID, GITHUB_ORG_ID, GITHUB_REPO, GITHUB_PAT, ARCHIVE_URL, null).Result)
+                .Setup(x => x.StartBbsMigration(MIGRATION_SOURCE_ID, BBS_REPO_URL, GITHUB_ORG_ID, GITHUB_REPO, GITHUB_PAT, ARCHIVE_URL, null).Result)
                 .Returns(MIGRATION_ID);
 
             // Act
@@ -447,6 +453,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             // Assert
             _mockGithubApi.Verify(m => m.StartBbsMigration(
                 MIGRATION_SOURCE_ID,
+                BBS_REPO_URL,
                 GITHUB_ORG_ID,
                 GITHUB_REPO,
                 githubPat,
@@ -464,7 +471,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
             _mockGithubApi.Setup(x => x.CreateBbsMigrationSource(GITHUB_ORG_ID).Result).Returns(MIGRATION_SOURCE_ID);
             _mockGithubApi
-                .Setup(x => x.StartBbsMigration(MIGRATION_SOURCE_ID, GITHUB_ORG_ID, GITHUB_REPO, GITHUB_PAT, ARCHIVE_URL, null).Result)
+                .Setup(x => x.StartBbsMigration(MIGRATION_SOURCE_ID, BBS_REPO_URL, GITHUB_ORG_ID, GITHUB_REPO, GITHUB_PAT, ARCHIVE_URL, null).Result)
                 .Throws(new OctoshiftCliException($"A repository called {GITHUB_ORG}/{GITHUB_REPO} already exists"));
 
             // Act
@@ -517,7 +524,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
             _mockGithubApi.Setup(x => x.CreateBbsMigrationSource(GITHUB_ORG_ID).Result).Returns(MIGRATION_SOURCE_ID);
             _mockGithubApi
-                .Setup(x => x.StartBbsMigration(MIGRATION_SOURCE_ID, GITHUB_ORG_ID, GITHUB_REPO, GITHUB_PAT, ARCHIVE_URL, null).Result)
+                .Setup(x => x.StartBbsMigration(MIGRATION_SOURCE_ID, BBS_REPO_URL, GITHUB_ORG_ID, GITHUB_REPO, GITHUB_PAT, ARCHIVE_URL, null).Result)
                 .Returns(MIGRATION_ID);
 
             // Act
@@ -534,6 +541,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             // Assert
             _mockGithubApi.Verify(m => m.StartBbsMigration(
                 MIGRATION_SOURCE_ID,
+                BBS_REPO_URL,
                 GITHUB_ORG_ID,
                 GITHUB_REPO,
                 GITHUB_PAT,
@@ -631,7 +639,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
             _mockGithubApi.Setup(x => x.CreateBbsMigrationSource(GITHUB_ORG_ID).Result).Returns(MIGRATION_SOURCE_ID);
             _mockGithubApi
-                .Setup(x => x.StartBbsMigration(MIGRATION_SOURCE_ID, GITHUB_ORG_ID, GITHUB_REPO, GITHUB_PAT, ARCHIVE_URL, null).Result)
+                .Setup(x => x.StartBbsMigration(MIGRATION_SOURCE_ID, BBS_REPO_URL, GITHUB_ORG_ID, GITHUB_REPO, GITHUB_PAT, ARCHIVE_URL, null).Result)
                 .Returns(MIGRATION_ID);
 
             _mockAwsApi.Setup(x => x.UploadToBucket(AWS_BUCKET_NAME, ARCHIVE_PATH, It.IsAny<string>())).ReturnsAsync(ARCHIVE_URL);
@@ -653,6 +661,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             // Assert
             _mockGithubApi.Verify(m => m.StartBbsMigration(
                 MIGRATION_SOURCE_ID,
+                BBS_REPO_URL,
                 GITHUB_ORG_ID,
                 GITHUB_REPO,
                 GITHUB_PAT,
@@ -897,6 +906,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
 
             // Assert
             _mockGithubApi.Verify(m => m.StartBbsMigration(
+                It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -183,6 +183,8 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         archiveUrl ??= args.ArchiveUrl;
 
+        var bbsRepoUrl = GetBbsRepoUrl(args.BbsServerUrl, args.BbsProject, args.BbsRepo);
+
         args.GithubPat ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
         var githubOrgId = await _githubApi.GetOrganizationId(args.GithubOrg);
         var migrationSourceId = await _githubApi.CreateBbsMigrationSource(githubOrgId);
@@ -191,7 +193,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         try
         {
-            migrationId = await _githubApi.StartBbsMigration(migrationSourceId, githubOrgId, args.GithubRepo, args.GithubPat, archiveUrl, args.TargetRepoVisibility);
+            migrationId = await _githubApi.StartBbsMigration(migrationSourceId, bbsRepoUrl, githubOrgId, args.GithubRepo, args.GithubPat, archiveUrl, args.TargetRepoVisibility);
         }
         catch (OctoshiftCliException ex) when (ex.Message == $"A repository called {args.GithubOrg}/{args.GithubRepo} already exists")
         {
@@ -242,6 +244,8 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
     private string GetBbsPassword(MigrateRepoCommandArgs args) => args.BbsPassword.HasValue() ? args.BbsPassword : _environmentVariableProvider.BbsPassword(false);
 
     private string GetSmbPassword(MigrateRepoCommandArgs args) => args.SmbPassword.HasValue() ? args.SmbPassword : _environmentVariableProvider.SmbPassword(false);
+
+    private string GetBbsRepoUrl(string url, string project, string repo) => $"{url.TrimEnd('/')}/projects/{project}/repos/{repo}/browse";
 
     private void ValidateOptions(MigrateRepoCommandArgs args)
     {


### PR DESCRIPTION
This PR updates the value passed in the `sourceRepositoryUrl` field when starting a repository migration in GEI to include the full BBS repo URL and is constructed using the values from the `--bbs-server-url`, `--bbs-project`, and `--bbs-repo` cli args. This change is being made, alongside upcoming GEI changes in the backend, to allow customers to properly migrate repositories that either are currently forks or used to be a fork but the parent repo was deleted. 

The [Bitbucket Server export API documentation](https://confluence.atlassian.com/bitbucketserver/exporting-957497835.html) states that when a fork is selected for export, all repos that are part of the fork network will be included in the export archive, which includes the parent repo and any other child forks of the parent repo. This resulted in a few error scenarios such as when a migration would fail with the `Multiple repositories found in archive` error or if the migration succeeded but instead of migrating the fork git data, the parent git data was picked instead.

This is my first contribution to the CLI so looking forward to any feedback!

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->