### PR TITLE
Drop old quick start videos from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,6 @@ Refer to the [official documentation](https://docs.github.com/en/migrations/usin
 
 Refer to the [official documentation](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-repositories-with-github-enterprise-importer/migrating-repositories-from-bitbucket-server-to-github-enterprise-cloud) for more details.
 
-## Quick Start Videos
-You'll find videos below to help you quickly get started with the GEI CLI. Be sure to pick the videos relevant to your migration scenario. 
-
->NOTE: We don't update these videos as often as we update the CLI, so they may not exactly match the functionality in the latest release of this CLI.
-
-### Migrating from Azure DevOps to GitHub
-Video guides below will help you get started with your first migration. Then help you build up to orchestrating a complete end-to-end production migration. 
-* Running your first few migrations: https://www.youtube.com/watch?v=yfnXbwtXY80
-* Orchestrating an end-to-end production migration: https://www.youtube.com/watch?v=AtFB-U1Og4c
-
 ## Contributions
 
 See [Contributing](CONTRIBUTING.md) for more info on how to get involved.


### PR DESCRIPTION
We have a rather old Azure DevOps migration video in the readme. It's a long while back, and doesn't reflect the modern GEI experience. Let's remove it until we can record newer, fresher videos for our migration paths.

Closes https://github.com/github/gh-gei/issues/376

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->