### PR TITLE
Update `ado2gh lock-repo` documentation to clarify required scopes fo…

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 - Update `bbs2gh inventory-report` help text to document that personal repositories owned by users are not supported
+- Update `ado2gh lock-repo` help text to document the scopes required for your Azure DevOps personal access token

--- a/src/ado2gh/Commands/LockRepo/LockRepoCommand.cs
+++ b/src/ado2gh/Commands/LockRepo/LockRepoCommand.cs
@@ -34,7 +34,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands.LockRepo
         {
             IsRequired = true
         };
-        public Option<string> AdoPat { get; } = new("--ado-pat");
+        public Option<string> AdoPat { get; } = new("--ado-pat")
+        {
+            Description = "An Azure DevOps personal access token with the 'Identity -> Read' and 'Security -> Manage' scopes."
+        };
         public Option<bool> Verbose { get; } = new("--verbose");
 
         public override LockRepoCommandHandler BuildHandler(LockRepoCommandArgs args, IServiceProvider sp)


### PR DESCRIPTION
This updates the documentation for the `ado2gh lock-repo` command to document which scopes you need on your personal access token. 

Props to @antgrutta for flagging this gap and figuring out the right scopes 🙌🏻 

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->