### PR TITLE
Add capability to skip version checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Refer to the [official documentation](https://docs.github.com/en/migrations/usin
 
 Refer to the [official documentation](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-repositories-with-github-enterprise-importer/migrating-repositories-from-bitbucket-server-to-github-enterprise-cloud) for more details.
 
+### Skipping version checks
+
+When the CLIs are launched, they perform a check to ensure that the latest version is being used and will display a warning message if this is not the case. However, if you wish to skip this check, you can do so by setting the `GEI_SKIP_VERSION_CHECK`` environment variable to true. This will prevent the CLIs from checking for the latest version on startup and displaying a warning message.
+
 ## Quick Start Videos
 You'll find videos below to help you quickly get started with the GEI CLI. Be sure to pick the videos relevant to your migration scenario. 
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,3 +2,4 @@
 - Allow CLI to fail fast when an unauthorized token is provided by preventing retry logic on 401 errors
 - Improve performance when reclaiming a single mannequin with `reclaim-mannequin`
 - Improve logging for `reclaim-mannequin` command
+- Skip version checking on startup if environment variable `GEI_SKIP_VERSION_CHECK` is set to true.

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -105,6 +105,12 @@ namespace OctoshiftCLI.AdoToGithub
 
         private static async Task LatestVersionCheck(ServiceProvider sp)
         {
+            if (Environment.GetEnvironmentVariable("GEI_SKIP_VERSION_CHECK")?.ToUpperInvariant() == "TRUE")
+            {
+                Logger.LogInformation("Skipped latest version check of the ado2gh CLI");
+                return;
+            }
+
             var versionChecker = sp.GetRequiredService<VersionChecker>();
 
             if (await versionChecker.IsLatest())

--- a/src/bbs2gh/Program.cs
+++ b/src/bbs2gh/Program.cs
@@ -112,6 +112,12 @@ namespace OctoshiftCLI.BbsToGithub
 
         private static async Task LatestVersionCheck(ServiceProvider sp)
         {
+            if (Environment.GetEnvironmentVariable("GEI_SKIP_VERSION_CHECK")?.ToUpperInvariant() == "TRUE")
+            {
+                Logger.LogInformation("Skipped latest version check of the bbs2gh extension");
+                return;
+            }
+
             var versionChecker = sp.GetRequiredService<VersionChecker>();
 
             if (await versionChecker.IsLatest())

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -105,6 +105,12 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
         private static async Task LatestVersionCheck(ServiceProvider sp)
         {
+            if (Environment.GetEnvironmentVariable("GEI_SKIP_VERSION_CHECK")?.ToUpperInvariant() == "TRUE")
+            {
+                Logger.LogInformation("Skipped latest version check of the gei CLI ");
+                return;
+            }
+
             var versionChecker = sp.GetRequiredService<VersionChecker>();
 
             if (await versionChecker.IsLatest())


### PR DESCRIPTION
If the environment variable GEI_SKIP_VERSION_CHECK is set to true, no version checks will be performed

Closes #1077 

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [X] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->