### PR TITLE
Improve log secret sanitization to remove secrets that have been URL encoded

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Improve log sanitization to also remove secret values that have been URL encoded

--- a/src/Octoshift/Services/OctoLogger.cs
+++ b/src/Octoshift/Services/OctoLogger.cs
@@ -83,7 +83,8 @@ public class OctoLogger
 
         foreach (var secret in _secrets.Where(x => x is not null))
         {
-            result = result.Replace(secret, "***");
+            result = result.Replace(secret, "***")
+                .Replace(Uri.EscapeDataString(secret), "***");
         }
 
         return result;

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
@@ -25,25 +25,39 @@ public class OctoLoggerTests
     public void Secrets_Should_Be_Masked_From_Logs_And_Console()
     {
         var secret = "purplemonkeydishwasher";
+        var urlEncodedSecret = Uri.EscapeDataString(secret);
 
         _octoLogger.RegisterSecret(secret);
 
         _octoLogger.Verbose = false;
         _octoLogger.LogInformation($"Don't tell anybody that {secret} is my password");
+        _octoLogger.LogInformation($"Don't tell anyone that {urlEncodedSecret} is my URL encoded password");
         _octoLogger.LogVerbose($"Don't tell anybody that {secret} is my password");
+        _octoLogger.LogVerbose($"Don't tell anyone that {urlEncodedSecret} is my URL encoded password");
         _octoLogger.LogWarning($"Don't tell anybody that {secret} is my password");
+        _octoLogger.LogWarning($"Don't tell anyone that {urlEncodedSecret} is my URL encoded password");
         _octoLogger.LogSuccess($"Don't tell anybody that {secret} is my password");
+        _octoLogger.LogSuccess($"Don't tell anyone that {urlEncodedSecret} is my URL encoded password");
         _octoLogger.LogError($"Don't tell anybody that {secret} is my password");
+        _octoLogger.LogError($"Don't tell anyone that {urlEncodedSecret} is my URL encoded password");
         _octoLogger.LogError(new OctoshiftCliException($"Don't tell anybody that {secret} is my password"));
+        _octoLogger.LogError(new OctoshiftCliException($"Don't tell anyone that {urlEncodedSecret} is my URL encoded password"));
         _octoLogger.LogError(new InvalidOperationException($"Don't tell anybody that {secret} is my password"));
+        _octoLogger.LogError(new InvalidOperationException($"Don't tell anyone that {urlEncodedSecret} is my URL encoded password"));
 
         _octoLogger.Verbose = true;
         _octoLogger.LogVerbose($"Don't tell anybody that {secret} is my password");
+        _octoLogger.LogVerbose($"Don't tell anyone that {urlEncodedSecret} is my URL encoded password");
 
         _consoleOutput.Should().NotContain(secret);
         _logOutput.Should().NotContain(secret);
         _verboseLogOutput.Should().NotContain(secret);
         _consoleError.Should().NotContain(secret);
+
+        _consoleOutput.Should().NotContain(urlEncodedSecret);
+        _logOutput.Should().NotContain(urlEncodedSecret);
+        _verboseLogOutput.Should().NotContain(urlEncodedSecret);
+        _consoleError.Should().NotContain(urlEncodedSecret);
     }
 
     [Fact]


### PR DESCRIPTION
When logging with `Octologger` to the console output and log files, we sanitize secrets, replacing them with `***`.

We identify what values are secrets - and so should be replaced - by marking certain command line arguments as secret.

Each time we log, we go through those registered secret values and perform a simple "search and replace" to remove them.

This updates that logic to also remove the URL-encoded version of each secret which can appear where GraphQL request bodies are logged.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->