### PR TITLE
Add process ID to log file names to ensure uniqueness

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,3 +2,4 @@
 - Allow CLI to fail fast when an unauthorized token is provided by preventing retry logic on 401 errors
 - Improve performance when reclaiming a single mannequin with `reclaim-mannequin`
 - Improve logging for `reclaim-mannequin` command
+- Log filename now contains the process id to make sure it is unique

--- a/src/Octoshift/Services/OctoLogger.cs
+++ b/src/Octoshift/Services/OctoLogger.cs
@@ -33,8 +33,9 @@ public class OctoLogger
     public OctoLogger()
     {
         var logStartTime = DateTime.Now;
-        _logFilePath = $"{logStartTime:yyyyMMddHHmmss}.octoshift.log";
-        _verboseFilePath = $"{logStartTime:yyyyMMddHHmmss}.octoshift.verbose.log";
+        var processId = Environment.ProcessId;
+        _logFilePath = $"{logStartTime:yyyyMMddHHmmss}-{processId}.octoshift.log";
+        _verboseFilePath = $"{logStartTime:yyyyMMddHHmmss}-{processId}.octoshift.verbose.log";
 
         if (Environment.GetEnvironmentVariable("GEI_DEBUG_MODE")?.ToUpperInvariant() == "TRUE")
         {

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -716,7 +716,7 @@ steps:
             var directoryInfo = new DirectoryInfo(GetOsDistPath());
 
             var firstLogFileWithError = directoryInfo.GetFiles("*.octoshift.log")
-                .Select(fi => (Timestamp: DateTime.ParseExact(fi.Name.Split('.').First(), "yyyyMMddHHmmss", null), FileInfo: fi))
+                .Select(fi => (Timestamp: DateTime.ParseExact(fi.Name.Split('.').First().Split('-').First(), "yyyyMMddHHmmss", null), FileInfo: fi))
                 .Where(x => x.Timestamp >= after)
                 .OrderBy(x => x.Timestamp)
                 .Select(x => x.FileInfo)


### PR DESCRIPTION
This increases the entropy of our automatically-generated log filenames by adding the process ID to the filename, alongside the current timestamp.

This ensures that separate CLI processes, which may be started in parallel, have their own log file, even if they are started at the same time.

Fixes https://github.com/github/gh-gei/issues/1075. Thanks to #1076 for the code which I copied into this new PR!

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->