### PR TITLE
Add `target-api-url` to reclaim mannequin and grant migrator commands

### DIFF
--- a/src/Octoshift/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandArgs.cs
+++ b/src/Octoshift/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandArgs.cs
@@ -9,4 +9,5 @@ public class GenerateMannequinCsvCommandArgs : CommandArgs
     public bool IncludeReclaimed { get; set; }
     [Secret]
     public string GithubPat { get; set; }
+    public string TargetApiUrl { get; set; }
 }

--- a/src/Octoshift/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandBase.cs
+++ b/src/Octoshift/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandBase.cs
@@ -37,6 +37,10 @@ public class GenerateMannequinCsvCommandBase : CommandBase<GenerateMannequinCsvC
     {
         Description = "Personal access token of the GitHub target. Overrides GH_PAT environment variable."
     };
+    public Option<string> TargetApiUrl { get; } = new("--target-api-url")
+    {
+        Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com"
+    };
 
     public override GenerateMannequinCsvCommandHandler BuildHandler(GenerateMannequinCsvCommandArgs args, IServiceProvider sp)
     {
@@ -52,7 +56,7 @@ public class GenerateMannequinCsvCommandBase : CommandBase<GenerateMannequinCsvC
 
         var log = sp.GetRequiredService<OctoLogger>();
         var githubApiFactory = sp.GetRequiredService<ITargetGithubApiFactory>();
-        var githubApi = githubApiFactory.Create(targetPersonalAccessToken: args.GithubPat);
+        var githubApi = githubApiFactory.Create(args.TargetApiUrl, args.GithubPat);
 
         return new GenerateMannequinCsvCommandHandler(log, githubApi);
     }
@@ -63,6 +67,7 @@ public class GenerateMannequinCsvCommandBase : CommandBase<GenerateMannequinCsvC
         AddOption(Output);
         AddOption(IncludeReclaimed);
         AddOption(GithubPat);
+        AddOption(TargetApiUrl);
         AddOption(Verbose);
     }
 }

--- a/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandArgs.cs
+++ b/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandArgs.cs
@@ -10,6 +10,7 @@ public class GrantMigratorRoleCommandArgs : CommandArgs
     [Secret]
     public string GithubPat { get; set; }
     public string GhesApiUrl { get; set; }
+    public string TargetApiUrl { get; set; }
 
     public override void Validate(OctoLogger log)
     {

--- a/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandArgs.cs
+++ b/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandArgs.cs
@@ -1,4 +1,5 @@
-﻿using OctoshiftCLI.Services;
+﻿using OctoshiftCLI.Extensions;
+using OctoshiftCLI.Services;
 
 namespace OctoshiftCLI.Commands.GrantMigratorRole;
 

--- a/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandArgs.cs
+++ b/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandArgs.cs
@@ -25,7 +25,7 @@ public class GrantMigratorRoleCommandArgs : CommandArgs
             throw new OctoshiftCliException("Actor type must be either TEAM or USER.");
         }
 
-        if (!string.IsNullOrEmpty(GhesApiUrl) && !string.IsNullOrEmpty(TargetApiUrl))
+        if (GhesApiUrl.HasValue() && TargetApiUrl.HasValue())
         {
             throw new OctoshiftCliException("Only one of --ghes-api-url or --target-api-url can be set at a time.");
         }

--- a/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandArgs.cs
+++ b/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandArgs.cs
@@ -24,5 +24,10 @@ public class GrantMigratorRoleCommandArgs : CommandArgs
         {
             throw new OctoshiftCliException("Actor type must be either TEAM or USER.");
         }
+
+        if (!string.IsNullOrEmpty(GhesApiUrl) && !string.IsNullOrEmpty(TargetApiUrl))
+        {
+            throw new OctoshiftCliException("Only one of --ghes-api-url or --target-api-url can be set at a time.");
+        }
     }
 }

