### PR TITLE
Validates API Url before generating script

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Adds GHES API URL validation

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandArgsTests.cs
@@ -52,5 +52,25 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.GenerateScript
                 .Should()
                 .Throw<OctoshiftCliException>();
         }
+
+        [Fact]
+        public void It_Throws_When_Invalid_URL_Provided()
+        {
+            // Arrange
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                GithubTargetOrg = TARGET_ORG,
+                Output = new FileInfo("unit-test-output"),
+                NoSslVerify = true,
+                Sequential = true,
+                GhesApiUrl = "ww.invalidUr/l.c"
+            };
+
+            // Act, Assert
+            FluentActions.Invoking(() => args.Validate(_mockOctoLogger.Object))
+                .Should()
+                .Throw<OctoshiftCliException>();
+        }
     }
 }

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandArgs.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandArgs.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Extensions;
 using OctoshiftCLI.Services;
@@ -32,6 +33,18 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
             if (NoSslVerify && GhesApiUrl.IsNullOrWhiteSpace())
             {
                 throw new OctoshiftCliException("--ghes-api-url must be specified when --no-ssl-verify is specified.");
+            }
+
+            if (!GhesApiUrl.IsNullOrWhiteSpace())
+            {
+                Uri uriResult;
+                bool result = Uri.TryCreate(GhesApiUrl, UriKind.Absolute, out uriResult)
+                    && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
+
+                if (!result)
+                {
+                    throw new OctoshiftCliException("--ghes-api-url is invalid. Please check URL before trying again.");
+                }
             }
         }
     }

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandArgs.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandArgs.cs
@@ -37,8 +37,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
 
             if (!GhesApiUrl.IsNullOrWhiteSpace())
             {
-                Uri uriResult;
-                bool result = Uri.TryCreate(GhesApiUrl, UriKind.Absolute, out uriResult)
+                var result = Uri.TryCreate(GhesApiUrl, UriKind.Absolute, out var uriResult)
                     && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
 
                 if (!result)

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandArgs.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandArgs.cs
@@ -35,7 +35,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
                 throw new OctoshiftCliException("--ghes-api-url must be specified when --no-ssl-verify is specified.");
             }
 
-            if (!GhesApiUrl.IsNullOrWhiteSpace())
+            if (GhesApiUrl.HasValue())
             {
                 var result = Uri.TryCreate(GhesApiUrl, UriKind.Absolute, out var uriResult)
                     && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);


### PR DESCRIPTION
Closes #621 

Validates API Url before generating script. If URL is not in valid format, command will fail fast and provide appropriate error message:

![Screenshot 2023-07-11 at 10 57 55 AM](https://github.com/github/gh-gei/assets/38845272/685d6c1b-05dc-4cbd-86e2-79e5b4c3a292)

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)
