### PR TITLE
Redact `?token=` querystring parameter from GHES <3.8 archive URLs in logs

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 
 - Skip GitHub status checking on startup if environment variable `GEI_SKIP_STATUS_CHECK` is set to `true`
+- Redact `?token=` querystring parameter from GHES <3.8 archive URLs in logs

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,2 @@
 
-- Skip GitHub status checking on startup if environment variable `GEI_SKIP_STATUS_CHECK` is set to true.
+- Skip GitHub status checking on startup if environment variable `GEI_SKIP_STATUS_CHECK` is set to `true`

--- a/src/Octoshift/Services/OctoLogger.cs
+++ b/src/Octoshift/Services/OctoLogger.cs
@@ -31,9 +31,9 @@ public class OctoLogger
 
     private const string GENERIC_ERROR_MESSAGE = "An unexpected error happened. Please see the logs for details.";
 
-    private readonly HashSet<Regex> _redactionPatterns = new()
+    private readonly List<string> _redactionPatterns = new()
     {
-        new Regex("\\b(?<=token=)(.+?)\\b")
+        "\\b(?<=token=)(.+?)\\b"
     };
 
     public OctoLogger()
@@ -96,7 +96,7 @@ public class OctoLogger
 
         foreach (var redactionPattern in _redactionPatterns)
         {
-            result = redactionPattern.Replace(result, "***");
+            result = Regex.Replace(result, redactionPattern, "***");
         }
 
         return result;

--- a/src/Octoshift/Services/OctoLogger.cs
+++ b/src/Octoshift/Services/OctoLogger.cs
@@ -65,7 +65,7 @@ public class OctoLogger
     private void Log(string msg, string level)
     {
         var output = FormatMessage(msg, level);
-        output = MaskSecrets(output);
+        output = Redact(output);
         if (level == LogLevel.ERROR)
         {
             _writeToConsoleError(output);
@@ -84,7 +84,7 @@ public class OctoLogger
         return $"[{timeFormat}] [{level}] {msg}\n";
     }
 
-    private string MaskSecrets(string msg)
+    private string Redact(string msg)
     {
         var result = msg;
 
@@ -128,14 +128,14 @@ public class OctoLogger
         var verboseMessage = ex is HttpRequestException httpEx ? $"[HTTP ERROR {(int?)httpEx.StatusCode}] {ex}" : ex.ToString();
         var logMessage = Verbose ? verboseMessage : ex is OctoshiftCliException ? ex.Message : GENERIC_ERROR_MESSAGE;
 
-        var output = MaskSecrets(FormatMessage(logMessage, LogLevel.ERROR));
+        var output = Redact(FormatMessage(logMessage, LogLevel.ERROR));
 
         Console.ForegroundColor = ConsoleColor.Red;
         _writeToConsoleError(output);
         Console.ResetColor();
 
         _writeToLog(output);
-        _writeToVerboseLog(MaskSecrets(FormatMessage(verboseMessage, LogLevel.ERROR)));
+        _writeToVerboseLog(Redact(FormatMessage(verboseMessage, LogLevel.ERROR)));
     }
 
     public virtual void LogVerbose(string msg)
@@ -148,7 +148,7 @@ public class OctoLogger
         }
         else
         {
-            _writeToVerboseLog(MaskSecrets(FormatMessage(msg, LogLevel.VERBOSE)));
+            _writeToVerboseLog(Redact(FormatMessage(msg, LogLevel.VERBOSE)));
         }
     }
 

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
@@ -82,6 +82,8 @@ public class OctoLoggerTests
         _logOutput.Should().NotContain(ghesArchiveUrl);
         _verboseLogOutput.Should().NotContain(ghesArchiveUrl);
         _consoleError.Should().NotContain(ghesArchiveUrl);
+
+        _consoleOutput.Should().Contain("Archive URL: https://files.github.acmeinc.com/foo?token=***");
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
-using System.Text.RegularExpressions;
 using FluentAssertions;
 using OctoshiftCLI.Services;
 using Xunit;
@@ -62,28 +61,27 @@ public class OctoLoggerTests
     }
 
     [Fact]
