### PR TITLE
Add ADO `abort-migration` command

### DIFF
--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/AbortMigration/AbortMigrationCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/AbortMigration/AbortMigrationCommandTests.cs
@@ -1,0 +1,20 @@
+using FluentAssertions;
+using OctoshiftCLI.AdoToGithub.Commands.WaitForMigration;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.AdoToGithub.Commands.AbortMigration;
+
+public class AbortMigrationCommandTests
+{
+    [Fact]
+    public void Should_Have_Options()
+    {
+        var command = new AbortMigrationCommand();
+        command.Should().NotBeNull();
+        command.Name.Should().Be("abort-migration");
+        command.Options.Count.Should().Be(1);
+
+        TestHelpers.VerifyCommandOption(command.Options, "migration-id", true);
+        TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
+    }
+}

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/AbortMigration/AbortMigrationCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/AbortMigration/AbortMigrationCommandTests.cs
@@ -12,7 +12,7 @@ public class AbortMigrationCommandTests
         var command = new AbortMigrationCommand();
         command.Should().NotBeNull();
         command.Name.Should().Be("abort-migration");
-        command.Options.Count.Should().Be(1);
+        command.Options.Count.Should().Be(3);
 
         TestHelpers.VerifyCommandOption(command.Options, "migration-id", true);
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/AbortMigration/AbortMigrationCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/AbortMigration/AbortMigrationCommandTests.cs
@@ -16,5 +16,6 @@ public class AbortMigrationCommandTests
 
         TestHelpers.VerifyCommandOption(command.Options, "migration-id", true);
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
+        TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
     }
 }

--- a/src/ado2gh/Commands/AbortMigration/WaitForMigrationCommand.cs
+++ b/src/ado2gh/Commands/AbortMigration/WaitForMigrationCommand.cs
@@ -1,0 +1,8 @@
+using OctoshiftCLI.Commands.AbortMigration;
+
+namespace OctoshiftCLI.AdoToGithub.Commands.WaitForMigration;
+
+public sealed class AbortMigrationCommand : AbortMigrationCommandBase
+{
+    public AbortMigrationCommand() : base() => AddOptions();
+}


### PR DESCRIPTION
Hey all! I've added a feature branch so that we can test these all out in smaller chunks. 

I wanted to get this in first so that I can double back and test out the live [API calls.](https://github.com/github/gh-gei/pull/1181)

I'll be opening up a larger PR at the end with all the commands and error scenarios lined up, but for now test out the happy path! 

Add your creds if you haven't done that already: 
```
export GH_PAT="pat"
export ADO_PAT="pat"
```

Kick off a migration: 
```
dotnet run --project src/ado2gh/ado2gh.csproj -- migrate-repo --ado-org valet-testing --ado-team-project build-playground --ado-repo build-playground --github-org import-testing --github-repo abort-repo-testing
```

ABORT it: 
```
dotnet run --project src/ado2gh/ado2gh.csproj -- abort-migration --migration-id RM_kgDaACQyZjk0YzIxYy02ZWFjLTRmZjItYWM3Ni04ZWFkMTBkOWYxOWY
```

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->