### PR TITLE
Add BBS Abort Migration command

### DIFF
--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/AbortMigration/AbortMigrationCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/AbortMigration/AbortMigrationCommandTests.cs
@@ -1,0 +1,21 @@
+using FluentAssertions;
+using OctoshiftCLI.AdoToGithub.Commands.WaitForMigration;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.BbsToGithub.Commands.AbortMigration;
+
+public class AbortMigrationCommandTests
+{
+    [Fact]
+    public void Should_Have_Options()
+    {
+        var command = new AbortMigrationCommand();
+        command.Should().NotBeNull();
+        command.Name.Should().Be("abort-migration");
+        command.Options.Count.Should().Be(3);
+
+        TestHelpers.VerifyCommandOption(command.Options, "migration-id", true);
+        TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
+        TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+    }
+}

--- a/src/bbs2gh/Commands/AbortMigration/WaitForMigrationCommand.cs
+++ b/src/bbs2gh/Commands/AbortMigration/WaitForMigrationCommand.cs
@@ -1,0 +1,8 @@
+using OctoshiftCLI.Commands.AbortMigration;
+
+namespace OctoshiftCLI.BbsToGithub.Commands.WaitForMigration;
+
+public sealed class AbortMigrationCommand : AbortMigrationCommandBase
+{
+    public AbortMigrationCommand() : base() => AddOptions();
+}


### PR DESCRIPTION
Add your creds if you haven't done that already: 
```
export BBS_USERNAME=bbsadmin
export GH_PAT="pat"
export BBS_PASSWORD=PASSWORD
```

Kick off a migration: 
```
dotnet run --project src/bbs2gh/bbs2gh.csproj -- migrate-repo --bbs-server-url https://test-bbs-o.githubapp.com/ --bbs-project IM --bbs-repo test-commit-id-blank-review
```

ABORT it: 
```
dotnet run --project src/bbs2gh/bbs2gh.csproj -- abort-migration --migration-id RM_kgDaACQyZjk0YzIxYy02ZWFjLTRmZjItYWM3Ni04ZWFkMTBkOWYxOWY
```

Closes: https://github.ghe.com/github/octoshift/issues/7877

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->