### PR TITLE
Fix flaky tests

### DIFF
--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/WaitForMigration/WaitForMigrationCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/WaitForMigration/WaitForMigrationCommandHandlerTests.cs
@@ -29,6 +29,8 @@ public class WaitForMigrationCommandHandlerTests
         {
             WaitIntervalInSeconds = WAIT_INTERVAL
         };
+
+        TestHelpers.SetCliContext();
     }
 
     [Fact]
@@ -54,7 +56,7 @@ public class WaitForMigrationCommandHandlerTests
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.InProgress}",
                 $"Waiting {WAIT_INTERVAL} seconds...",
                 $"Migration {REPO_MIGRATION_ID} succeeded for {TARGET_REPO}",
-                $"Migration log available at {MIGRATION_URL} or by running `gh {CliContext.RootCommand} download-logs`"
+                $"Migration log available at {MIGRATION_URL} or by running `gh {TestHelpers.CLI_ROOT_COMMAND} download-logs`"
     };
 
         // Act
@@ -100,7 +102,7 @@ public class WaitForMigrationCommandHandlerTests
                 $"Waiting {WAIT_INTERVAL} seconds...",
                 $"Migration {REPO_MIGRATION_ID} succeeded for {TARGET_REPO}",
                 "1 warning encountered during this migration",
-                $"Migration log available at {MIGRATION_URL} or by running `gh {CliContext.RootCommand} download-logs`"
+                $"Migration log available at {MIGRATION_URL} or by running `gh {TestHelpers.CLI_ROOT_COMMAND} download-logs`"
     };
 
         // Act
@@ -147,7 +149,7 @@ public class WaitForMigrationCommandHandlerTests
                 $"Waiting {WAIT_INTERVAL} seconds...",
                 $"Migration {REPO_MIGRATION_ID} succeeded for {TARGET_REPO}",
                 "4 warnings encountered during this migration",
-                $"Migration log available at {MIGRATION_URL} or by running `gh {CliContext.RootCommand} download-logs`"
+                $"Migration log available at {MIGRATION_URL} or by running `gh {TestHelpers.CLI_ROOT_COMMAND} download-logs`"
     };
 
         // Act
@@ -194,7 +196,7 @@ public class WaitForMigrationCommandHandlerTests
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.InProgress}",
                 $"Waiting {WAIT_INTERVAL} seconds...",
                 $"Migration {REPO_MIGRATION_ID} failed for {TARGET_REPO}",
-                $"Migration log available at {MIGRATION_URL} or by running `gh {CliContext.RootCommand} download-logs`"
+                $"Migration log available at {MIGRATION_URL} or by running `gh {TestHelpers.CLI_ROOT_COMMAND} download-logs`"
             };
 
         // Act
@@ -244,7 +246,7 @@ public class WaitForMigrationCommandHandlerTests
                 $"Migration {REPO_MIGRATION_ID} for {TARGET_REPO} is {RepositoryMigrationStatus.PendingValidation}",
                 $"Waiting {WAIT_INTERVAL} seconds...",
                 $"Migration {REPO_MIGRATION_ID} failed for {TARGET_REPO}",
-                $"Migration log available at {MIGRATION_URL} or by running `gh {CliContext.RootCommand} download-logs`"
+                $"Migration log available at {MIGRATION_URL} or by running `gh {TestHelpers.CLI_ROOT_COMMAND} download-logs`"
             };
 
         // Act

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/VersionCheckerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/VersionCheckerTests.cs
@@ -10,11 +10,7 @@ public class VersionCheckerTests
     public void GetVersionComments_Returns_Root_And_Executing_Commands()
     {
         // Arrange
-        const string rootCommand = "ROOT_COMMAND";
-        const string executingCommand = "EXECUTING_COMMAND";
-
-        CliContext.RootCommand = rootCommand;
-        CliContext.ExecutingCommand = executingCommand;
+        TestHelpers.SetCliContext();
 
         var versionChecker = new VersionChecker(null, null);
 
@@ -22,6 +18,6 @@ public class VersionCheckerTests
         var comments = versionChecker.GetVersionComments();
 
         // Assert
-        comments.Should().Be($"({rootCommand}/{executingCommand})");
+        comments.Should().Be($"({TestHelpers.CLI_ROOT_COMMAND}/{TestHelpers.CLI_EXECUTING_COMMAND})");
     }
 }

--- a/src/OctoshiftCLI.Tests/TestHelpers.cs
+++ b/src/OctoshiftCLI.Tests/TestHelpers.cs
@@ -8,6 +8,11 @@ namespace OctoshiftCLI.Tests
 {
     public static class TestHelpers
     {
+        private static readonly object _mutex = new();
+
+        public const string CLI_ROOT_COMMAND = "ROOT_COMMAND";
+        public const string CLI_EXECUTING_COMMAND = "EXECUTING_COMMAND";
+
         public static Mock<T> CreateMock<T>() where T : class
         {
             var ctor = typeof(T).GetConstructors().First();
@@ -23,6 +28,15 @@ namespace OctoshiftCLI.Tests
 
             Assert.Equal(required, option.IsRequired);
             Assert.Equal(isHidden, option.IsHidden);
+        }
+
+        public static void SetCliContext()
+        {
+            lock (_mutex)
+            {
+                CliContext.RootCommand ??= CLI_ROOT_COMMAND;
+                CliContext.ExecutingCommand ??= CLI_EXECUTING_COMMAND;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes [flaky tests](https://github.com/github/gh-gei/actions/runs/6870726372/job/18686177642?pr=1162) that was caused by trying to access the `CliContext` without setting it first. The `CliContext` values are only going to be set during the execution of a command but in unit tests if we want to use the context values (`CliContext.RootCommand` and `CliConext.ExecutingCommand`) we need to set them first. 

Interestingly the flakiness was happening because of a race condition! The flaky tests were in `OctoshiftCLI.Tests.Octoshift.Commands.WaitForMigration.WaitForMigrationCommandHandlerTests` and specifically the ones that were relying on the value of `CliContext.RootCommand` (for example `With_Migration_ID_That_Succeeds_With_1_Warning`). We used to set the context values only in the `VersionCheckerTests.cs` and because of a race condition the expected and actual values of the following string might have different values depending on whether `WaitForMigrationCommandHandlerTests.With_Migration_ID_That_Succeeds_With_1_Warning` or `VersionCheckerTests.GetVersionComments_Returns_Root_And_Executing_Commands` runs first:

```c#
$"Migration log available at {MIGRATION_URL} or by running `gh {CliContext.RootCommand} download-logs`"
```

To fix the problem, a new static helper methods (`SetCliContext`) was added to `TestHelpers` to set the CLI context values in a thread safe manner to make sure they are going to be set just once. Any test that needs the context values need to call `TestHelpers.SetCliContext` first to make sure the values are set. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->