### PR TITLE
In `bbs2gh migrate-repo` and `gei migrate-repo`, create the migration source before starting the export

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- When running migrations with `gh bbs2gh` and migrations from GitHub Enterprise Server with `gh gei`, create the migration source before starting the export


### PR DESCRIPTION
This reworks `bbs2gh migrate-repo` and `gei migrate-repo` to create the migration source before running the export from the migration origin.

This change will allow us to deduce a rough estimate of how long exports take on GitHub Enterprise Server and Bitbucket Server.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->