### PR TITLE
Document that `bbs2gh inventory-report` doesn't return personal repos

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Update `bbs2gh inventory-report` help text to document that personal repositories owned by users are not supported

--- a/src/bbs2gh/Commands/InventoryReport/InventoryReportCommand.cs
+++ b/src/bbs2gh/Commands/InventoryReport/InventoryReportCommand.cs
@@ -11,7 +11,7 @@ namespace OctoshiftCLI.BbsToGithub.Commands.InventoryReport
     {
         public InventoryReportCommand() : base(
                 name: "inventory-report",
-                description: "Generates several CSV files containing lists of BBS projects and repos. Useful for planning large migrations." +
+                description: "Generates several CSV files containing lists of BBS projects and repos. Useful for planning large migrations. Personal repositories owned by individual users will not be included." +
                              Environment.NewLine +
                              "Note: Expects BBS_USERNAME and BBS_PASSWORD env variables or --bbs-username and --bbs-password options to be set.")
         {


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->