### PR TITLE
Redact `X-Amz-Credential` querystring parameters from URLs in logs

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 - Redact `X-Amz-Credential` querystring parameters in AWS S3 URLs included in logs
+- When redacting sensitive patterns in log output, use a non-case sensitive search

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Redact `X-Amz-Credential` querystring parameters in AWS S3 URLs included in logs

--- a/src/Octoshift/Services/OctoLogger.cs
+++ b/src/Octoshift/Services/OctoLogger.cs
@@ -33,7 +33,8 @@ public class OctoLogger
 
     private readonly List<string> _redactionPatterns = new()
     {
-        "\\b(?<=token=)(.+?)\\b"
+        "\\b(?<=token=)(.+?)\\b",
+        "\\b(?<=X-Amz-Credential=)(.+?)\\b",
     };
 
     public OctoLogger()

--- a/src/Octoshift/Services/OctoLogger.cs
+++ b/src/Octoshift/Services/OctoLogger.cs
@@ -97,7 +97,7 @@ public class OctoLogger
 
         foreach (var redactionPattern in _redactionPatterns)
         {
-            result = Regex.Replace(result, redactionPattern, "***");
+            result = Regex.Replace(result, redactionPattern, "***", RegexOptions.IgnoreCase);
         }
 
         return result;

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
@@ -63,25 +63,33 @@ public class OctoLoggerTests
     [Fact]
     public void Ghes_Archive_Url_Tokens_Should_Be_Replaced_In_Logs_And_Console()
     {
-
         var ghesArchiveUrl = "https://files.github.acmeinc.com/foo?token=foobar";
+        var variants = new[]
+        {
+            ghesArchiveUrl,
+            ghesArchiveUrl.ToUpper(),
+            ghesArchiveUrl.ToLower()
+        };
 
-        _octoLogger.Verbose = false;
-        _octoLogger.LogInformation($"Archive URL: {ghesArchiveUrl}");
-        _octoLogger.LogVerbose($"Archive URL: {ghesArchiveUrl}");
-        _octoLogger.LogWarning($"Archive URL: {ghesArchiveUrl}");
-        _octoLogger.LogSuccess($"Archive URL: {ghesArchiveUrl}");
-        _octoLogger.LogError($"Archive URL: {ghesArchiveUrl}");
-        _octoLogger.LogError(new OctoshiftCliException($"Archive URL: {ghesArchiveUrl}"));
-        _octoLogger.LogError(new InvalidOperationException($"Archive URL: {ghesArchiveUrl}"));
+        foreach (var variant in variants)
+        {
+            _octoLogger.Verbose = false;
+            _octoLogger.LogInformation($"Archive URL: {variant}");
+            _octoLogger.LogVerbose($"Archive URL: {variant}");
+            _octoLogger.LogWarning($"Archive URL: {variant}");
+            _octoLogger.LogSuccess($"Archive URL: {variant}");
+            _octoLogger.LogError($"Archive URL: {variant}");
+            _octoLogger.LogError(new OctoshiftCliException($"Archive URL: {variant}"));
+            _octoLogger.LogError(new InvalidOperationException($"Archive URL: {variant}"));
 
-        _octoLogger.Verbose = true;
-        _octoLogger.LogVerbose($"Archive URL: {ghesArchiveUrl}");
+            _octoLogger.Verbose = true;
+            _octoLogger.LogVerbose($"Archive URL: {variant}");
 
-        _consoleOutput.Should().NotContain(ghesArchiveUrl);
-        _logOutput.Should().NotContain(ghesArchiveUrl);
-        _verboseLogOutput.Should().NotContain(ghesArchiveUrl);
-        _consoleError.Should().NotContain(ghesArchiveUrl);
+            _consoleOutput.Should().NotContain(variant);
+            _logOutput.Should().NotContain(variant);
+            _verboseLogOutput.Should().NotContain(variant);
+            _consoleError.Should().NotContain(variant);
+        }
 
         _consoleOutput.Should().Contain("Archive URL: https://files.github.acmeinc.com/foo?token=***");
     }