--- a/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBase.cs
@@ -53,7 +53,7 @@ public class GrantMigratorRoleCommandBase : CommandBase<GrantMigratorRoleCommand
         var log = sp.GetRequiredService<OctoLogger>();
         var githubApiFactory = sp.GetRequiredService<ITargetGithubApiFactory>();
         var apiUrl = args.TargetApiUrl ?? args.GhesApiUrl;
-        var githubApi = githubApiFactory.Create(api_url, args.GithubPat);
+        var githubApi = githubApiFactory.Create(apiUrl, args.GithubPat);
 
         return new GrantMigratorRoleCommandHandler(log, githubApi);
     }

--- a/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBase.cs
@@ -25,10 +25,15 @@ public class GrantMigratorRoleCommandBase : CommandBase<GrantMigratorRoleCommand
         Description = "Personal access token of the GitHub target. Overrides GH_PAT environment variable."
     };
 
-    public virtual Option<string> GhesApiUrl { get; } = new("--ghes-api-url") { IsRequired = false };
+    public virtual Option<string> GhesApiUrl { get; } = new("--ghes-api-url")
+    {
+        IsRequired = false,
+        Description = "The URL of the GitHub Enterprise Server instance, if migrating from GHES. Supports granting access for exports. Can only configure one of --ghes-api-url or --target-api-url at a time."
+    };
     public Option<string> TargetApiUrl { get; } = new("--target-api-url")
     {
-        Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com"
+        IsRequired = false,
+        Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com. Can only configure one of --ghes-api-url or --target-api-url at a time."
     };
 
     public virtual Option<bool> Verbose { get; } = new("--verbose") { IsRequired = false };

--- a/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBase.cs
@@ -52,7 +52,7 @@ public class GrantMigratorRoleCommandBase : CommandBase<GrantMigratorRoleCommand
 
         var log = sp.GetRequiredService<OctoLogger>();
         var githubApiFactory = sp.GetRequiredService<ITargetGithubApiFactory>();
-        var api_url = args.TargetApiUrl ?? args.GhesApiUrl;
+        var apiUrl = args.TargetApiUrl ?? args.GhesApiUrl;
         var githubApi = githubApiFactory.Create(api_url, args.GithubPat);
 
         return new GrantMigratorRoleCommandHandler(log, githubApi);

--- a/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBase.cs
@@ -26,6 +26,10 @@ public class GrantMigratorRoleCommandBase : CommandBase<GrantMigratorRoleCommand
     };
 
     public virtual Option<string> GhesApiUrl { get; } = new("--ghes-api-url") { IsRequired = false };
+    public Option<string> TargetApiUrl { get; } = new("--target-api-url")
+    {
+        Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com"
+    };
 
     public virtual Option<bool> Verbose { get; } = new("--verbose") { IsRequired = false };
 
@@ -43,7 +47,8 @@ public class GrantMigratorRoleCommandBase : CommandBase<GrantMigratorRoleCommand
 
         var log = sp.GetRequiredService<OctoLogger>();
         var githubApiFactory = sp.GetRequiredService<ITargetGithubApiFactory>();
-        var githubApi = githubApiFactory.Create(args.GhesApiUrl, args.GithubPat);
+        var api_url = args.TargetApiUrl ?? args.GhesApiUrl;
+        var githubApi = githubApiFactory.Create(api_url, args.GithubPat);
 
         return new GrantMigratorRoleCommandHandler(log, githubApi);
     }
@@ -56,5 +61,6 @@ public class GrantMigratorRoleCommandBase : CommandBase<GrantMigratorRoleCommand
         AddOption(GithubPat);
         AddOption(Verbose);
         AddOption(GhesApiUrl);
+        AddOption(TargetApiUrl);
     }
 }

--- a/src/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandArgs.cs
+++ b/src/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandArgs.cs
@@ -15,7 +15,6 @@ public class ReclaimMannequinCommandArgs : CommandArgs
     public string GithubPat { get; set; }
     public bool SkipInvitation { get; set; }
     public string TargetApiUrl { get; set; }
