### PR TITLE
Require the Bitbucket Server URL, project and repo name to always be passed for `bbs2gh migrate-repo`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
+- __BREAKING CHANGE__: Require the Bitbucket Server URL, project key and repo to always be provided for `bbs2gh migrate-repo`, even if using the upload-and-migrate (`--archive-path`) or migrate-only (`--archive-url`) flows
 - Drop support for deprecated `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` environment variables in `gh gei` and `gh bbs2gh`. The AWS S3 credentials can now be configured using the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variables or command line arguments.
 - Increase timeouts in archive uploads to AWS to prevent timeouts during large uploads

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
@@ -284,44 +284,6 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
         }
 
         [Fact]
-        public void Errors_If_BbsServer_Url_Not_Provided_But_Bbs_Project_Is_Provided()
-        {
-            // Act
-            var args = new MigrateRepoCommandArgs
-            {
-                ArchivePath = ARCHIVE_PATH,
-                GithubOrg = GITHUB_ORG,
-                GithubRepo = GITHUB_REPO,
-                BbsProject = BBS_PROJECT
-            };
-
-            // Assert
-            args.Invoking(x => x.Validate(_mockOctoLogger.Object))
-                .Should()
-                .ThrowExactly<OctoshiftCliException>()
-                .WithMessage("*--bbs-project*--bbs-server-url*");
-        }
-
-        [Fact]
-        public void Errors_If_BbsServer_Url_Not_Provided_But_Bbs_Repo_Is_Provided()
-        {
-            // Act
-            var args = new MigrateRepoCommandArgs
-            {
-                ArchivePath = ARCHIVE_PATH,
-                GithubOrg = GITHUB_ORG,
-                GithubRepo = GITHUB_REPO,
-                BbsRepo = BBS_REPO
-            };
-
-            // Assert
-            args.Invoking(x => x.Validate(_mockOctoLogger.Object))
-                .Should()
-                .ThrowExactly<OctoshiftCliException>()
-                .WithMessage("*--bbs-repo*--bbs-server-url*");
-        }
-
-        [Fact]
         public void It_Throws_If_Github_Org_Is_Provided_But_Github_Repo_Is_Not()
         {
             // Act
@@ -573,7 +535,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
         }
 
         [Fact]
-        public void Errors_If_BbsServer_Url_And_Archive_Url_Are_Passed()
+        public void Allows_BbsServer_Url_And_Archive_Url_To_Be_Passed_Together()
         {
             // Act
             var args = new MigrateRepoCommandArgs
@@ -587,12 +549,11 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             // Assert
             args.Invoking(x => x.Validate(_mockOctoLogger.Object))
                 .Should()
-                .ThrowExactly<OctoshiftCliException>()
-                .WithMessage("*--bbs-server-url*--archive-url*");
+                .NotThrow();
         }
 
         [Fact]
-        public void Errors_If_BbsServer_Url_And_Archive_Path_Are_Passed()
+        public void Allows_BbsServer_Url_And_Archive_Path_To_Be_Passed_Together()
         {
             // Act
             var args = new MigrateRepoCommandArgs
@@ -606,8 +567,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             // Assert
             args.Invoking(x => x.Validate(_mockOctoLogger.Object))
                 .Should()
-                .ThrowExactly<OctoshiftCliException>()
-                .WithMessage("*--bbs-server-url*--archive-path*");
+                .NotThrow();
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandTests.cs
@@ -56,9 +56,9 @@ public class MigrateRepoCommandTests
         command.Name.Should().Be("migrate-repo");
         command.Options.Count.Should().Be(31);
 
-        TestHelpers.VerifyCommandOption(command.Options, "bbs-server-url", false);
-        TestHelpers.VerifyCommandOption(command.Options, "bbs-project", false);
-        TestHelpers.VerifyCommandOption(command.Options, "bbs-repo", false);
+        TestHelpers.VerifyCommandOption(command.Options, "bbs-server-url", true);
+        TestHelpers.VerifyCommandOption(command.Options, "bbs-project", true);
+        TestHelpers.VerifyCommandOption(command.Options, "bbs-repo", true);
         TestHelpers.VerifyCommandOption(command.Options, "bbs-username", false);
         TestHelpers.VerifyCommandOption(command.Options, "bbs-password", false);
         TestHelpers.VerifyCommandOption(command.Options, "archive-url", false);

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -52,15 +52,24 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
 
     public Option<string> BbsServerUrl { get; } = new(
         name: "--bbs-server-url",
-        description: "The full URL of the Bitbucket Server/Data Center to migrate from. E.g. http://bitbucket.contoso.com:7990");
+        description: "The full URL of the Bitbucket Server/Data Center to migrate from. E.g. http://bitbucket.contoso.com:7990")
+    {
+        IsRequired = true
+    };
 
     public Option<string> BbsProject { get; } = new(
         name: "--bbs-project",
-        description: "The Bitbucket project to migrate.");
+        description: "The Bitbucket project to migrate.")
+    {
+        IsRequired = true
+    };
 
     public Option<string> BbsRepo { get; } = new(
         name: "--bbs-repo",
-        description: "The Bitbucket repository to migrate.");
+        description: "The Bitbucket repository to migrate.")
+    {
+        IsRequired = true
+    };
 
     public Option<string> BbsUsername { get; } = new(
         name: "--bbs-username",

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
@@ -59,16 +59,6 @@ public class MigrateRepoCommandArgs : CommandArgs
             throw new OctoshiftCliException("Either --bbs-server-url, --archive-path, or --archive-url must be specified.");
         }
 
