### PR TITLE
Skip ADO Server integration tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -151,7 +151,7 @@ jobs:
       fail-fast: false
       matrix:
         runner-os: [windows-latest, ubuntu-latest, macos-latest]
-        source-vcs: [AdoBasic, AdoCsv, AdoServer, Bbs, Ghes, Github]
+        source-vcs: [AdoBasic, AdoCsv, Bbs, Ghes, Github]
     runs-on: ${{ matrix.runner-os }}
     concurrency: integration-test-${{ matrix.source-vcs }}-${{ matrix.runner-os }}
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       matrix:
         runner-os: [windows-latest, ubuntu-latest, macos-latest]
-        source-vcs: [AdoBasic, AdoCsv, AdoServer, Bbs, Ghes, Github]
+        source-vcs: [AdoBasic, AdoCsv, Bbs, Ghes, Github]
     runs-on: ${{ matrix.runner-os }}
     concurrency: integration-test-${{ matrix.source-vcs }}-${{ matrix.runner-os }}
     steps:

--- a/src/OctoshiftCLI.IntegrationTests/AdoServerToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoServerToGithub.cs
@@ -13,7 +13,7 @@ namespace OctoshiftCLI.IntegrationTests
         {
         }
 
-        [Fact]
+        [Fact (Skip = "ADO Server is not a supported feature in GEI")]
         public async Task Basic()
         {
             var adoOrg = $"gei-e2e-testing-basic-{TestHelper.GetOsName()}";

--- a/src/OctoshiftCLI.IntegrationTests/AdoServerToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/AdoServerToGithub.cs
@@ -13,7 +13,7 @@ namespace OctoshiftCLI.IntegrationTests
         {
         }
 
-        [Fact (Skip = "ADO Server is not a supported feature in GEI")]
+        [Fact(Skip = "ADO Server is not a supported feature in GEI")]
         public async Task Basic()
         {
             var adoOrg = $"gei-e2e-testing-basic-{TestHelper.GetOsName()}";


### PR DESCRIPTION
Part of https://github.com/github/octoshift/issues/7146!

We don't officially support ADO Server yet, so this PR skips the ADO Server integration tests :+1: 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->