-    
     public override void Validate(OctoLogger log)
     {
         if (string.IsNullOrEmpty(Csv) && (string.IsNullOrEmpty(MannequinUser) || string.IsNullOrEmpty(TargetUser)))

--- a/src/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandArgs.cs
+++ b/src/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandArgs.cs
@@ -14,7 +14,8 @@ public class ReclaimMannequinCommandArgs : CommandArgs
     [Secret]
     public string GithubPat { get; set; }
     public bool SkipInvitation { get; set; }
-
+    public string TargetApiUrl { get; set; }
+    
     public override void Validate(OctoLogger log)
     {
         if (string.IsNullOrEmpty(Csv) && (string.IsNullOrEmpty(MannequinUser) || string.IsNullOrEmpty(TargetUser)))

--- a/src/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandBase.cs
+++ b/src/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandBase.cs
@@ -67,6 +67,11 @@ public class ReclaimMannequinCommandBase : CommandBase<ReclaimMannequinCommandAr
         Description = "Reclaim mannequins immediately without sending an invitation to the user. Only available for Enterprise Managed Users (EMU) organizations. Warning: this is irreversible!"
     };
 
+    public Option<string> TargetApiUrl { get; } = new("--target-api-url")
+    {
+        Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com"
+    };
+
     public virtual Option<bool> Verbose { get; } = new("--verbose");
 
     public override ReclaimMannequinCommandHandler BuildHandler(ReclaimMannequinCommandArgs args, IServiceProvider sp)
@@ -83,7 +88,7 @@ public class ReclaimMannequinCommandBase : CommandBase<ReclaimMannequinCommandAr
 
         var log = sp.GetRequiredService<OctoLogger>();
         var githubApiFactory = sp.GetRequiredService<ITargetGithubApiFactory>();
-        var githubApi = githubApiFactory.Create(targetPersonalAccessToken: args.GithubPat);
+        var githubApi = githubApiFactory.Create(args.TargetApiUrl, args.GithubPat);
         var reclaimService = new ReclaimService(githubApi, log);
         var confirmationService = sp.GetRequiredService<ConfirmationService>();
 
@@ -101,6 +106,7 @@ public class ReclaimMannequinCommandBase : CommandBase<ReclaimMannequinCommandAr
         AddOption(NoPrompt);
         AddOption(GithubPat);
         AddOption(SkipInvitation);
+        AddOption(TargetApiUrl);
         AddOption(Verbose);
     }
 }

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandBaseTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandBaseTests.cs
@@ -12,8 +12,7 @@ public class GenerateMannequinCsvCommandBaseTests
     private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
     private readonly Mock<ITargetGithubApiFactory> _mockGithubApiFactory = new();
     private readonly ServiceProvider _serviceProvider;
-    private readonly GenerateMannequinCsvCommandBase _command;
-
+    private readonly GenerateMannequinCsvCommandBase _command = new();
     private const string GITHUB_ORG = "FooOrg";
 
     public GenerateMannequinCsvCommandBaseTests()

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandBaseTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandBaseTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using OctoshiftCLI.Commands.GenerateMannequinCsv;
+using OctoshiftCLI.Contracts;
+using OctoshiftCLI.Services;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.Octoshift.Commands.GeneerateMannequinCsv;
+
+public class GenerateMannequinCsvCommandBaseTests
+{
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+    private readonly Mock<ITargetGithubApiFactory> _mockGithubApiFactory = new();
+    private readonly ServiceProvider _serviceProvider;
+    private readonly GenerateMannequinCsvCommandBase _command;
+
+    private const string GITHUB_ORG = "FooOrg";
+
+    public GenerateMannequinCsvCommandBaseTests()
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection
+            .AddSingleton(_mockOctoLogger.Object)
+            .AddSingleton(_mockGithubApiFactory.Object);
+
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void It_Uses_The_TargetApiUrl_When_Provided()
+    {
+        var targetApiUrl = "TARGET-API-URL";
+
+        var args = new GenerateMannequinCsvCommandArgs
+        {
+            GithubOrg = GITHUB_ORG,
+            IncludeReclaimed = false,
+            TargetApiUrl = targetApiUrl,
+        };
+
+        _command.BuildHandler(args, _serviceProvider);
+
+        _mockGithubApiFactory.Verify(m => m.Create(targetApiUrl, null));
+    }
+}

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandArgsTests.cs
@@ -26,4 +26,20 @@ public class GrantMigratorRoleCommandArgsTests
         FluentActions.Invoking(() => args.Validate(_mockOctoLogger.Object))
             .Should().Throw<OctoshiftCliException>();
     }
