### PR TITLE
Improve performance of single mannequin reclaims by looking up the mannequin by its `login`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - Adds GHES API URL validation
 - Allow CLI to fail fast when an unauthorized token is provided by preventing retry logic on 401 errors
+- Improve performance when reclaiming a single mannequin with `reclaim-mannequin`

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1048,7 +1048,7 @@ public class GithubApi
         return new
         {
             query = $"{query} {{ {gql} }}",
-            variables = new { id = orgId, login = login }
+            variables = new { id = orgId, login }
         };
     }
 

--- a/src/Octoshift/Services/ReclaimService.cs
+++ b/src/Octoshift/Services/ReclaimService.cs
@@ -84,16 +84,7 @@ public class ReclaimService
     {
         var githubOrgId = await _githubApi.GetOrganizationId(githubOrg);
 
-        Mannequins mannequins;
-
-        if (String.IsNullOrEmpty(mannequinUser))
-        {
-            mannequins = new Mannequins((await GetMannequins(githubOrgId)).GetByLogin(mannequinUser, mannequinId));
-        }
-        else
-        {
-            mannequins = new Mannequins((await GetMannequinsByLogin(githubOrgId, mannequinUser)).GetByLogin(mannequinUser, mannequinId));
-        }
+        var mannequins = new Mannequins((await GetMannequinsByLogin(githubOrgId, mannequinUser)).GetByLogin(mannequinUser, mannequinId));
 
         if (mannequins.IsEmpty())
         {

--- a/src/Octoshift/Services/ReclaimService.cs
+++ b/src/Octoshift/Services/ReclaimService.cs
@@ -84,7 +84,17 @@ public class ReclaimService
     {
         var githubOrgId = await _githubApi.GetOrganizationId(githubOrg);
 
-        var mannequins = new Mannequins((await GetMannequins(githubOrgId)).GetByLogin(mannequinUser, mannequinId));
+        Mannequins mannequins;
+
+        if (String.IsNullOrEmpty(mannequinUser))
+        {
+            mannequins = new Mannequins((await GetMannequins(githubOrgId)).GetByLogin(mannequinUser, mannequinId));
+        }
+        else
+        {
+            mannequins = new Mannequins((await GetMannequinsByLogin(githubOrgId, mannequinUser)).GetByLogin(mannequinUser, mannequinId));
+        }
+
         if (mannequins.IsEmpty())
         {
             throw new OctoshiftCliException($"User {mannequinUser} is not a mannequin.");
@@ -234,6 +244,13 @@ public class ReclaimService
     private async Task<Mannequins> GetMannequins(string githubOrgId)
     {
         var returnedMannequins = await _githubApi.GetMannequins(githubOrgId);
+
+        return new Mannequins(returnedMannequins);
+    }
+
+    private async Task<Mannequins> GetMannequinsByLogin(string githubOrgId, string login)
+    {
+        var returnedMannequins = await _githubApi.GetMannequinsByLogin(githubOrgId, login);
 
         return new Mannequins(returnedMannequins);
     }

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -2167,7 +2167,7 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
 
         var mannequin = new
         {
-            login = login,
+            login,
             id = "DUMMYID1",
             claimant = new { }
         };

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/ReclaimServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/ReclaimServiceTests.cs
@@ -674,7 +674,7 @@ public class ReclaimServiceTests
         };
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
         _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN).Result).Returns(TARGET_USER_ID);
         _mockGithubApi.Setup(x => x.CreateAttributionInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse);
         _mockGithubApi.Setup(x => x.CreateAttributionInvitation(ORG_ID, mannequinUserId2, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse2);
@@ -708,7 +708,7 @@ public class ReclaimServiceTests
         };
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
         _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN).Result).Returns(TARGET_USER_ID);
         _mockGithubApi.Setup(x => x.CreateAttributionInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse);
 
@@ -739,7 +739,7 @@ public class ReclaimServiceTests
         };
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
         _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN).Result).Returns(TARGET_USER_ID);
         _mockGithubApi.Setup(x => x.CreateAttributionInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse);
 
@@ -783,7 +783,7 @@ public class ReclaimServiceTests
         };
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
         _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN).Result).Returns(TARGET_USER_ID);
         _mockGithubApi.Setup(x => x.CreateAttributionInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse);
         _mockGithubApi.Setup(x => x.CreateAttributionInvitation(ORG_ID, mannequinUserId2, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse2);
@@ -818,7 +818,7 @@ public class ReclaimServiceTests
         };
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
         _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN).Result).Returns(TARGET_USER_ID);
         _mockGithubApi.Setup(x => x.CreateAttributionInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse);
 
