### PR TITLE
Fix `dotnet format` linting failure

### DIFF
--- a/src/OctoshiftCLI.Tests/Octoshift/Services/AdoClientTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/AdoClientTests.cs
@@ -239,7 +239,7 @@ public sealed class AdoClientTests : IDisposable
     public async Task GetAsync_Throws_HttpRequestException_On_Non_Success_Response()
     {
         // Arrange
-        var httpResponse = () => new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        using var httpResponse = new HttpResponseMessage(HttpStatusCode.InternalServerError);
         var handlerMock = new Mock<HttpMessageHandler>();
         handlerMock
             .Protected()


### PR DESCRIPTION
This fixes a linting failure which is currently breaking `dotnet format` on `main`...but strangely, only when running on macOS:

```
Warning: /Users/runner/work/gh-gei/gh-gei/src/OctoshiftCLI.Tests/Octoshift/Services/AdoClientTests.cs(242,13): warning
IDE0039: Use local function [/Users/runner/work/gh-gei/gh-gei/src/OctoshiftCLI.Tests/OctoshiftCLI.Tests.csproj]
```

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->