@@ -89,25 +97,34 @@ public class OctoLoggerTests
     [Fact]
     public void Aws_Url_X_Aws_Credential_Parameters_Should_Be_Replaced_In_Logs_And_Console()
     {
-
         var awsUrl = "https://example-s3-bucket-name.s3.amazonaws.com/uuid-uuid-uuid.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AAAAAAAAAAAAAAAAAAAAAAA&X-Amz-Date=20231025T104425Z&X-Amz-Expires=172800&X-Amz-Signature=AAAAAAAAAAAAAAAAAAAAAAA&X-Amz-SignedHeaders=host&actor_id=1&key_id=0&repo_id=0&response-content-disposition=filename%3Duuid-uuid-uuid.tar.gz&response-content-type=application%2Fx-gzip";
+        var variants = new[]
+        {
+            awsUrl,
+            awsUrl.ToUpper(),
+            awsUrl.ToLower()
+        };
 
-        _octoLogger.Verbose = false;
-        _octoLogger.LogInformation($"Archive (metadata) download url: {awsUrl}");
-        _octoLogger.LogVerbose($"Archive (metadata) download url: {awsUrl}");
-        _octoLogger.LogWarning($"Archive (metadata) download url: {awsUrl}");
-        _octoLogger.LogSuccess($"Archive (metadata) download url: {awsUrl}");
-        _octoLogger.LogError($"Archive (metadata) download url: {awsUrl}");
-        _octoLogger.LogError(new OctoshiftCliException($"Archive (metadata) download url: {awsUrl}"));
-        _octoLogger.LogError(new InvalidOperationException($"Archive (metadata) download url: {awsUrl}"));
+        foreach (var variant in variants)
+        {
+            _octoLogger.Verbose = false;
+            _octoLogger.LogInformation($"Archive (metadata) download url: {variant}");
+            _octoLogger.LogVerbose($"Archive (metadata) download url: {variant}");
+            _octoLogger.LogWarning($"Archive (metadata) download url: {variant}");
+            _octoLogger.LogSuccess($"Archive (metadata) download url: {variant}");
+            _octoLogger.LogError($"Archive (metadata) download url: {variant}");
+            _octoLogger.LogError(new OctoshiftCliException($"Archive (metadata) download url: {variant}"));
+            _octoLogger.LogError(new InvalidOperationException($"Archive (metadata) download url: {variant}"));
+            _octoLogger.LogInformation($"Archive (metadata) download url: {variant.ToLower()}");
 
-        _octoLogger.Verbose = true;
-        _octoLogger.LogVerbose($"Archive (metadata) download url: {awsUrl}");
+            _octoLogger.Verbose = true;
+            _octoLogger.LogVerbose($"Archive (metadata) download url: {variant}");
 
-        _consoleOutput.Should().NotContain(awsUrl);
-        _logOutput.Should().NotContain(awsUrl);
-        _verboseLogOutput.Should().NotContain(awsUrl);
-        _consoleError.Should().NotContain(awsUrl);
+            _consoleOutput.Should().NotContain(variant);
+            _logOutput.Should().NotContain(variant);
+            _verboseLogOutput.Should().NotContain(variant);
+            _consoleError.Should().NotContain(variant);
+        }
 
         _consoleOutput.Should().Contain("https://example-s3-bucket-name.s3.amazonaws.com/uuid-uuid-uuid.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=***&X-Amz-Date=20231025T104425Z&X-Amz-Expires=172800&X-Amz-Signature=AAAAAAAAAAAAAAAAAAAAAAA&X-Amz-SignedHeaders=host&actor_id=1&key_id=0&repo_id=0&response-content-disposition=filename%3Duuid-uuid-uuid.tar.gz&response-content-type=application%2Fx-gzip");
     }

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
@@ -72,11 +72,11 @@ public class OctoLoggerTests
         _octoLogger.LogWarning($"Archive URL: {ghesArchiveUrl}");
         _octoLogger.LogSuccess($"Archive URL: {ghesArchiveUrl}");
         _octoLogger.LogError($"Archive URL: {ghesArchiveUrl}");
