### PR TITLE
Extend timeout from 10 hours to 20 hours when generating GitHub Enterprise Server migration archives in `gh gei migrate-repo`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Extend timeout from 10 hours to 20 hours when generating GitHub Enterprise Server migration archives in `gh gei migrate-repo`

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -23,7 +23,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
     private readonly GhesVersionChecker _ghesVersionChecker;
     private readonly RetryPolicy _retryPolicy;
     private readonly WarningsCountLogger _warningsCountLogger;
-    private const int ARCHIVE_GENERATION_TIMEOUT_IN_HOURS = 10;
+    private const int ARCHIVE_GENERATION_TIMEOUT_IN_HOURS = 20;
     private const int CHECK_STATUS_DELAY_IN_MILLISECONDS = 10000; // 10 seconds
     private const string GIT_ARCHIVE_FILE_NAME = "git_archive.tar.gz";
     private const string METADATA_ARCHIVE_FILE_NAME = "metadata_archive.tar.gz";


### PR DESCRIPTION
When migrating from GitHub Enterprise Server with `gh gei migrate- repo`, we give up if the migration archive takes more than 10 hours to generate, and retry.

This may be too aggressive in certain cases, for particularly large repos or GitHub Enterprise Server instances with limited resources.

This extends the timeout to 20 hours to allow more time.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [X] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->