### PR TITLE
Always use the `global.json` file when setting up .NET Core in GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        global-json-file: global.json
 
     - name: Build Artifacts (Linux)
       if: matrix.target-os == 'ubuntu-latest'
@@ -160,7 +160,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        global-json-file: global.json
 
     - name: Download Binaries
       uses: actions/download-artifact@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -307,7 +307,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        global-json-file: global.json
 
     - name: Build Artifacts
       run: ./publish.ps1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -85,8 +85,8 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
-
+        global-json-file: global.json
+        
     - name: Download Binaries
       uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
This updates our GitHub Actions workflows to consistently use the `global.json` file to set up .NET Core, rather than sometimes using hard-coded version numbers.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->