-        _octoLogger.LogError(new OctoshiftCliException("Archive URL: {ghesArchiveUrl}"));
-        _octoLogger.LogError(new InvalidOperationException("Archive URL: {ghesArchiveUrl}"));
+        _octoLogger.LogError(new OctoshiftCliException($"Archive URL: {ghesArchiveUrl}"));
+        _octoLogger.LogError(new InvalidOperationException($"Archive URL: {ghesArchiveUrl}"));
 
         _octoLogger.Verbose = true;
-        _octoLogger.LogVerbose("Archive URL: {ghesArchiveUrl}");
+        _octoLogger.LogVerbose($"Archive URL: {ghesArchiveUrl}");
 
         _consoleOutput.Should().NotContain(ghesArchiveUrl);
         _logOutput.Should().NotContain(ghesArchiveUrl);

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
@@ -87,6 +87,32 @@ public class OctoLoggerTests
     }
 
     [Fact]
+    public void Aws_Url_X_Aws_Credential_Parameters_Should_Be_Replaced_In_Logs_And_Console()
+    {
+
+        var awsUrl = "https://example-s3-bucket-name.s3.amazonaws.com/uuid-uuid-uuid.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AAAAAAAAAAAAAAAAAAAAAAA&X-Amz-Date=20231025T104425Z&X-Amz-Expires=172800&X-Amz-Signature=AAAAAAAAAAAAAAAAAAAAAAA&X-Amz-SignedHeaders=host&actor_id=1&key_id=0&repo_id=0&response-content-disposition=filename%3Duuid-uuid-uuid.tar.gz&response-content-type=application%2Fx-gzip";
+
+        _octoLogger.Verbose = false;
+        _octoLogger.LogInformation($"Archive (metadata) download url: {awsUrl}");
+        _octoLogger.LogVerbose($"Archive (metadata) download url: {awsUrl}");
+        _octoLogger.LogWarning($"Archive (metadata) download url: {awsUrl}");
+        _octoLogger.LogSuccess($"Archive (metadata) download url: {awsUrl}");
+        _octoLogger.LogError($"Archive (metadata) download url: {awsUrl}");
+        _octoLogger.LogError(new OctoshiftCliException($"Archive (metadata) download url: {awsUrl}"));
+        _octoLogger.LogError(new InvalidOperationException($"Archive (metadata) download url: {awsUrl}"));
+
+        _octoLogger.Verbose = true;
+        _octoLogger.LogVerbose($"Archive (metadata) download url: {awsUrl}");
+
+        _consoleOutput.Should().NotContain(awsUrl);
+        _logOutput.Should().NotContain(awsUrl);
+        _verboseLogOutput.Should().NotContain(awsUrl);
+        _consoleError.Should().NotContain(awsUrl);
+
+        _consoleOutput.Should().Contain("https://example-s3-bucket-name.s3.amazonaws.com/uuid-uuid-uuid.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=***&X-Amz-Date=20231025T104425Z&X-Amz-Expires=172800&X-Amz-Signature=AAAAAAAAAAAAAAAAAAAAAAA&X-Amz-SignedHeaders=host&actor_id=1&key_id=0&repo_id=0&response-content-disposition=filename%3Duuid-uuid-uuid.tar.gz&response-content-type=application%2Fx-gzip");
+    }
+
+    [Fact]
     public void LogError_For_OctoshiftCliException_Should_Log_Exception_Message_In_Non_Verbose_Mode()
     {
         // Arrange

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
@@ -60,73 +60,54 @@ public class OctoLoggerTests
         _consoleError.Should().NotContain(urlEncodedSecret);
     }
 
