### PR TITLE
Add missing release notes from #1000

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 
+- Hide the `reclaim-mannequin --skip-invitation` option from documentation, since it's still under development and not yet available


### PR DESCRIPTION
In #1000, I hid the `--skip-invitation` flag in the documentation for the `reclaim-mannequin` command because it's not yet available and working - but I forgot to update the release notes.

This adds release notes so we can actually release this tweak.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->