### PR TITLE
Log a warning when `bbs2gh`'s `--ssh-port` is set to the port usually used for Git operations

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Warn when the `--ssh-port` argument for `bbs2gh migrate-repo` and `bbs2gh generate-script` is set to the default port for Git operations

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScript/GenerateScriptCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScript/GenerateScriptCommandArgsTests.cs
@@ -24,4 +24,14 @@ public class GenerateScriptCommandArgsTests
             .ThrowExactly<OctoshiftCliException>()
             .WithMessage("*--no-ssl-verify*--bbs-server-url*");
     }
+
+    [Fact]
+    public void Invoke_With_Ssh_Port_Set_To_7999_Logs_Warning()
+    {
+        _args.SshPort = 7999;
+
+        _args.Validate(_mockOctoLogger.Object);
+
+        _mockOctoLogger.Verify(x => x.LogWarning(It.Is<string>(x => x.ToLower().Contains("--ssh-port is set to 7999"))));
+    }
 }

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
@@ -626,5 +626,26 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
                 .ThrowExactly<OctoshiftCliException>()
                 .WithMessage("*--bbs-server-url*--archive-path*--archive-url*");
         }
+
+        [Fact]
+        public void Invoke_With_Ssh_Port_Set_To_7999_Logs_Warning()
+        {
+            var args = new MigrateRepoCommandArgs
+            {
+                BbsProject = BBS_PROJECT,
+                BbsRepo = BBS_REPO,
+                BbsServerUrl = BBS_SERVER_URL,
+                BbsUsername = BBS_USERNAME,
+                BbsPassword = BBS_PASSWORD,
+                AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                SshPort = 7999
+            };
+
+            args.Validate(_mockOctoLogger.Object);
+
+            _mockOctoLogger.Verify(x => x.LogWarning(It.Is<string>(x => x.ToLower().Contains("--ssh-port is set to 7999"))));
+        }
     }
 }

--- a/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommandArgs.cs
+++ b/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommandArgs.cs
@@ -33,5 +33,10 @@ public class GenerateScriptCommandArgs : CommandArgs
         {
             throw new OctoshiftCliException("--no-ssl-verify can only be provided with --bbs-server-url.");
         }
+
+        if (SshPort == 7999)
+        {
+            log?.LogWarning("--ssh-port is set to 7999, which is the default port that Bitbucket Server and Bitbucket Data Center use for Git operations over SSH. This is probably the wrong value, because --ssh-port should be configured with the SSH port used to manage the server where Bitbucket Server/Bitbucket Data Center is running, not the port used for Git operations over SSH.");
+        }
     }
 }

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
@@ -108,6 +108,11 @@ public class MigrateRepoCommandArgs : CommandArgs
         {
             log?.LogWarning("The default behavior has changed from only queueing the migration, to waiting for the migration to finish. If you ran this as part of a script to run multiple migrations in parallel, consider using the new --queue-only option to preserve the previous default behavior. This warning will be removed in a future version.");
         }
+
+        if (SshPort == 7999)
+        {
+            log?.LogWarning("--ssh-port is set to 7999, which is the default port that Bitbucket Server and Bitbucket Data Center use for Git operations over SSH. This is probably the wrong value, because --ssh-port should be configured with the SSH port used to manage the server where Bitbucket Server/Bitbucket Data Center is running, not the port used for Git operations over SSH.");
+        }
     }
 
     private void ValidateNoGenerateOptions()


### PR DESCRIPTION
This updates `bbs2gh migrate-repo` and `bbs2gh generate-script` to log a warning when `--ssh port` is set to `7999`.

By default, Bitbucket Server and Bitbucket Data Center [use][1] this port for Git operations over SSH, so it's likely that users will think this is the correct port to use. But in fact, you need to use the SSH port used to administer the server where Bitbucket is running, not this special port which is only used for Git-over- SSH.

Adding a warning will help to point out that users have probably made a mistake, and point them in the right direction!

[1]:
https://confluence.atlassian.com/bitbucketserver/setting-up-ssh-port-forwarding-776640364.html#:~:text=Bitbucket%C2%A0listens%20for%20SSH%20connections%20on%20port%207999%20by%20default.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->