### PR TITLE
Fix message when `GEI_SKIP_VERSION_CHECK` is turned on

### DIFF
--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -118,7 +118,7 @@ namespace OctoshiftCLI.AdoToGithub
 
             if (envProvider.SkipVersionCheck()?.ToUpperInvariant() is "TRUE" or "1")
             {
-                Logger.LogInformation("Skipped latest version check due to GEI_VERSION_CHECK environment variable");
+                Logger.LogInformation("Skipped latest version check due to GEI_SKIP_VERSION_CHECK environment variable");
                 return;
             }
 

--- a/src/bbs2gh/Program.cs
+++ b/src/bbs2gh/Program.cs
@@ -125,7 +125,7 @@ namespace OctoshiftCLI.BbsToGithub
 
             if (envProvider.SkipVersionCheck()?.ToUpperInvariant() is "TRUE" or "1")
             {
-                Logger.LogInformation("Skipped latest version check due to GEI_VERSION_CHECK environment variable");
+                Logger.LogInformation("Skipped latest version check due to GEI_SKIP_VERSION_CHECK environment variable");
                 return;
             }
 

--- a/src/gei/Program.cs
+++ b/src/gei/Program.cs
@@ -118,7 +118,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter
 
             if (envProvider.SkipVersionCheck()?.ToUpperInvariant() is "TRUE" or "1")
             {
-                Logger.LogInformation("Skipped latest version check due to GEI_VERSION_CHECK environment variable");
+                Logger.LogInformation("Skipped latest version check due to GEI_SKIP_VERSION_CHECK environment variable");
                 return;
             }
 


### PR DESCRIPTION
Whilst testing the new feature introduced in #1077 to skip the "latest version" check, I spotted that the log message we emit when the check is skipped is incorrect. This fixes it.