### PR TITLE
Fix `gh gei generate-script --download-migration-logs` to include valid `download-logs` command in script

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 - Fix version check so that a version later than the latest version published on GitHub isn't considered old
+- Fix `gei generate-script --download-migration-logs` so the generated script successfully downloads the migration logs

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
@@ -433,11 +433,11 @@ if (-not $env:GH_PAT) {
             expected.AppendLine();
             expected.AppendLine($"if ($RepoMigrations[\"{repo1}\"]) {{ gh gei wait-for-migration --migration-id $RepoMigrations[\"{repo1}\"] }}");
             expected.AppendLine($"if ($RepoMigrations[\"{repo1}\"] -and $lastexitcode -eq 0) {{ $Succeeded++ }} else {{ $Failed++ }}");
-            expected.AppendLine($"gh gei download-logs --github-target-org \"{TARGET_ORG}\" --target-repo \"{repo1}\"");
+            expected.AppendLine($"gh gei download-logs --github-org \"{TARGET_ORG}\" --github-repo \"{repo1}\"");
             expected.AppendLine();
             expected.AppendLine($"if ($RepoMigrations[\"{repo2}\"]) {{ gh gei wait-for-migration --migration-id $RepoMigrations[\"{repo2}\"] }}");
             expected.AppendLine($"if ($RepoMigrations[\"{repo2}\"] -and $lastexitcode -eq 0) {{ $Succeeded++ }} else {{ $Failed++ }}");
-            expected.AppendLine($"gh gei download-logs --github-target-org \"{TARGET_ORG}\" --target-repo \"{repo2}\"");
+            expected.AppendLine($"gh gei download-logs --github-org \"{TARGET_ORG}\" --github-repo \"{repo2}\"");
             expected.AppendLine();
             expected.AppendLine();
             expected.AppendLine("Write-Host =============== Summary ===============");
@@ -522,7 +522,7 @@ if (-not $env:AZURE_STORAGE_CONNECTION_STRING) {
             expected.AppendLine();
             expected.AppendLine($"if ($RepoMigrations[\"{REPO}\"]) {{ gh gei wait-for-migration --migration-id $RepoMigrations[\"{REPO}\"] }}");
             expected.AppendLine($"if ($RepoMigrations[\"{REPO}\"] -and $lastexitcode -eq 0) {{ $Succeeded++ }} else {{ $Failed++ }}");
-            expected.AppendLine($"gh gei download-logs --github-target-org \"{TARGET_ORG}\" --target-repo \"{REPO}\"");
+            expected.AppendLine($"gh gei download-logs --github-org \"{TARGET_ORG}\" --github-repo \"{REPO}\"");
             expected.AppendLine();
             expected.AppendLine();
             expected.AppendLine("Write-Host =============== Summary ===============");

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -215,7 +215,7 @@ if ($Failed -ne 0) {
 
     private string DownloadMigrationLogScript(string githubTargetOrg, string targetRepo)
     {
-        return $"gh gei download-logs --github-target-org \"{githubTargetOrg}\" --target-repo \"{targetRepo}\"";
+        return $"gh gei download-logs --github-org \"{githubTargetOrg}\" --github-repo \"{targetRepo}\"";
     }
 
     private string Exec(string script) => Wrap(script, "Exec");


### PR DESCRIPTION
…

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->