### PR TITLE
Add capability to skip GH status check

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Refer to the [official documentation](https://docs.github.com/en/migrations/usin
 
 Refer to the [official documentation](https://docs.github.com/en/migrations/using-github-enterprise-importer/migrating-repositories-with-github-enterprise-importer/migrating-repositories-from-bitbucket-server-to-github-enterprise-cloud) for more details.
 
+### Skipping GitHub status checks
+
+When the CLIs are launched, they check if GitHub has any ongoing incidents and will display a warning message if this is the case. However, if you wish to skip this check, you can do so by setting the `GEI_SKIP_STATUS_CHECK` environment variable to true. This will prevent the CLIs check for active incidents.
+
 ## Contributions
 
 See [Contributing](CONTRIBUTING.md) for more info on how to get involved.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Refer to the [official documentation](https://docs.github.com/en/migrations/usin
 
 ### Skipping GitHub status checks
 
-When the CLIs are launched, they check if GitHub has any ongoing incidents and will display a warning message if this is the case. However, if you wish to skip this check, you can do so by setting the `GEI_SKIP_STATUS_CHECK` environment variable to true. This will prevent the CLIs check for active incidents.
+When the CLI is launched, it logs a warning if there are any ongoing [GitHub incidents](https://www.githubstatus.com/) that might affect your use of the CLI. You can skip this check by setting the `GEI_SKIP_STATUS_CHECK` environment variable to `true`. 
 
 ## Contributions
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 
+- Skip GitHub status checking on startup if environment variable `GEI_SKIP_STATUS_CHECK` is set to true.

--- a/src/Octoshift/Services/EnvironmentVariableProvider.cs
+++ b/src/Octoshift/Services/EnvironmentVariableProvider.cs
@@ -64,12 +64,14 @@ public class EnvironmentVariableProvider
     {
         var value = Environment.GetEnvironmentVariable(name);
 
+#pragma warning disable IDE0046 // Convert to conditional expression
         if (string.IsNullOrEmpty(value))
         {
             return throwIfNotFound
                 ? throw new OctoshiftCliException($"{name} environment variable is not set.")
                 : null;
         }
+#pragma warning restore IDE0046 // Convert to conditional expression
 
         return value;
     }

--- a/src/Octoshift/Services/EnvironmentVariableProvider.cs
+++ b/src/Octoshift/Services/EnvironmentVariableProvider.cs
@@ -75,6 +75,7 @@ public class EnvironmentVariableProvider
 
         return value;
     }
+
     private string GetSecret(string secretName, bool throwIfNotFound)
     {
         var secret = GetValue(secretName, throwIfNotFound);

--- a/src/Octoshift/Services/EnvironmentVariableProvider.cs
+++ b/src/Octoshift/Services/EnvironmentVariableProvider.cs
@@ -15,6 +15,7 @@ public class EnvironmentVariableProvider
     private const string BBS_USERNAME = "BBS_USERNAME";
     private const string BBS_PASSWORD = "BBS_PASSWORD";
     private const string SMB_PASSWORD = "SMB_PASSWORD";
+    private const string GEI_SKIP_STATUS_CHECK = "GEI_SKIP_STATUS_CHECK";
 
     private readonly OctoLogger _logger;
 
@@ -56,16 +57,25 @@ public class EnvironmentVariableProvider
     public virtual string SmbPassword(bool throwIfNotFound = true) =>
         GetSecret(SMB_PASSWORD, throwIfNotFound);
 
-    private string GetSecret(string secretName, bool throwIfNotFound)
-    {
-        var secret = Environment.GetEnvironmentVariable(secretName);
+    public virtual string SkipStatusCheck(bool throwIfNotFound = false) =>
+        GetValue(GEI_SKIP_STATUS_CHECK, throwIfNotFound);
 
-        if (string.IsNullOrEmpty(secret))
+    private string GetValue(string name, bool throwIfNotFound)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+
+        if (string.IsNullOrEmpty(value))
         {
             return throwIfNotFound
-                ? throw new OctoshiftCliException($"{secretName} environment variable is not set.")
+                ? throw new OctoshiftCliException($"{name} environment variable is not set.")
                 : null;
         }
+
+        return value;
+    }
+    private string GetSecret(string secretName, bool throwIfNotFound)
+    {
+        var secret = GetValue(secretName, throwIfNotFound);
 
         _logger?.RegisterSecret(secret);
 

--- a/src/Octoshift/Services/EnvironmentVariableProvider.cs
+++ b/src/Octoshift/Services/EnvironmentVariableProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using OctoshiftCLI.Extensions;
 
 namespace OctoshiftCLI.Services;
 
@@ -65,7 +66,7 @@ public class EnvironmentVariableProvider
         var value = Environment.GetEnvironmentVariable(name);
 
 #pragma warning disable IDE0046 // Convert to conditional expression
-        if (string.IsNullOrEmpty(value))
+        if (value.IsNullOrWhiteSpace())
         {
             return throwIfNotFound
                 ? throw new OctoshiftCliException($"{name} environment variable is not set.")

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/EnvironmentVariableProviderTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/EnvironmentVariableProviderTests.cs
@@ -17,6 +17,7 @@ public class EnvironmentVariableProviderTests
     private const string AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
     private const string BBS_USERNAME = "BBS_USERNAME";
     private const string BBS_PASSWORD = "BBS_PASSWORD";
+    private const string GEI_SKIP_STATUS_CHECK = "GEI_SKIP_STATUS_CHECK";
 
     private readonly EnvironmentVariableProvider _environmentVariableProvider;
     private readonly Mock<OctoLogger> _mockLogger = TestHelpers.CreateMock<OctoLogger>();
@@ -112,6 +113,21 @@ public class EnvironmentVariableProviderTests
     {
         _environmentVariableProvider.Invoking(env => env.TargetGithubPersonalAccessToken())
             .Should().Throw<OctoshiftCliException>();
+    }
+
+    [Fact]
+    public void SkipStatusCheck_DoesNot_RegisterValue_Against_Logger()
+    {
+        // Arrange
+        var expectedValue = "true";
+        Environment.SetEnvironmentVariable(GEI_SKIP_STATUS_CHECK, expectedValue);
+
+        // Act
+        var value = _environmentVariableProvider.SkipStatusCheck();
+
+        // Assert
+        value.Should().Be(expectedValue);
+        _mockLogger.VerifyNoOtherCalls();
     }
 
     private void ResetEnvs()

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/EnvironmentVariableProviderTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/EnvironmentVariableProviderTests.cs
@@ -140,5 +140,6 @@ public class EnvironmentVariableProviderTests
         Environment.SetEnvironmentVariable(AWS_SECRET_ACCESS_KEY, null);
         Environment.SetEnvironmentVariable(BBS_USERNAME, null);
         Environment.SetEnvironmentVariable(BBS_PASSWORD, null);
+        Environment.SetEnvironmentVariable(GEI_SKIP_STATUS_CHECK, null);
     }
 }

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/EnvironmentVariableProviderTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/EnvironmentVariableProviderTests.cs
@@ -116,6 +116,19 @@ public class EnvironmentVariableProviderTests
     }
 
     [Fact]
+    public void SkipStatusCheck_WhitespacesOnly_Should_Return_Null()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable(GEI_SKIP_STATUS_CHECK, " ");
+
+        // Act
+        var result = _environmentVariableProvider.SkipStatusCheck();
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public void SkipStatusCheck_DoesNot_RegisterValue_Against_Logger()
     {
         // Arrange

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -100,7 +100,7 @@ namespace OctoshiftCLI.AdoToGithub
 
             if (envProvider.SkipStatusCheck()?.ToUpperInvariant() is "TRUE" or "1")
             {
-                Logger.LogInformation("Skipped GitHub status check.");
+                Logger.LogInformation("Skipped GitHub status check due to GEI_SKIP_STATUS_CHECK environment variable");
                 return;
             }
 

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -96,7 +96,9 @@ namespace OctoshiftCLI.AdoToGithub
 
         private static async Task GithubStatusCheck(ServiceProvider sp)
         {
-            if (Environment.GetEnvironmentVariable("GEI_SKIP_STATUS_CHECK")?.ToUpperInvariant() == "TRUE")
+            var envProvider = sp.GetRequiredService<EnvironmentVariableProvider>();
+
+            if (envProvider.SkipStatusCheck()?.ToUpperInvariant() is "TRUE" or "1")
             {
                 Logger.LogInformation("Skipped GitHub status check.");
                 return;

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -96,6 +96,12 @@ namespace OctoshiftCLI.AdoToGithub
 
         private static async Task GithubStatusCheck(ServiceProvider sp)
         {
+            if (Environment.GetEnvironmentVariable("GEI_SKIP_STATUS_CHECK")?.ToUpperInvariant() == "TRUE")
+            {
+                Logger.LogInformation("Skipped GitHub status check.");
+                return;
+            }
+
             var githubStatusApi = sp.GetRequiredService<GithubStatusApi>();
 
             if (await githubStatusApi.GetUnresolvedIncidentsCount() > 0)

--- a/src/bbs2gh/Program.cs
+++ b/src/bbs2gh/Program.cs
@@ -103,7 +103,9 @@ namespace OctoshiftCLI.BbsToGithub
 
         private static async Task GithubStatusCheck(ServiceProvider sp)
         {
-            if (Environment.GetEnvironmentVariable("GEI_SKIP_STATUS_CHECK")?.ToUpperInvariant() == "TRUE")
+            var envProvider = sp.GetRequiredService<EnvironmentVariableProvider>();
+
+            if (envProvider.SkipStatusCheck()?.ToUpperInvariant() is "TRUE" or "1")
             {
                 Logger.LogInformation("Skipped GitHub status check.");
                 return;

--- a/src/bbs2gh/Program.cs
+++ b/src/bbs2gh/Program.cs
@@ -103,6 +103,12 @@ namespace OctoshiftCLI.BbsToGithub
 
         private static async Task GithubStatusCheck(ServiceProvider sp)
         {
+            if (Environment.GetEnvironmentVariable("GEI_SKIP_STATUS_CHECK")?.ToUpperInvariant() == "TRUE")
+            {
+                Logger.LogInformation("Skipped GitHub status check.");
+                return;
+            }
+
             var githubStatusApi = sp.GetRequiredService<GithubStatusApi>();
 
             if (await githubStatusApi.GetUnresolvedIncidentsCount() > 0)

--- a/src/bbs2gh/Program.cs
+++ b/src/bbs2gh/Program.cs
@@ -107,7 +107,7 @@ namespace OctoshiftCLI.BbsToGithub
 
             if (envProvider.SkipStatusCheck()?.ToUpperInvariant() is "TRUE" or "1")
             {
-                Logger.LogInformation("Skipped GitHub status check.");
+                Logger.LogInformation("Skipped GitHub status check due to GEI_SKIP_STATUS_CHECK environment variable");
                 return;
             }
 

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -100,7 +100,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
             if (envProvider.SkipStatusCheck()?.ToUpperInvariant() is "TRUE" or "1")
             {
-                Logger.LogInformation("Skipped GitHub status check.");
+                Logger.LogInformation("Skipped GitHub status check due to GEI_SKIP_STATUS_CHECK environment variable");
                 return;
             }
 

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -96,7 +96,9 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
         private static async Task GithubStatusCheck(ServiceProvider sp)
         {
-            if (Environment.GetEnvironmentVariable("GEI_SKIP_STATUS_CHECK")?.ToUpperInvariant() == "TRUE")
+            var envProvider = sp.GetRequiredService<EnvironmentVariableProvider>();
+
+            if (envProvider.SkipStatusCheck()?.ToUpperInvariant() is "TRUE" or "1")
             {
                 Logger.LogInformation("Skipped GitHub status check.");
                 return;

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -96,6 +96,12 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
         private static async Task GithubStatusCheck(ServiceProvider sp)
         {
+            if (Environment.GetEnvironmentVariable("GEI_SKIP_STATUS_CHECK")?.ToUpperInvariant() == "TRUE")
+            {
+                Logger.LogInformation("Skipped GitHub status check.");
+                return;
+            }
+
             var githubStatusApi = sp.GetRequiredService<GithubStatusApi>();
 
             if (await githubStatusApi.GetUnresolvedIncidentsCount() > 0)


### PR DESCRIPTION
If environment variable GEI_SKIP_STATUS_CHECK is set true, no GH status check will be performed

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->