### PR TITLE
Add abort migration generic commands

### DIFF
--- a/src/Octoshift/Commands/AbortMigration/AbortCommandBase.cs
+++ b/src/Octoshift/Commands/AbortMigration/AbortCommandBase.cs
@@ -1,0 +1,58 @@
+using System;
+using System.CommandLine;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
+using OctoshiftCLI.Contracts;
+using OctoshiftCLI.Services;
+
+[assembly: InternalsVisibleTo("OctoshiftCLI.Tests")]
+
+namespace OctoshiftCLI.Commands.AbortMigration;
+
+public class AbortMigrationCommandBase : CommandBase<AbortMigrationCommandArgs, AbortMigrationCommandHandler>
+{
+    public AbortMigrationCommandBase() : base(
+        name: "abort-migration",
+        description: "Aborts a migration that is in progress.")
+    {
+    }
+
+    public virtual Option<string> MigrationId { get; } = new("--migration-id")
+    {
+        IsRequired = true,
+        Description = "Waits for the specified migration to finish."
+    };
+
+    public virtual Option<string> GithubPat { get; } = new("--github-pat")
+    {
+        Description = "Personal access token of the GitHub target. Overrides GH_PAT environment variable."
+    };
+
+    public virtual Option<bool> Verbose { get; } = new("--verbose");
+
+    protected void AddOptions()
+    {
+        AddOption(MigrationId);
+        AddOption(GithubPat);
+        AddOption(Verbose);
+    }
+
+    public override AbortMigrationCommandHandler BuildHandler(AbortMigrationCommandArgs args, IServiceProvider sp)
+    {
+        if (args is null)
+        {
+            throw new ArgumentNullException(nameof(args));
+        }
+
+        if (sp is null)
+        {
+            throw new ArgumentNullException(nameof(sp));
+        }
+
+        var log = sp.GetRequiredService<OctoLogger>();
+        var githubApi = sp.GetRequiredService<ITargetGithubApiFactory>().Create(targetPersonalAccessToken: args.GithubPat);
+
+
+        return new AbortMigrationCommandHandler(log, githubApi);
+    }
+}

--- a/src/Octoshift/Commands/AbortMigration/AbortMigrationCommandArgs.cs
+++ b/src/Octoshift/Commands/AbortMigration/AbortMigrationCommandArgs.cs
@@ -1,0 +1,26 @@
+﻿using OctoshiftCLI.Extensions;
+using OctoshiftCLI.Services;
+
+namespace OctoshiftCLI.Commands.AbortMigration;
+
+public class AbortMigrationCommandArgs : CommandArgs
+{
+    public string MigrationId { get; set; }
+    [Secret]
+    public string GithubPat { get; set; }
+
+    public const string REPO_MIGRATION_ID_PREFIX = "RM_";
+
+    public override void Validate(OctoLogger log)
+    {
+        if (MigrationId.IsNullOrWhiteSpace())
+        {
+            throw new OctoshiftCliException("MigrationId must be provided");
+        }
+
+        if (!MigrationId.StartsWith(REPO_MIGRATION_ID_PREFIX))
+        {
+            throw new OctoshiftCliException($"Invalid migration id: {MigrationId}");
+        }
+    }
+}

--- a/src/Octoshift/Commands/AbortMigration/AbortMigrationCommandHandler.cs
+++ b/src/Octoshift/Commands/AbortMigration/AbortMigrationCommandHandler.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using OctoshiftCLI.Services;
+
+[assembly: InternalsVisibleTo("OctoshiftCLI.Tests")]
+
+namespace OctoshiftCLI.Commands.AbortMigration;
+
+public class AbortMigrationCommandHandler : ICommandHandler<AbortMigrationCommandArgs>
+{
+    internal int WaitIntervalInSeconds = 10;
+
+    private readonly OctoLogger _log;
+    private readonly GithubApi _githubApi;
+
+    public AbortMigrationCommandHandler(OctoLogger log, GithubApi githubApi)
+    {
+        _log = log;
+        _githubApi = githubApi;
+    }
+
+    public async Task Handle(AbortMigrationCommandArgs args)
+    {
+        if (args is null)
+        {
+            throw new ArgumentNullException(nameof(args));
+        }
+
+        await AbortRepositoryMigration(args.MigrationId);
+    }
+
+    private async Task AbortRepositoryMigration(string migrationId)
+    {
+        var abortion_state = await _githubApi.AbortMigration(migrationId);
+
+        if (abortion_state == false)
+        {
+            _log.LogError($"Failed to abort migration {migrationId}");
+            return;
+        }
+
+        _log.LogInformation($"Migration {migrationId} was cancelled");
+    }
+}

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/AbortMigration/AbortMirationCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/AbortMigration/AbortMirationCommandHandlerTests.cs
@@ -1,0 +1,69 @@
+using System.Threading.Tasks;
+using Moq;
+using OctoshiftCLI.Commands.AbortMigration;
+using OctoshiftCLI.Services;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.Octoshift.Commands.AbortMigration;
+
+public class AbortMigrationCommandHandlerTests
+{
+    private readonly Mock<GithubApi> _mockGithubApi = TestHelpers.CreateMock<GithubApi>();
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+
+    private readonly WarningsCountLogger _warningsCountLogger;
+    private readonly AbortMigrationCommandHandler _handler;
+
+    private const string REPO_MIGRATION_ID = "RM_MIGRATION_ID";
+
+    public AbortMigrationCommandHandlerTests()
+    {
+        _warningsCountLogger = new WarningsCountLogger(_mockOctoLogger.Object);
+        _handler = new AbortMigrationCommandHandler(_mockOctoLogger.Object, _mockGithubApi.Object);
+
+        TestHelpers.SetCliContext();
+    }
+
+    [Fact]
+    public async Task With_Migration_ID_That_Succeeds()
+    {
+        // Arrange
+        _mockGithubApi.Setup(x => x.AbortMigration(It.IsAny<string>())).ReturnsAsync(true);
+
+        // Act
+        var args = new AbortMigrationCommandArgs
+        {
+            MigrationId = REPO_MIGRATION_ID,
+        };
+        await _handler.Handle(args);
+
+        // Assert
+        _mockOctoLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
+        _mockOctoLogger.Verify(m => m.LogSuccess(It.IsAny<string>()), Times.Once);
+        _mockGithubApi.Verify(m => m.AbortMigration(REPO_MIGRATION_ID), Times.Exactly(1));
+
+        _mockGithubApi.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task With_Migration_ID_That_Fails()
+    {
+        // Arrange
+        _mockGithubApi.Setup(x => x.AbortMigration(It.IsAny<string>())).ReturnsAsync(false);
+
+        // Act
+        var args = new AbortMigrationCommandArgs
+        {
+            MigrationId = REPO_MIGRATION_ID,
+        };
+        await _handler.Handle(args);
+
+        // Assert
+        _mockOctoLogger.Verify(m => m.LogInformation(It.IsAny<string>()), Times.Exactly(7));
+        _mockOctoLogger.Verify(m => m.LogSuccess(It.IsAny<string>()), Times.Once);
+        _mockGithubApi.Verify(m => m.AbortMigration(REPO_MIGRATION_ID), Times.Exactly(1));
+
+        _mockGithubApi.VerifyNoOtherCalls();
+    }
+}
+


### PR DESCRIPTION
What is changing? 


How is it tested? 
- unit tests 
 (Once these generic commands are hooked up to the providers) 

- [x] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [x ] Appropriate logging output
- [x ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