+
+    [Fact]
+    public void It_Validates_GhesApiUrl_And_TargetApiUrl()
+    {
+        var args = new GrantMigratorRoleCommandArgs
+        {
+            GithubOrg = GITHUB_ORG,
+            Actor = ACTOR,
+            ActorType = "USER",
+            GhesApiUrl = "https://ghes.example.com",
+            TargetApiUrl = "https://api.github.com",
+        };
+
+        FluentActions.Invoking(() => args.Validate(_mockOctoLogger.Object))
+            .Should().Throw<OctoshiftCliException>();
+    }
 }

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBaseTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBaseTests.cs
@@ -62,7 +62,7 @@ public class GrantMigratorRoleCommandBaseTests
         _mockGithubApiFactory.Verify(m => m.Create(ghesApiUrl, null));
     }
 
-        [Fact]
+    [Fact]
     public void It_Uses_The_TargetApiUrl_When_Provided()
     {
         var ghesApiUrl = "GHES-API-URL";

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBaseTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBaseTests.cs
@@ -61,4 +61,23 @@ public class GrantMigratorRoleCommandBaseTests
 
         _mockGithubApiFactory.Verify(m => m.Create(ghesApiUrl, null));
     }
+
+        [Fact]
+    public void It_Uses_The_TargetApiUrl_When_Provided()
+    {
+        var ghesApiUrl = "GHES-API-URL";
+        var targetApiUrl = "TARGET-API-URL";
+
+        var args = new GrantMigratorRoleCommandArgs
+        {
+            GithubOrg = "foo",
+            Actor = "blah",
+            ActorType = "TEAM",
+            TargetApiUrl = targetApiUrl,
+        };
+
+        _command.BuildHandler(args, _serviceProvider);
+
+        _mockGithubApiFactory.Verify(m => m.Create(targetApiUrl, null));
+    }
 }

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBaseTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBaseTests.cs
@@ -65,7 +65,6 @@ public class GrantMigratorRoleCommandBaseTests
     [Fact]
     public void It_Uses_The_TargetApiUrl_When_Provided()
     {
-        var ghesApiUrl = "GHES-API-URL";
         var targetApiUrl = "TARGET-API-URL";
 
         var args = new GrantMigratorRoleCommandArgs

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandBaseTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandBaseTests.cs
@@ -12,7 +12,7 @@ public class ReclaimMannequinCommandBaseTests
     private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
     private readonly Mock<ITargetGithubApiFactory> _mockGithubApiFactory = new();
     private readonly ServiceProvider _serviceProvider;
-    private readonly ReclaimMannequinCommandBase _command;
+    private readonly ReclaimMannequinCommandBase _command = new();
 
     private const string GITHUB_ORG = "FooOrg";
 

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandBaseTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandBaseTests.cs
@@ -10,6 +10,7 @@ namespace OctoshiftCLI.Tests.Octoshift.Commands.ReclaimMannequin;
 public class ReclaimMannequinCommandBaseTests
 {
     private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+    private readonly Mock<ConfirmationService> _mockConfirmationService = TestHelpers.CreateMock<ConfirmationService>();
     private readonly Mock<ITargetGithubApiFactory> _mockGithubApiFactory = new();
     private readonly ServiceProvider _serviceProvider;
     private readonly ReclaimMannequinCommandBase _command = new();
@@ -21,7 +22,8 @@ public class ReclaimMannequinCommandBaseTests
         var serviceCollection = new ServiceCollection();
         serviceCollection
             .AddSingleton(_mockOctoLogger.Object)
-            .AddSingleton(_mockGithubApiFactory.Object);
+            .AddSingleton(_mockGithubApiFactory.Object)
+            .AddSingleton(_mockConfirmationService.Object);
 
         _serviceProvider = serviceCollection.BuildServiceProvider();
     }

--- a/src/OctoshiftCLI.Tests/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandBaseTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandBaseTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using OctoshiftCLI.Commands.ReclaimMannequin;
+using OctoshiftCLI.Contracts;
+using OctoshiftCLI.Services;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.Octoshift.Commands.ReclaimMannequin;
+
+public class ReclaimMannequinCommandBaseTests
+{
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+    private readonly Mock<ITargetGithubApiFactory> _mockGithubApiFactory = new();
+    private readonly ServiceProvider _serviceProvider;
+    private readonly ReclaimMannequinCommandBase _command;
+
+    private const string GITHUB_ORG = "FooOrg";
+
+    public ReclaimMannequinCommandBaseTests()
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection
+            .AddSingleton(_mockOctoLogger.Object)
+            .AddSingleton(_mockGithubApiFactory.Object);
+
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void It_Uses_The_TargetApiUrl_When_Provided()
+    {
+        var targetApiUrl = "TARGET-API-URL";
+
+        var args = new ReclaimMannequinCommandArgs
+        {
+            GithubOrg = GITHUB_ORG,
+            Csv = "file.csv",
+            TargetApiUrl = targetApiUrl,
+        };
+
+        _command.BuildHandler(args, _serviceProvider);
+
+        _mockGithubApiFactory.Verify(m => m.Create(targetApiUrl, null));
+    }
+}

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandTests.cs
@@ -11,12 +11,13 @@ public class GenerateMannequinCsvCommandTests
         var command = new GenerateMannequinCsvCommand();
         Assert.NotNull(command);
         Assert.Equal("generate-mannequin-csv", command.Name);
-        Assert.Equal(5, command.Options.Count);
+        Assert.Equal(6, command.Options.Count);
 
         TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "output", false);
         TestHelpers.VerifyCommandOption(command.Options, "include-reclaimed", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
         TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+        TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRole/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GrantMigratorRole/GrantMigratorRoleCommandTests.cs
@@ -11,7 +11,7 @@ public class GrantMigratorRoleCommandTests
         var command = new GrantMigratorRoleCommand();
         Assert.NotNull(command);
         Assert.Equal("grant-migrator-role", command.Name);
-        Assert.Equal(6, command.Options.Count);
+        Assert.Equal(7, command.Options.Count);
 
         TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "actor", true);