@@ -852,7 +852,7 @@ public class ReclaimServiceTests
         };
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
         _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN).Result).Returns(TARGET_USER_ID);
         _mockGithubApi.Setup(x => x.CreateAttributionInvitation(ORG_ID, null, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse);
 
@@ -874,7 +874,7 @@ public class ReclaimServiceTests
         };
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
 
         var reclaimService = new ReclaimService(_mockGithubApi.Object, TestHelpers.CreateMock<OctoLogger>().Object);
 
@@ -917,7 +917,7 @@ public class ReclaimServiceTests
         };
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
         _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN).Result).Returns(TARGET_USER_ID);
         _mockGithubApi.Setup(x => x.CreateAttributionInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse);
 
@@ -952,7 +952,7 @@ public class ReclaimServiceTests
         };
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
         _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN).Result).Returns(TARGET_USER_ID);
         _mockGithubApi.Setup(x => x.CreateAttributionInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse);
 
@@ -1005,7 +1005,7 @@ public class ReclaimServiceTests
         };
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
         _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN).Result).Returns(TARGET_USER_ID);
         _mockGithubApi.Setup(x => x.CreateAttributionInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse);
         _mockGithubApi.Setup(x => x.CreateAttributionInvitation(ORG_ID, mannequinUserId2, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse2);
@@ -1029,7 +1029,7 @@ public class ReclaimServiceTests
         var mannequinsResponse = Array.Empty<Mannequin>();
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
         _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN).Result).Returns(TARGET_USER_ID);
 
         // Act
@@ -1049,7 +1049,7 @@ public class ReclaimServiceTests
         };
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
         _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN)).Throws(new OctoshiftCliException("Could not resolve to a User with the login of 'idonotexist'."));
 
         // Act
@@ -1082,7 +1082,7 @@ public class ReclaimServiceTests
         };
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
         _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN).Result).Returns(TARGET_USER_ID);
         _mockGithubApi.Setup(x => x.ReclaimMannequinSkipInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse);
 
@@ -1091,7 +1091,7 @@ public class ReclaimServiceTests
 
         // Assert
         _mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG), Times.Once);
-        _mockGithubApi.Verify(m => m.GetMannequins(ORG_ID), Times.Once);
+        _mockGithubApi.Verify(m => m.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN), Times.Once);
         _mockGithubApi.Verify(x => x.CreateAttributionInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID), Times.Never);
         _mockGithubApi.Verify(x => x.ReclaimMannequinSkipInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID), Times.Once);
         _mockGithubApi.Verify(x => x.GetUserId(TARGET_USER_LOGIN), Times.Once);
@@ -1117,7 +1117,7 @@ public class ReclaimServiceTests
         };
 
         _mockGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(ORG_ID);
-        _mockGithubApi.Setup(x => x.GetMannequins(ORG_ID).Result).Returns(mannequinsResponse);
+        _mockGithubApi.Setup(x => x.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN).Result).Returns(mannequinsResponse);
         _mockGithubApi.Setup(x => x.GetUserId(TARGET_USER_LOGIN).Result).Returns(TARGET_USER_ID);
         _mockGithubApi.Setup(x => x.ReclaimMannequinSkipInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID).Result).Returns(reclaimMannequinResponse);
 
@@ -1129,7 +1129,7 @@ public class ReclaimServiceTests
 
         // Assert
         _mockGithubApi.Verify(m => m.GetOrganizationId(TARGET_ORG), Times.Once);
-        _mockGithubApi.Verify(m => m.GetMannequins(ORG_ID), Times.Once);
+        _mockGithubApi.Verify(m => m.GetMannequinsByLogin(ORG_ID, MANNEQUIN_LOGIN), Times.Once);
         _mockGithubApi.Verify(x => x.CreateAttributionInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID), Times.Never);
         _mockGithubApi.Verify(x => x.ReclaimMannequinSkipInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID), Times.Once);
         _mockGithubApi.Verify(x => x.GetUserId(TARGET_USER_LOGIN), Times.Once);


### PR DESCRIPTION
This PR improves the performance of the `reclaim-mannequin` command when used in "single reclaim" (non-CSV) mode.

Right now, to find the right mannequin(s), we paginate through all of the organization's mannequins, 100 at a time. For organizations with many mannequins, this can take a long time and use up a lot of rate limit points.

We recently introduced the ability to filter mannequins by `login` in the GraphQL API. This means that we can immediately look up the mannequins we actually care about, rather than going through all of them, searching for a needle in a haystack.

In a pathological case (e.g. 10000 mannequins, and the one you want happens to be on the last page), this can make the operation 100x faster.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->