### PR TITLE
Print a warning when `bbs2gh migrate-repo` is run in "on the Bitbucket instance" mode, which users often do by mistake

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 - Fix version check so that a version later than the latest version published on GitHub isn't considered old
+- Add a warning to help users who accidentally end up in the "running on the Bitbucket instance" flow in `bbs2gh migrate-repo`

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -167,7 +167,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             throw new OctoshiftCliException($"Bitbucket export failed --> State: {exportState}; Message: {exportMessage}");
         }
 
-        _log.LogInformation($"Export completed. Your migration archive should be ready on your instance at $BITBUCKET_SHARED_HOME/data/migration/export/Bitbucket_export_{exportId}.tar");
+        _log.LogInformation($"Export completed. Your migration archive should be ready **on your Bitbucket instance** at $BITBUCKET_SHARED_HOME/data/migration/export/Bitbucket_export_{exportId}.tar");
 
         return exportId;
     }

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -75,6 +75,11 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             {
                 args.ArchivePath = await DownloadArchive(exportId);
             }
+
+            if (!args.ShouldDownloadArchive() && args.ShouldUploadArchive())
+            {
+                _log.LogWarning($"You haven't specified --ssh-user or --smb-user, so we assume that you're running the CLI on the Bitbucket instance itself. If you are not running this command on the Bitbucket instance, run this command again with the --ssh-user or --smb-user argument to allow the CLI to download the migration archive from the server.");
+            }
         }
 
         if (args.ShouldUploadArchive())


### PR DESCRIPTION
When running `bbs2gh migrate-repo`, there are a lot of different branches depending on the CLI arguments (and environment variables 😓 ) specified.

One of our branches is designed for the case where the CLI is run on the Bitbucket instance itself, where we assume that the generated migration archive is available in the local filesystem.

This branch is not usually the one that users want, but it is easy to accidentally fall into it by mistake because of the arguments you specified.

This PR introduces a new warning log if you fall into that branch to tell you that you're probably not where you intend to be, and to point you in the right direction:

> You haven't specified --ssh-user or --smb-user, so we assume that you're running the CLI on the Bitbucket instance itself. If you are not running this command on the Bitbucket instance, run this command again with the --ssh-user or --smb-user argument to allow the CLI to download the migration archive from the server.

As part of this PR, I've also made a small tweak to the existing "Export completed..." log line to clarify that the archive is now on the Bitbucket Server.

Fixes #1145.

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->