@@ -19,5 +19,6 @@ public class GrantMigratorRoleCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
         TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         TestHelpers.VerifyCommandOption(command.Options, "ghes-api-url", false);
+        TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/ReclaimMannequin/ReclaimMannequinCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/ReclaimMannequin/ReclaimMannequinCommandTests.cs
@@ -11,7 +11,7 @@ public class ReclaimMannequinCommandTests
         var command = new ReclaimMannequinCommand();
         Assert.NotNull(command);
         Assert.Equal("reclaim-mannequin", command.Name);
-        Assert.Equal(10, command.Options.Count);
+        Assert.Equal(11, command.Options.Count);
 
         TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "csv", false);
@@ -22,6 +22,7 @@ public class ReclaimMannequinCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "no-prompt", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
         TestHelpers.VerifyCommandOption(command.Options, "skip-invitation", false);
+        TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
         TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandTests.cs
@@ -11,12 +11,13 @@ public class GenerateMannequinCsvCommandTests
         var command = new GenerateMannequinCsvCommand();
         Assert.NotNull(command);
         Assert.Equal("generate-mannequin-csv", command.Name);
-        Assert.Equal(5, command.Options.Count);
+        Assert.Equal(6, command.Options.Count);
 
         TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "output", false);
         TestHelpers.VerifyCommandOption(command.Options, "include-reclaimed", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
         TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+        TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GrantMigratorRole/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GrantMigratorRole/GrantMigratorRoleCommandTests.cs
@@ -11,7 +11,7 @@ public class GrantMigratorRoleCommandTests
         var command = new GrantMigratorRoleCommand();
         Assert.NotNull(command);
         Assert.Equal("grant-migrator-role", command.Name);
-        Assert.Equal(6, command.Options.Count);
+        Assert.Equal(7, command.Options.Count);
 
         TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "actor", true);