-        if (BbsServerUrl.HasValue() && ArchiveUrl.HasValue())
-        {
-            throw new OctoshiftCliException("Only one of --bbs-server-url or --archive-url can be specified.");
-        }
-
-        if (BbsServerUrl.HasValue() && ArchivePath.HasValue())
-        {
-            throw new OctoshiftCliException("Only one of --bbs-server-url or --archive-path can be specified.");
-        }
-
         if (ArchivePath.HasValue() && ArchiveUrl.HasValue())
         {
             throw new OctoshiftCliException("Only one of --archive-path or --archive-url can be specified.");
@@ -127,23 +117,19 @@ public class MigrateRepoCommandArgs : CommandArgs
             throw new OctoshiftCliException("--no-ssl-verify can only be provided with --bbs-server-url.");
         }
 
-        if (BbsProject.HasValue() || BbsRepo.HasValue())
-        {
-            throw new OctoshiftCliException("--bbs-project and --bbs-repo can only be provided with --bbs-server-url.");
-        }
-
         if (new[] { SshUser, SshPrivateKey, ArchiveDownloadHost, SmbUser, SmbPassword, SmbDomain }.Any(obj => obj.HasValue()))
         {
             throw new OctoshiftCliException("SSH or SMB download options can only be provided with --bbs-server-url.");
         }
     }
 
-    public bool ShouldGenerateArchive() => BbsServerUrl.HasValue();
+    public bool ShouldGenerateArchive() => BbsServerUrl.HasValue() && !ArchivePath.HasValue() && !ArchiveUrl.HasValue();
 
     public bool ShouldDownloadArchive() => SshUser.HasValue() || SmbUser.HasValue();
 
     public bool ShouldUploadArchive() => ArchiveUrl.IsNullOrWhiteSpace() && GithubOrg.HasValue();
 
+    // NOTE: ArchiveUrl doesn't necessarily refer to the value passed in by the user to the CLI - it is set during CLI runtime when an archive is uploaded to blob storage
     public bool ShouldImportArchive() => ArchiveUrl.HasValue() || GithubOrg.HasValue();
 
     private void ValidateGenerateOptions()


### PR DESCRIPTION
This makes a **breaking change** to `bbs2gh migrate-repo` requiring the `--bbs-server-url`, `--bbs-project` and `--bbs-repo` to always be passed, even in the flows where the CLI doesn't talk to the Bitbucket Server API.

This change allows us to always construct the URL of the repository and then send it to the GitHub API when starting the migration. 

That's important, because the URL allows us to intelligently pick the right repo to migrate from the archive, rather than picking the "first" repo in the fork hierarchy (which may be wrong!).

I did consider introducing a warning first and then making a breaking change, but I thought going straight to a breaking change was the right decision because:

* This is currently in private beta, so I can easily contact affected users
* We're getting ready to move to public beta very soon, and I want this to be "right" before the public beta
* The impact of this change is limited, given that most users use the default end-to-end flow

Fixes https://github.com/github/gh-gei/issues/1056.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->