### PR TITLE
wait-for-migration should output info to log before calling API's

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,4 @@
 - Add new '--skip-invitation' flag for `reclaim-mannequin` to allow EMU organizations to reclaim mannequins without an email invitation
 - Write warnings to log and console if GitHub is experiencing an availability incident.
 - Improve the error thrown when you have insufficient permissions for the target GitHub organization to explicitly mention the relevant organization
-- Updated log order during migration for better readability
+- Write log output prior to making API calls in wait-for-migration commands

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
 - Add new '--skip-invitation' flag for `reclaim-mannequin` to allow EMU organizations to reclaim mannequins without an email invitation
 - Write warnings to log and console if GitHub is experiencing an availability incident.
 - Improve the error thrown when you have insufficient permissions for the target GitHub organization to explicitly mention the relevant organization
+- Updated log order during migration for better readability

--- a/src/Octoshift/Commands/WaitForMigration/WaitForMigrationCommandHandler.cs
+++ b/src/Octoshift/Commands/WaitForMigration/WaitForMigrationCommandHandler.cs
@@ -79,7 +79,7 @@ public class WaitForMigrationCommandHandler : ICommandHandler<WaitForMigrationCo
 
         var (state, repositoryName, failureReason, migrationLogUrl) = await githubApi.GetMigration(migrationId);
 
-        _log.LogInformation($"Waiting for migration of repository (name: {repositoryName}) to finish...");
+        _log.LogInformation($"Waiting for migration of repository {repositoryName} to finish...");
 
         while (true)
         {

--- a/src/Octoshift/Commands/WaitForMigration/WaitForMigrationCommandHandler.cs
+++ b/src/Octoshift/Commands/WaitForMigration/WaitForMigrationCommandHandler.cs
@@ -75,9 +75,11 @@ public class WaitForMigrationCommandHandler : ICommandHandler<WaitForMigrationCo
 
     private async Task WaitForRepositoryMigration(string migrationId, GithubApi githubApi)
     {
+        _log.LogInformation($"Waiting for migration (ID: {migrationId}) to finish...");
+
         var (state, repositoryName, failureReason, migrationLogUrl) = await githubApi.GetMigration(migrationId);
 
-        _log.LogInformation($"Waiting for {repositoryName} migration (ID: {migrationId}) to finish...");
+        _log.LogInformation($"Waiting for migration of repository (name: {repositoryName}) to finish...");
 
         while (true)
         {

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/WaitForMigration/WaitForMigrationCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/WaitForMigration/WaitForMigrationCommandHandlerTests.cs
@@ -45,7 +45,8 @@ public class WaitForMigrationCommandHandlerTests
 
         var expectedLogOutput = new List<string>
             {
-                $"Waiting for {TARGET_REPO} migration (ID: {REPO_MIGRATION_ID}) to finish...",
+                $"Waiting for migration (ID: {REPO_MIGRATION_ID}) to finish...",
+                $"Waiting for migration of repository (name: {TARGET_REPO}) to finish...",
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.InProgress}",
                 $"Waiting {WAIT_INTERVAL} seconds...",
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.InProgress}",
@@ -62,7 +63,7 @@ public class WaitForMigrationCommandHandlerTests
         await _handler.Handle(args);
 
         // Assert
-        _mockOctoLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(6));
+        _mockOctoLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
         _mockOctoLogger.Verify(m => m.LogSuccess(It.IsAny<string>()), Times.Once);
 
         _mockGithubApi.Verify(m => m.GetMigration(REPO_MIGRATION_ID), Times.Exactly(3));
@@ -90,7 +91,8 @@ public class WaitForMigrationCommandHandlerTests
 
         var expectedLogOutput = new List<string>
             {
-                $"Waiting for {TARGET_REPO} migration (ID: {REPO_MIGRATION_ID}) to finish...",
+                $"Waiting for migration (ID: {REPO_MIGRATION_ID}) to finish...",
+                $"Waiting for migration of repository (name: {TARGET_REPO}) to finish...",
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.InProgress}",
                 $"Waiting {WAIT_INTERVAL} seconds...",
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.InProgress}",
@@ -111,7 +113,7 @@ public class WaitForMigrationCommandHandlerTests
             .WithMessage(failureReason);
 
         // Assert
-        _mockOctoLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(6));
+        _mockOctoLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
         _mockOctoLogger.Verify(m => m.LogError(It.IsAny<string>()), Times.Once);
 
         _mockGithubApi.Verify(m => m.GetMigration(REPO_MIGRATION_ID), Times.Exactly(3));
@@ -139,7 +141,8 @@ public class WaitForMigrationCommandHandlerTests
 
         var expectedLogOutput = new List<string>
             {
-                $"Waiting for {TARGET_REPO} migration (ID: {REPO_MIGRATION_ID}) to finish...",
+                $"Waiting for migration (ID: {REPO_MIGRATION_ID}) to finish...",
+                $"Waiting for migration of repository (name: {TARGET_REPO}) to finish...",
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.PendingValidation}",
                 $"Waiting {WAIT_INTERVAL} seconds...",
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.PendingValidation}",
@@ -161,7 +164,7 @@ public class WaitForMigrationCommandHandlerTests
 
         // Assert
 
-        _mockOctoLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(6));
+        _mockOctoLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
         _mockOctoLogger.Verify(m => m.LogError(It.IsAny<string>()), Times.Once);
 
         _mockGithubApi.Verify(m => m.GetMigration(REPO_MIGRATION_ID), Times.Exactly(3));

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/WaitForMigration/WaitForMigrationCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/WaitForMigration/WaitForMigrationCommandHandlerTests.cs
@@ -46,7 +46,7 @@ public class WaitForMigrationCommandHandlerTests
         var expectedLogOutput = new List<string>
             {
                 $"Waiting for migration (ID: {REPO_MIGRATION_ID}) to finish...",
-                $"Waiting for migration of repository (name: {TARGET_REPO}) to finish...",
+                $"Waiting for migration of repository {TARGET_REPO} to finish...",
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.InProgress}",
                 $"Waiting {WAIT_INTERVAL} seconds...",
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.InProgress}",
@@ -92,7 +92,7 @@ public class WaitForMigrationCommandHandlerTests
         var expectedLogOutput = new List<string>
             {
                 $"Waiting for migration (ID: {REPO_MIGRATION_ID}) to finish...",
-                $"Waiting for migration of repository (name: {TARGET_REPO}) to finish...",
+                $"Waiting for migration of repository {TARGET_REPO} to finish...",
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.InProgress}",
                 $"Waiting {WAIT_INTERVAL} seconds...",
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.InProgress}",
@@ -142,7 +142,7 @@ public class WaitForMigrationCommandHandlerTests
         var expectedLogOutput = new List<string>
             {
                 $"Waiting for migration (ID: {REPO_MIGRATION_ID}) to finish...",
-                $"Waiting for migration of repository (name: {TARGET_REPO}) to finish...",
+                $"Waiting for migration of repository {TARGET_REPO} to finish...",
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.PendingValidation}",
                 $"Waiting {WAIT_INTERVAL} seconds...",
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.PendingValidation}",


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

closes: https://github.com/github/gh-gei/issues/683

Adding a info log before API call, as sometimes logs weird if an API call fails.

<img width="1323" alt="Screenshot 2023-05-25 at 1 45 31 PM" src="https://github.com/github/gh-gei/assets/240665/ab53c2cd-dc78-483a-b5fd-d237f8b486ce">


- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->