### PR TITLE
Use a `global.json` file to keep everything locked to a consistent .NET SDK version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        global-json-file: global.json
 
     - name: dotnet format
       run: dotnet format src/OctoshiftCLI.sln --verify-no-changes

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        global-json-file: global.json
 
     - name: Build Artifacts (Linux)
       if: matrix.target-os == 'ubuntu-latest'

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.413",
+    "rollForward": "minor"
+  }
+}


### PR DESCRIPTION
We've recently seen [issues][1] where we get different build results on macOS, Windows and Linux because they run different versions of `dotnet format` with different rules.

At first look, this is a surprise! We use the
[`actions/setup-dotnet@v2`][2] action to make sure that a specific .NET version is installed in CI, v6.0.x, and we expect that to be used consistently across the board.

But all the `actions/setup-dotnet` action does is installs a specific .NET version. It doesn't guarantee that that version will actually be used for everything!

The `dotnet` driver is the `dotnet` binary used to run .NET commands. All of the `dotnet` driver's commands [use the latest installed .NET SDK version by default][3], and the different GitHub Actions runner images come with different SDKs pre-installed.

From investigation, the Windows and Linux images
come with *no pre-installed SDKs* (so `actions/setup-dotnet` does all the work), but the Mac version comes with a sizeable list preinstalled, from which the most recent is automatically picked:

```bash
bash-3.2$ dotnet --list-sdks
7.0.102 [/Users/runner/.dotnet/sdk]
7.0.202 [/Users/runner/.dotnet/sdk]
7.0.306 [/Users/runner/.dotnet/sdk]
7.0.400 [/Users/runner/.dotnet/sdk]
```

This PR introduces a [`global.json`][4] file, which the `dotnet` driver will use to automatically pick the right SDK when running `dotnet format` or any other command.

I configure it with `version: v6.0.413` and `rollForward: minor` to say "prefer v6.0.413 (which is the latest v6.0 version at the time of writing), but you can roll forward to the latest "v6.0" version.

I also reconfigure `actions/setup-dotnet` to use that file, so we have one source of truth of the version we're using.

The end result should be that we get consistent installation and usage of the same .NET SDK version locally and in CI.

[1]: https://github.com/github/gh-gei/actions/runs/5929364217
[2]: https://github.com/actions/setup-dotnet
[3]: https://learn.microsoft.com/en-us/dotnet/core/versions/selection#the-sdk-uses-the-latest-installed-version
[4]: https://learn.microsoft.com/en-us/dotnet/core/tools/global-json

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->