-    [Fact]
-    public void Ghes_Archive_Url_Tokens_Should_Be_Replaced_In_Logs_And_Console()
+    [Theory]
+    [InlineData("https://files.github.acmeinc.com/foo?token=foobar")]
+    [InlineData("HTTPS://FILES.GITHUB.ACMEINC.COM/FOO?TOKEN=FOOBAR")]
+    public void Ghes_Archive_Url_Tokens_Should_Be_Replaced_In_Logs_And_Console(string archiveUrl)
     {
-        var ghesArchiveUrl = "https://files.github.acmeinc.com/foo?token=foobar";
-        var variants = new[]
-        {
-            ghesArchiveUrl,
-            ghesArchiveUrl.ToUpper(),
-            ghesArchiveUrl.ToLower()
-        };
+        _octoLogger.Verbose = false;
+        _octoLogger.LogInformation($"Archive URL: {archiveUrl}");
+        _octoLogger.LogVerbose($"Archive URL: {archiveUrl}");
+        _octoLogger.LogWarning($"Archive URL: {archiveUrl}");
+        _octoLogger.LogSuccess($"Archive URL: {archiveUrl}");
+        _octoLogger.LogError($"Archive URL: {archiveUrl}");
+        _octoLogger.LogError(new OctoshiftCliException($"Archive URL: {archiveUrl}"));
+        _octoLogger.LogError(new InvalidOperationException($"Archive URL: {archiveUrl}"));
 
-        foreach (var variant in variants)
-        {
-            _octoLogger.Verbose = false;
-            _octoLogger.LogInformation($"Archive URL: {variant}");
-            _octoLogger.LogVerbose($"Archive URL: {variant}");
-            _octoLogger.LogWarning($"Archive URL: {variant}");
-            _octoLogger.LogSuccess($"Archive URL: {variant}");
-            _octoLogger.LogError($"Archive URL: {variant}");
-            _octoLogger.LogError(new OctoshiftCliException($"Archive URL: {variant}"));
-            _octoLogger.LogError(new InvalidOperationException($"Archive URL: {variant}"));
+        _octoLogger.Verbose = true;
+        _octoLogger.LogVerbose($"Archive URL: {archiveUrl}");
 
-            _octoLogger.Verbose = true;
-            _octoLogger.LogVerbose($"Archive URL: {variant}");
+        _consoleOutput.Should().NotContain(archiveUrl);
+        _logOutput.Should().NotContain(archiveUrl);
+        _verboseLogOutput.Should().NotContain(archiveUrl);
+        _consoleError.Should().NotContain(archiveUrl);
 
-            _consoleOutput.Should().NotContain(variant);
-            _logOutput.Should().NotContain(variant);
-            _verboseLogOutput.Should().NotContain(variant);
-            _consoleError.Should().NotContain(variant);
-        }
-
-        _consoleOutput.Should().Contain("Archive URL: https://files.github.acmeinc.com/foo?token=***");
+        _consoleOutput.ToLower().Should().Contain("?token=***");
     }
 
