### PR TITLE
When checking if the running version is the latest CLI version, compare as semantic versions, not strings

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
 - Add a warning to help users who accidentally end up in the "running on the Bitbucket instance" flow in `bbs2gh migrate-repo`
 - Fix version check so that a version later than the latest version published on GitHub isn't considered old
 - Fix `download-logs` commands suggested by `bbs2gh migrate-repo` and `ado2gh migrate-repo` to use correct arguments
+- Fix version number exposed in headers and `generate-script` scripts, removing the [revision component](https://learn.microsoft.com/en-us/dotnet/api/system.version?view=net-7.0#remarks) so it matches the published version

--- a/src/Octoshift/Services/VersionChecker.cs
+++ b/src/Octoshift/Services/VersionChecker.cs
@@ -30,7 +30,7 @@ public class VersionChecker : IVersionProvider
 
     public string GetCurrentVersion()
     {
-        return Assembly.GetExecutingAssembly().GetName().Version.ToString();
+        return Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
     }
 
     public string GetVersionComments() =>

--- a/src/Octoshift/Services/VersionChecker.cs
+++ b/src/Octoshift/Services/VersionChecker.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -21,12 +22,10 @@ public class VersionChecker : IVersionProvider
 
     public async Task<bool> IsLatest()
     {
-        var curVersion = GetCurrentVersion();
-        var latestVersion = await GetLatestVersion();
+        var currentVersion = Version.Parse(GetCurrentVersion());
+        var latestVersion = Version.Parse(await GetLatestVersion());
 
-        curVersion = curVersion[..latestVersion.Length];
-
-        return latestVersion.CompareTo(curVersion) <= 0;
+        return currentVersion >= latestVersion;
     }
 
     public string GetCurrentVersion()

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/AdoClientTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/AdoClientTests.cs
@@ -1170,13 +1170,13 @@ public sealed class AdoClientTests : IDisposable
     public void It_Sets_User_Agent_Header_With_Comments()
     {
         // Arrange
-        const string currentVersion = "1.1.1.1";
+        const string currentVersion = "1.1.1";
         const string versionComments = "(COMMENTS)";
 
         using var httpClient = new HttpClient();
 
         var mockVersionProvider = new Mock<IVersionProvider>();
-        mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+        mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
         mockVersionProvider.Setup(m => m.GetVersionComments()).Returns(versionComments);
 
         // Act

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/BasicHttpClientTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/BasicHttpClientTests.cs
@@ -92,13 +92,13 @@ public sealed class BasicHttpClientTests
     public void It_Sets_User_Agent_Header_With_Comments()
     {
         // Arrange
-        const string currentVersion = "1.1.1.1";
+        const string currentVersion = "1.1.1";
         const string versionComments = "(COMMENTS)";
 
         using var httpClient = new HttpClient();
 
         var mockVersionProvider = new Mock<IVersionProvider>();
-        mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+        mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
         mockVersionProvider.Setup(m => m.GetVersionComments()).Returns(versionComments);
 
         // Act

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubClientTests.cs
@@ -1969,13 +1969,13 @@ query($id: ID!, $first: Int, $after: String) {
     public void It_Sets_User_Agent_Header_With_Comments()
     {
         // Arrange
-        const string currentVersion = "1.1.1.1";
+        const string currentVersion = "1.1.1";
         const string versionComments = "(COMMENTS)";
 
         using var httpClient = new HttpClient();
 
         var mockVersionProvider = new Mock<IVersionProvider>();
-        mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+        mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
         mockVersionProvider.Setup(m => m.GetVersionComments()).Returns(versionComments);
 
         // Act

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
@@ -44,7 +44,7 @@ public class GenerateScriptCommandHandlerTests
     public GenerateScriptCommandHandlerTests()
     {
         var mockVersionProvider = new Mock<IVersionProvider>();
-        mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+        mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
 
         _handler = new GenerateScriptCommandHandler(_mockOctoLogger.Object, _mockAdoApi.Object, mockVersionProvider.Object, _mockAdoInspector.Object)
         {
@@ -608,7 +608,7 @@ public class GenerateScriptCommandHandlerTests
         var expected = new StringBuilder();
         expected.AppendLine("#!/usr/bin/env pwsh");
         expected.AppendLine();
-        expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+        expected.AppendLine("# =========== Created with CLI version 1.1.1 ===========");
         expected.AppendLine(@"
 function Exec {
     param (
@@ -719,7 +719,7 @@ if ($Failed -ne 0) {
         var expected = new StringBuilder();
         expected.AppendLine("#!/usr/bin/env pwsh");
         expected.AppendLine();
-        expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+        expected.AppendLine("# =========== Created with CLI version 1.1.1 ===========");
         expected.AppendLine(@"
 function Exec {
     param (
@@ -861,7 +861,7 @@ if ($Failed -ne 0) {
         var expected = new StringBuilder();
         expected.AppendLine("#!/usr/bin/env pwsh");
         expected.AppendLine();
-        expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+        expected.AppendLine("# =========== Created with CLI version 1.1.1 ===========");
         expected.AppendLine(@"
 function Exec {
     param (
@@ -1016,7 +1016,7 @@ if ($Failed -ne 0) {
         var expected = new StringBuilder();
         expected.AppendLine("#!/usr/bin/env pwsh");
         expected.AppendLine();
-        expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+        expected.AppendLine("# =========== Created with CLI version 1.1.1 ===========");
         expected.AppendLine(@"
 function Exec {
     param (

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
@@ -556,8 +556,8 @@ if (-not $env:SMB_PASSWORD) {
     public async Task Generated_Script_Contains_The_Cli_Version_Comment()
     {
         // Arrange
-        _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
-        const string cliVersionComment = "# =========== Created with CLI version 1.1.1.1 ===========";
+        _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
+        const string cliVersionComment = "# =========== Created with CLI version 1.1.1 ===========";
 
         // Act
         var args = new GenerateScriptCommandArgs

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
@@ -224,12 +224,12 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.GenerateScript
             const string repo2 = "FOO-REPO-2";
 
             _mockGithubApi.Setup(m => m.GetRepos(SOURCE_ORG)).ReturnsAsync(new[] { (repo1, "private"), (repo2, "public") });
-            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
 
             var expected = new StringBuilder();
             expected.AppendLine("#!/usr/bin/env pwsh");
             expected.AppendLine();
-            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+            expected.AppendLine("# =========== Created with CLI version 1.1.1 ===========");
             expected.AppendLine(@"
 function ExecAndGetMigrationID {
     param (
@@ -305,13 +305,13 @@ if ($Failed -ne 0) {
                 .Setup(m => m.GetRepos(SOURCE_ORG))
                 .ReturnsAsync(new[] { (REPO, "private") });
 
-            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
             _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(true);
 
             var expected = new StringBuilder();
             expected.AppendLine("#!/usr/bin/env pwsh");
             expected.AppendLine();
-            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+            expected.AppendLine("# =========== Created with CLI version 1.1.1 ===========");
             expected.AppendLine(@"
 function ExecAndGetMigrationID {
     param (
@@ -390,12 +390,12 @@ if ($Failed -ne 0) {
                 .Setup(m => m.GetRepos(SOURCE_ORG))
                 .ReturnsAsync(new[] { (repo1, "private"), (repo2, "private") });
 
-            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
 
             var expected = new StringBuilder();
             expected.AppendLine("#!/usr/bin/env pwsh");
             expected.AppendLine();
-            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+            expected.AppendLine("# =========== Created with CLI version 1.1.1 ===========");
             expected.AppendLine(@"
 function ExecAndGetMigrationID {
     param (
@@ -474,13 +474,13 @@ if ($Failed -ne 0) {
                 .Setup(m => m.GetRepos(SOURCE_ORG))
                 .ReturnsAsync(new[] { (REPO, "private") });
 
-            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
             _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(true);
 
             var expected = new StringBuilder();
             expected.AppendLine("#!/usr/bin/env pwsh");
             expected.AppendLine();
-            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+            expected.AppendLine("# =========== Created with CLI version 1.1.1 ===========");
             expected.AppendLine(@"
 function ExecAndGetMigrationID {
     param (
@@ -560,13 +560,13 @@ if ($Failed -ne 0) {
                 .Setup(m => m.GetRepos(SOURCE_ORG))
                 .ReturnsAsync(new[] { (REPO, "private") });
 
-            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
             _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(true);
 
             var expected = new StringBuilder();
             expected.AppendLine("#!/usr/bin/env pwsh");
             expected.AppendLine();
-            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+            expected.AppendLine("# =========== Created with CLI version 1.1.1 ===========");
             expected.AppendLine(@"
 function ExecAndGetMigrationID {
     param (
@@ -645,13 +645,13 @@ if ($Failed -ne 0) {
                 .Setup(m => m.GetRepos(SOURCE_ORG))
                 .ReturnsAsync(new[] { (REPO, "private") });
 
-            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
             _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(false);
 
             var expected = new StringBuilder();
             expected.AppendLine("#!/usr/bin/env pwsh");
             expected.AppendLine();
-            expected.AppendLine("# =========== Created with CLI version 1.1.1.1 ===========");
+            expected.AppendLine("# =========== Created with CLI version 1.1.1 ===========");
             expected.AppendLine(@"
 function ExecAndGetMigrationID {
     param (
@@ -833,9 +833,9 @@ if ($Failed -ne 0) {
                 .Setup(m => m.GetRepos(SOURCE_ORG))
                 .ReturnsAsync(new[] { (REPO, "private") });
 
-            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
 
-            const string expectedCliVersionComment = "# =========== Created with CLI version 1.1.1.1 ===========";
+            const string expectedCliVersionComment = "# =========== Created with CLI version 1.1.1 ===========";
 
             // Act
             var args = new GenerateScriptCommandArgs
@@ -856,9 +856,9 @@ if ($Failed -ne 0) {
         {
             // Arrange
             _mockGithubApi.Setup(m => m.GetRepos(SOURCE_ORG)).ReturnsAsync(new[] { (REPO, "private") });
-            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1.1");
+            _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
 
-            const string expectedCliVersionComment = "# =========== Created with CLI version 1.1.1.1 ===========";
+            const string expectedCliVersionComment = "# =========== Created with CLI version 1.1.1 ===========";
 
             // Act
             var args = new GenerateScriptCommandArgs

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -110,11 +110,11 @@ namespace OctoshiftCLI.AdoToGithub
 
             if (await versionChecker.IsLatest())
             {
-                Logger.LogInformation($"You are running the latest version of the ado2gh CLI [v{await versionChecker.GetLatestVersion()}]");
+                Logger.LogInformation($"You are running an up-to-date version of the ado2gh CLI [v{versionChecker.GetCurrentVersion()}]");
             }
             else
             {
-                Logger.LogWarning($"You are running an older version of the ado2gh CLI [v{versionChecker.GetCurrentVersion()}]. The latest version is v{await versionChecker.GetLatestVersion()}.");
+                Logger.LogWarning($"You are running an old version of the ado2gh CLI [v{versionChecker.GetCurrentVersion()}]. The latest version is v{await versionChecker.GetLatestVersion()}.");
                 Logger.LogWarning($"Please update by running: gh extension upgrade ado2gh");
             }
         }

--- a/src/bbs2gh/Program.cs
+++ b/src/bbs2gh/Program.cs
@@ -117,11 +117,11 @@ namespace OctoshiftCLI.BbsToGithub
 
             if (await versionChecker.IsLatest())
             {
-                Logger.LogInformation($"You are running the latest version of the bbs2gh extension [v{await versionChecker.GetLatestVersion()}]");
+                Logger.LogInformation($"You are running an up-to-date version of the bbs2gh extension [v{versionChecker.GetCurrentVersion()}]");
             }
             else
             {
-                Logger.LogWarning($"You are running an older version of the bbs2gh extension [v{versionChecker.GetCurrentVersion()}]. The latest version is v{await versionChecker.GetLatestVersion()}.");
+                Logger.LogWarning($"You are running an old version of the bbs2gh extension [v{versionChecker.GetCurrentVersion()}]. The latest version is v{await versionChecker.GetLatestVersion()}.");
                 Logger.LogWarning($"Please update by running: gh extension upgrade bbs2gh");
             }
         }

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -110,11 +110,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
             if (await versionChecker.IsLatest())
             {
-                Logger.LogInformation($"You are running the latest version of the gei CLI [v{await versionChecker.GetLatestVersion()}]");
+                Logger.LogInformation($"You are running an up-to-date version of the gei CLI [v{versionChecker.GetCurrentVersion()}]");
             }
             else
             {
-                Logger.LogWarning($"You are running an older version of the gei CLI [v{versionChecker.GetCurrentVersion()}]. The latest version is v{await versionChecker.GetLatestVersion()}.");
+                Logger.LogWarning($"You are running an old version of the gei CLI [v{versionChecker.GetCurrentVersion()}]. The latest version is v{await versionChecker.GetLatestVersion()}.");
                 Logger.LogWarning($"Please update by running: gh extension upgrade gei");
             }
         }


### PR DESCRIPTION
Each time you run the CLI, we fetch the `LATEST-VERSION.txt` file from GitHub to check the current latest version of the CLI.

Prior to #1137, we told users that their CLI was out of date if the version didn't _exactly match_ the latest version. 

With changes in #1137, we now compare the versions as strings, but this can lead to surprisingly (and wrong!) results - e.g. `v1.2.0 > v1.12.0`.

This further improves the version check by comparing the versions correctly, treating them as semantic version values, not just strings.

As part of this change, I'm refactoring the `GetCurrentVersion()` method to return a `Version` rather than a `string`. We then have to present that string correctly in the relevant places - either in its full form in `User-Agent` headers, or just `major.minor.patch` in customer-facing places.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->