### PR TITLE
Fix log messages when running `reclaim-mannequin`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - Adds GHES API URL validation
 - Allow CLI to fail fast when an unauthorized token is provided by preventing retry logic on 401 errors
+- Improve logging for `reclaim-mannequin` command

--- a/src/Octoshift/Services/ReclaimService.cs
+++ b/src/Octoshift/Services/ReclaimService.cs
@@ -242,7 +242,7 @@ public class ReclaimService
     {
         if (result.Errors != null)
         {
-            _log.LogError($"Failed to invite {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId}) Reason: {result.Errors[0].Message}");
+            _log.LogError($"Failed to send reclaim invitation email to {targetUser} for mannequin {mannequinUser} ({mannequin.Id}): {result.Errors[0].Message}");
             return false;
         }
 
@@ -250,11 +250,11 @@ public class ReclaimService
             result.Data.CreateAttributionInvitation.Source.Id != mannequin.Id ||
             result.Data.CreateAttributionInvitation.Target.Id != targetUserId)
         {
-            _log.LogError($"Failed to invite {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId})");
+            _log.LogError($"Failed to send reclaim invitation email to {targetUser} for mannequin {mannequinUser} ({mannequin.Id})");
             return false;
         }
 
-        _log.LogInformation($"Mannequin reclaim invitation email successfully sent to: {mannequinUser} ({mannequin.Id}) for {targetUser} ({targetUserId})");
+        _log.LogInformation($"Mannequin reclaim invitation email successfully sent to {targetUser} for {mannequinUser} ({mannequin.Id})");
 
         return true;
     }
@@ -270,7 +270,7 @@ public class ReclaimService
                     _log.LogError("Failed to reclaim mannequins. The --skip-invitation flag is only available to EMU organizations.");
                     return false; // Indicates we should stop parsing through the CSV
                 default:
-                    _log.LogWarning($"Failed to reclaim {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId}): {result.Errors[0].Message}");
+                    _log.LogWarning($"Failed to reattribute content belonging to mannequin {mannequinUser} ({mannequin.Id}) to {targetUser}: {result.Errors[0].Message}");
                     return true;
             }
         }
@@ -280,11 +280,11 @@ public class ReclaimService
             result.Data.ReattributeMannequinToUser.Target.Id != targetUserId)
         {
 
-            _log.LogWarning($"Failed to reclaim {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId})");
+            _log.LogWarning($"Failed to reattribute content belonging to mannequin {mannequinUser} ({mannequin.Id}) to {targetUser}");
             return true;
         }
 
-        _log.LogInformation($"Successfully reclaimed {mannequinUser} ({mannequin.Id}) to {targetUser} ({targetUserId})");
+        _log.LogInformation($"Successfully reclaimed content belonging to mannequin {mannequinUser} ({mannequin.Id}) to {targetUser}");
 
         return true; // Indiciates we should continue onto the next mannequin
     }

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/ReclaimServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/ReclaimServiceTests.cs
@@ -962,7 +962,7 @@ public class ReclaimServiceTests
             .Should().ThrowAsync<OctoshiftCliException>();
         exception.WithMessage("Failed to send reclaim mannequin invitation(s).");
 
-        _mockOctoLogger.Verify(m => m.LogError($"Failed to invite {MANNEQUIN_LOGIN} ({MANNEQUIN_ID}) to {TARGET_USER_LOGIN} ({TARGET_USER_ID}) Reason: {failureMessage}"), Times.Once);
+        _mockOctoLogger.Verify(m => m.LogError($"Failed to send reclaim invitation email to {TARGET_USER_LOGIN} for mannequin {MANNEQUIN_LOGIN} ({MANNEQUIN_ID}): {failureMessage}"), Times.Once);
     }
 
     [Fact]
@@ -1019,7 +1019,7 @@ public class ReclaimServiceTests
         _mockGithubApi.Verify(x => x.CreateAttributionInvitation(ORG_ID, MANNEQUIN_ID, TARGET_USER_ID), Times.Once);
         _mockGithubApi.Verify(x => x.CreateAttributionInvitation(ORG_ID, mannequinUserId2, TARGET_USER_ID), Times.Once);
 
-        _mockOctoLogger.Verify(m => m.LogError($"Failed to invite {MANNEQUIN_LOGIN} ({MANNEQUIN_ID}) to {TARGET_USER_LOGIN} ({TARGET_USER_ID}) Reason: {failureMessage}"), Times.Once);
+        _mockOctoLogger.Verify(m => m.LogError($"Failed to send reclaim invitation email to {TARGET_USER_LOGIN} for mannequin {MANNEQUIN_LOGIN} ({MANNEQUIN_ID}): {failureMessage}"), Times.Once);
     }
 
 


### PR DESCRIPTION
The `reclaim-mannequin` command allows reclaiming a single mannequin like this:

```bash
gh gei reclaim-mannequin --github-org caffeinesoftware \
--mannequin-user redacteduser --target-user timrogers \
--verbose
```

Once the operation has completed, we log something like this:

> [2023-07-19 14:13:23] [INFO] Mannequin reclaim invitation email successfully sent to: redacteduser (M_kgDOCDLDDQ) for timrogers (MDQ6VXNlcjExNjEzNA==)

This log message is the wrong way round - in this case, I reclaimed a mannequin called `redacteduser` and linked it to the GitHub user `timrogers`, and the email is going to be sent to me, not to `redacteduser`.

This fixes that message so it says the right thing. In this PR, I also take the opportunity to:

* stop logging users' GraphQL IDs which aren't very useful
* try to make the language in the logs clearer to help customers to understand exactly what has happened

Fixes https://github.com/github/gh-gei/issues/1072.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->