### PR TITLE
Fix target repo existence check in GHES migrations so it doesn't explode if the target repo used to exist, but has been renamed

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Fix target repo existence check in GitHub Enterprise Server migrations so it doesn't error if the target repo used to exist, but has been renamed

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -158,6 +158,10 @@ public class GithubApi
         {
             return true;
         }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.MovedPermanently)
+        {
+            return false;
+        }
     }
 
     public virtual async Task<bool> DoesOrgExist(string org)

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -337,6 +337,21 @@ public class GithubApiTests
     }
 
     [Fact]
+    public async Task DoesRepoExist_Returns_False_When_301()
+    {
+        // Arrange
+        var url = $"https://api.github.com/repos/{GITHUB_ORG}/{GITHUB_REPO}";
+
+        _githubClientMock.Setup(m => m.GetNonSuccessAsync(url, HttpStatusCode.MovedPermanently)).ReturnsAsync("Moved Permanently");
+
+        // Act
+        var result = await _githubApi.DoesRepoExist(GITHUB_ORG, GITHUB_REPO);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task DoesRepoExist_Throws_On_Unexpected_Response()
     {
         // Arrange


### PR DESCRIPTION
When migrating from GHES with `migrate-repo`, we perform a quick validation check before starting the export to ensure that the target repo doesn't already exist. If it does already exist, we can fail fast and not run the export at all.

If the repo used to exist but has been renamed, then this causes the CLI to error, because the REST API returns `301 Moved Permanently` and that's not something we handle or expect.

This updates our code to handle `301 Moved Permanently` and treat it correctly as "the repo doesn't exist".

Fixes https://github.com/github/gh-gei/issues/1074.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->