-    [Fact]
-    public void Aws_Url_X_Aws_Credential_Parameters_Should_Be_Replaced_In_Logs_And_Console()
+    [Theory]
+    [InlineData("https://example-s3-bucket-name.s3.amazonaws.com/uuid-uuid-uuid.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AAAAAAAAAAAAAAAAAAAAAAA&X-Amz-Date=20231025T104425Z&X-Amz-Expires=172800&X-Amz-Signature=AAAAAAAAAAAAAAAAAAAAAAA&X-Amz-SignedHeaders=host&actor_id=1&key_id=0&repo_id=0&response-content-disposition=filename%3Duuid-uuid-uuid.tar.gz&response-content-type=application%2Fx-gzip")]
+    [InlineData("HTTPS://EXAMPLE-S3-BUCKET-NAME.S3.AMAZONAWS.COM/UUID-UUID-UUID.TAR.GZ?X-AMZ-ALGORITHM=AWS4-HMAC-SHA256&X-AMZ-CREDENTIAL=AAAAAAAAAAAAAAAAAAAAAAA&X-AMZ-DATE=20231025T104425Z&X-AMZ-EXPIRES=172800&X-AMZ-SIGNATURE=AAAAAAAAAAAAAAAAAAAAAAA&X-AMZ-SIGNEDHEADERS=HOST&ACTOR_ID=1&KEY_ID=0&REPO_ID=0&RESPONSE-CONTENT-DISPOSITION=FILENAME%3DUUID-UUID-UUID.TAR.GZ&RESPONSE-CONTENT-TYPE=APPLICATION%2FX-GZIP")]
+    public void Aws_Url_X_Aws_Credential_Parameters_Should_Be_Replaced_In_Logs_And_Console(string awsUrl)
     {
-        var awsUrl = "https://example-s3-bucket-name.s3.amazonaws.com/uuid-uuid-uuid.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AAAAAAAAAAAAAAAAAAAAAAA&X-Amz-Date=20231025T104425Z&X-Amz-Expires=172800&X-Amz-Signature=AAAAAAAAAAAAAAAAAAAAAAA&X-Amz-SignedHeaders=host&actor_id=1&key_id=0&repo_id=0&response-content-disposition=filename%3Duuid-uuid-uuid.tar.gz&response-content-type=application%2Fx-gzip";
-        var variants = new[]
-        {
-            awsUrl,
-            awsUrl.ToUpper(),
-            awsUrl.ToLower()
-        };
+        _octoLogger.Verbose = false;
+        _octoLogger.LogInformation($"Archive (metadata) download url: {awsUrl}");
+        _octoLogger.LogVerbose($"Archive (metadata) download url: {awsUrl}");
+        _octoLogger.LogWarning($"Archive (metadata) download url: {awsUrl}");
+        _octoLogger.LogSuccess($"Archive (metadata) download url: {awsUrl}");
+        _octoLogger.LogError($"Archive (metadata) download url: {awsUrl}");
+        _octoLogger.LogError(new OctoshiftCliException($"Archive (metadata) download url: {awsUrl}"));
+        _octoLogger.LogError(new InvalidOperationException($"Archive (metadata) download url: {awsUrl}"));
 
-        foreach (var variant in variants)
-        {
-            _octoLogger.Verbose = false;
-            _octoLogger.LogInformation($"Archive (metadata) download url: {variant}");
-            _octoLogger.LogVerbose($"Archive (metadata) download url: {variant}");
-            _octoLogger.LogWarning($"Archive (metadata) download url: {variant}");
-            _octoLogger.LogSuccess($"Archive (metadata) download url: {variant}");
-            _octoLogger.LogError($"Archive (metadata) download url: {variant}");
-            _octoLogger.LogError(new OctoshiftCliException($"Archive (metadata) download url: {variant}"));
-            _octoLogger.LogError(new InvalidOperationException($"Archive (metadata) download url: {variant}"));
-            _octoLogger.LogInformation($"Archive (metadata) download url: {variant.ToLower()}");
+        _octoLogger.Verbose = true;
+        _octoLogger.LogVerbose($"Archive (metadata) download url: {awsUrl}");
 
-            _octoLogger.Verbose = true;
-            _octoLogger.LogVerbose($"Archive (metadata) download url: {variant}");
+        _consoleOutput.Should().NotContain(awsUrl);
+        _logOutput.Should().NotContain(awsUrl);
+        _verboseLogOutput.Should().NotContain(awsUrl);
+        _consoleError.Should().NotContain(awsUrl);
 
-            _consoleOutput.Should().NotContain(variant);
-            _logOutput.Should().NotContain(variant);
-            _verboseLogOutput.Should().NotContain(variant);
-            _consoleError.Should().NotContain(variant);
-        }
-
-        _consoleOutput.Should().Contain("https://example-s3-bucket-name.s3.amazonaws.com/uuid-uuid-uuid.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=***&X-Amz-Date=20231025T104425Z&X-Amz-Expires=172800&X-Amz-Signature=AAAAAAAAAAAAAAAAAAAAAAA&X-Amz-SignedHeaders=host&actor_id=1&key_id=0&repo_id=0&response-content-disposition=filename%3Duuid-uuid-uuid.tar.gz&response-content-type=application%2Fx-gzip");
+        _consoleOutput.ToLower().Should().Contain("&x-amz-credential=***");
     }
 
     [Fact]


### PR DESCRIPTION
After uploading archives to AWS, we log the URL in a few different places. 

It isn't desirable for unredacted URLs to be available in the log output as this represents a security risk, providing access to potentially sensitive files.

This redacts the AWS URLs, removing the `X-Aws-Credential` argument so they will no longer be "live" URLs.

Fixes #1159.

As part of this PR, I'm also fixing some other `OctoLogger` tests which parse but are incorrect, because variable interpolation is not enabled for relevant strings.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->