### PR TITLE
Fix recommended follow-up commands outputted to the logs

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Fix recommended `gh gei`, `gh bbs2gh` and `gh ado2gh` commands in log output

--- a/src/Octoshift/CliContext.cs
+++ b/src/Octoshift/CliContext.cs
@@ -23,5 +23,11 @@ namespace OctoshiftCLI
                 : throw new InvalidOperationException("Value can only be set once.");
             get => _executingCommand;
         }
+
+        public static void Clear()
+        {
+            _rootCommand = null;
+            _executingCommand = null;
+        }
     }
 }

--- a/src/Octoshift/CliContext.cs
+++ b/src/Octoshift/CliContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 
 namespace OctoshiftCLI
 {
@@ -10,7 +11,7 @@ namespace OctoshiftCLI
         public static string RootCommand
         {
             set => _rootCommand = _rootCommand is null
-                ? value
+                ? Regex.Replace(value, @"^gh-", string.Empty)
                 : throw new InvalidOperationException("Value can only be set once.");
             get => _rootCommand;
         }

--- a/src/OctoshiftCLI.Tests/Octoshift/CliContextTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/CliContextTests.cs
@@ -6,7 +6,7 @@ namespace OctoshiftCLI.Tests.Octoshift;
 public class CliContextTests
 {
     [Fact]
-    public void SetRootCommandShouldRemoveGhPrefix()
+    public void Set_RootCommand_Should_Remove_Gh_Prefix()
     {
         CliContext.Clear();
 
@@ -17,7 +17,7 @@ public class CliContextTests
     }
 
     [Fact]
-    public void SetRootCommandShouldNotChangeValueWithoutGhPrefix()
+    public void Set_RootCommand_Should_Not_Change_Value_Without_Gh_Prefix()
     {
         CliContext.Clear();
 

--- a/src/OctoshiftCLI.Tests/Octoshift/CliContextTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/CliContextTests.cs
@@ -1,0 +1,29 @@
+using FluentAssertions;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.Octoshift;
+
+public class CliContextTests
+{
+    [Fact]
+    public void SetRootCommandShouldRemoveGhPrefix()
+    {
+        CliContext.Clear();
+
+        CliContext.RootCommand = "gh-gei";
+        CliContext.RootCommand.Should().Be("gei");
+
+        CliContext.Clear();
+    }
+
+    [Fact]
+    public void SetRootCommandShouldNotChangeValueWithoutGhPrefix()
+    {
+        CliContext.Clear();
+
+        CliContext.RootCommand = "bbs2gh";
+        CliContext.RootCommand.Should().Be("bbs2gh");
+
+        CliContext.Clear();
+    }
+}

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/VersionCheckerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/VersionCheckerTests.cs
@@ -13,6 +13,7 @@ public class VersionCheckerTests
         const string rootCommand = "ROOT_COMMAND";
         const string executingCommand = "EXECUTING_COMMAND";
 
+        CliContext.Clear();
         CliContext.RootCommand = rootCommand;
         CliContext.ExecutingCommand = executingCommand;
 
@@ -23,5 +24,7 @@ public class VersionCheckerTests
 
         // Assert
         comments.Should().Be($"({rootCommand}/{executingCommand})");
+
+        CliContext.Clear();
     }
 }


### PR DESCRIPTION
In a number of places in the CLI, we recommend follow-up `gh [gei|bbs2gh|ado2gh]` commands to run.

When the CLI is run as a `gh` extension rather than standalone, the examples commands we output in the logs are incorrect, repeating `gh` twice (e.g. `gh gh-gei`).

This fixes it so we produce accurate, usable commands that you can actually run.

I chose to fix this in `CliContext.RootCommand` (as [suggested][1] by @dylan-smith). It would also have been possible to fix this in the `Program` classes that set `CliContext.RootCommand`, but that would have required duplicating logic in 3 places.

Fixes https://github.com/github/gh-gei/issues/1033.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->