-    public void Redaction_Patterns_Should_Be_Replaced_In_Logs_And_Console()
+    public void Ghes_Archive_Url_Tokens_Should_Be_Replaced_In_Logs_And_Console()
     {
-        var password = "hunter2";
 
-        _octoLogger.AddRedactionPattern(new Regex("hunter\\d", RegexOptions.IgnoreCase));
+        var ghesArchiveUrl = "https://files.github.acmeinc.com/foo?token=foobar";
 
         _octoLogger.Verbose = false;
-        _octoLogger.LogInformation($"Don't tell anyone that {password} is my password");
-        _octoLogger.LogVerbose($"Don't tell anyone that {password} is my password");
-        _octoLogger.LogWarning($"Don't tell anyone that {password} is my password");
-        _octoLogger.LogSuccess($"Don't tell anyone that {password} is my password");
-        _octoLogger.LogError($"Don't tell anyone that {password} is my password");
-        _octoLogger.LogError(new OctoshiftCliException($"Don't tell anyone that {password} is my password"));
-        _octoLogger.LogError(new InvalidOperationException($"Don't tell anyone that {password} is my password"));
+        _octoLogger.LogInformation($"Archive URL: {ghesArchiveUrl}");
+        _octoLogger.LogVerbose($"Archive URL: {ghesArchiveUrl}");
+        _octoLogger.LogWarning($"Archive URL: {ghesArchiveUrl}");
+        _octoLogger.LogSuccess($"Archive URL: {ghesArchiveUrl}");
+        _octoLogger.LogError($"Archive URL: {ghesArchiveUrl}");
+        _octoLogger.LogError(new OctoshiftCliException("Archive URL: {ghesArchiveUrl}"));
+        _octoLogger.LogError(new InvalidOperationException("Archive URL: {ghesArchiveUrl}"));
 
         _octoLogger.Verbose = true;
-        _octoLogger.LogVerbose($"Don't tell anyone that {password} is my password");
+        _octoLogger.LogVerbose("Archive URL: {ghesArchiveUrl}");
 
-        _consoleOutput.Should().NotContain(password);
-        _logOutput.Should().NotContain(password);
-        _verboseLogOutput.Should().NotContain(password);
-        _consoleError.Should().NotContain(password);
+        _consoleOutput.Should().NotContain(ghesArchiveUrl);
+        _logOutput.Should().NotContain(ghesArchiveUrl);
+        _verboseLogOutput.Should().NotContain(ghesArchiveUrl);
+        _consoleError.Should().NotContain(ghesArchiveUrl);
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using FluentAssertions;
 using OctoshiftCLI.Services;
 using Xunit;
@@ -58,6 +59,31 @@ public class OctoLoggerTests
         _logOutput.Should().NotContain(urlEncodedSecret);
         _verboseLogOutput.Should().NotContain(urlEncodedSecret);
         _consoleError.Should().NotContain(urlEncodedSecret);
+    }
+
+    [Fact]
+    public void Redaction_Patterns_Should_Be_Replaced_In_Logs_And_Console()
+    {
+        var password = "hunter2";
+
+        _octoLogger.AddRedactionPattern(new Regex("hunter\\d", RegexOptions.IgnoreCase));
+
+        _octoLogger.Verbose = false;
+        _octoLogger.LogInformation($"Don't tell anyone that {password} is my password");
+        _octoLogger.LogVerbose($"Don't tell anyone that {password} is my password");
+        _octoLogger.LogWarning($"Don't tell anyone that {password} is my password");
+        _octoLogger.LogSuccess($"Don't tell anyone that {password} is my password");
+        _octoLogger.LogError($"Don't tell anyone that {password} is my password");
+        _octoLogger.LogError(new OctoshiftCliException($"Don't tell anyone that {password} is my password"));
+        _octoLogger.LogError(new InvalidOperationException($"Don't tell anyone that {password} is my password"));
+
+        _octoLogger.Verbose = true;
+        _octoLogger.LogVerbose($"Don't tell anyone that {password} is my password");
+
+        _consoleOutput.Should().NotContain(password);
+        _logOutput.Should().NotContain(password);
+        _verboseLogOutput.Should().NotContain(password);
+        _consoleError.Should().NotContain(password);
     }
 
     [Fact]

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.CommandLine;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;
@@ -187,6 +188,8 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
 
             var ghesVersionChecker = ghesVersionCheckerFactory.Create(ghesApi);
             var warningsCountLogger = sp.GetRequiredService<WarningsCountLogger>();
+
+            log.AddRedactionPattern(new Regex("\\?token=[A-Z0-9]{29}"));
 
             return new MigrateRepoCommandHandler(
                 log,

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -1,6 +1,5 @@
 using System;
 using System.CommandLine;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using OctoshiftCLI.Commands;
 using OctoshiftCLI.Contracts;
@@ -188,8 +187,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
 
             var ghesVersionChecker = ghesVersionCheckerFactory.Create(ghesApi);
             var warningsCountLogger = sp.GetRequiredService<WarningsCountLogger>();
-
-            log.AddRedactionPattern(new Regex("\\?token=[A-Z0-9]{29}"));
 
             return new MigrateRepoCommandHandler(
                 log,


### PR DESCRIPTION
Existing code allows us to redact secrets in the logs to stop them being outputted to the shell and to log files. Secret strings are registered during execution, and then replaced in the output.

This PR also allows classes using `OctoLogger` to register regular expressions to replace, and begins redacting GHES download tokens for GHES <3.8 using a simple regular expression.

Fixes #1151.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->