@@ -19,5 +19,6 @@ public class GrantMigratorRoleCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
         TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         TestHelpers.VerifyCommandOption(command.Options, "ghes-api-url", false);
+        TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/ReclaimMannequin/ReclaimMannequinCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/ReclaimMannequin/ReclaimMannequinCommandTests.cs
@@ -11,7 +11,7 @@ public class ReclaimMannequinCommandTests
         var command = new ReclaimMannequinCommand();
         Assert.NotNull(command);
         Assert.Equal("reclaim-mannequin", command.Name);
-        Assert.Equal(10, command.Options.Count);
+        Assert.Equal(11, command.Options.Count);
 
         TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "csv", false);
@@ -22,6 +22,7 @@ public class ReclaimMannequinCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "no-prompt", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-pat", false);
         TestHelpers.VerifyCommandOption(command.Options, "skip-invitation", false);
+        TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
         TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandTests.cs
@@ -11,12 +11,13 @@ public class GenerateMannequinCsvCommandTests
         var command = new GenerateMannequinCsvCommand();
         Assert.NotNull(command);
         Assert.Equal("generate-mannequin-csv", command.Name);
-        Assert.Equal(5, command.Options.Count);
+        Assert.Equal(6, command.Options.Count);
 
         TestHelpers.VerifyCommandOption(command.Options, "github-target-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "output", false);
         TestHelpers.VerifyCommandOption(command.Options, "include-reclaimed", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
         TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+        TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRole/GrantMigratorRoleCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GrantMigratorRole/GrantMigratorRoleCommandTests.cs
@@ -11,7 +11,7 @@ public class GrantMigratorRoleCommandTests
         var command = new GrantMigratorRoleCommand();
         Assert.NotNull(command);
         Assert.Equal("grant-migrator-role", command.Name);
-        Assert.Equal(6, command.Options.Count);
+        Assert.Equal(7, command.Options.Count);
 
         TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "actor", true);
@@ -19,5 +19,6 @@ public class GrantMigratorRoleCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
         TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
         TestHelpers.VerifyCommandOption(command.Options, "ghes-api-url", false);
+        TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/ReclaimMannequin/ReclaimMannequinCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/ReclaimMannequin/ReclaimMannequinCommandTests.cs
@@ -11,7 +11,7 @@ public class ReclaimMannequinCommandTests
         var command = new ReclaimMannequinCommand();
         Assert.NotNull(command);
         Assert.Equal("reclaim-mannequin", command.Name);
-        Assert.Equal(10, command.Options.Count);
+        Assert.Equal(11, command.Options.Count);
 
         TestHelpers.VerifyCommandOption(command.Options, "github-target-org", true);
         TestHelpers.VerifyCommandOption(command.Options, "csv", false);
@@ -22,6 +22,7 @@ public class ReclaimMannequinCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "no-prompt", false);
         TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
         TestHelpers.VerifyCommandOption(command.Options, "skip-invitation", false);
+        TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
         TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
     }
 }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->
Part of https://github.com/github/gh-gei/issues/1094 and https://github.ghe.com/github/octoshift/issues/7956

Follow-up to https://github.com/github/gh-gei/pull/1214 adding support for reclaim mannequin related commands and grant migrator role command.

testing notes: https://github.ghe.com/github/octoshift/issues/7956#issuecomment-8112611

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->