### PR TITLE
Add Process Id to logfiles name

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,3 +2,4 @@
 - Allow CLI to fail fast when an unauthorized token is provided by preventing retry logic on 401 errors
 - Improve performance when reclaiming a single mannequin with `reclaim-mannequin`
 - Improve logging for `reclaim-mannequin` command
+- Log filename now contains the process id to make sure it is unique

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,4 +2,4 @@
 - Allow CLI to fail fast when an unauthorized token is provided by preventing retry logic on 401 errors
 - Improve performance when reclaiming a single mannequin with `reclaim-mannequin`
 - Improve logging for `reclaim-mannequin` command
-- Log filename now contains the process id to make sure it is unique
+- Add ID of current process to log filenames to ensure that they are unique

--- a/src/Octoshift/Services/OctoLogger.cs
+++ b/src/Octoshift/Services/OctoLogger.cs
@@ -33,8 +33,9 @@ public class OctoLogger
     public OctoLogger()
     {
         var logStartTime = DateTime.Now;
-        _logFilePath = $"{logStartTime:yyyyMMddHHmmss}.octoshift.log";
-        _verboseFilePath = $"{logStartTime:yyyyMMddHHmmss}.octoshift.verbose.log";
+        var processId = Environment.ProcessId;
+        _logFilePath = $"{logStartTime:yyyyMMddHHmmss}-{processId}.octoshift.log";
+        _verboseFilePath = $"{logStartTime:yyyyMMddHHmmss}-{processId}.octoshift.verbose.log";
 
         if (Environment.GetEnvironmentVariable("GEI_DEBUG_MODE")?.ToUpperInvariant() == "TRUE")
         {


### PR DESCRIPTION
By adding the process id we make sure the log file is going to be unique per process.

If two or more commands are executed at the same second the log results would be intermixed.

closes #1075

- [ ] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

