### PR TITLE
Fix #1220 - Unable to rewire pipeline when ADO Team Project has many BuildDefinitions (+10000)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 - Add `--target-api-url` to `gh ado2gh migrate-repo`, `gh bbs2gh migrate-repo`, and `gh gei migrate-org` to support newer GitHub migration paths.
+- Fixed `gh ado2gh rewire-pipeline` command for ADO Team Projects with more than 10,000 Build Definitions.

--- a/src/Octoshift/Services/AdoApi.cs
+++ b/src/Octoshift/Services/AdoApi.cs
@@ -423,7 +423,7 @@ public class AdoApi
             return result;
         }
 
-        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/build/definitions";
+        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/build/definitions?queryOrder=definitionNameAscending";
         var response = await _client.GetWithPagingAsync(url);
 
         foreach (var item in response)

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/AdoApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/AdoApiTests.cs
@@ -702,7 +702,7 @@ public class AdoApiTests
         var pipeline = "foo-pipe";
         var pipelineId = 36383;
 
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions?queryOrder=definitionNameAscending";
         var response = new object[]
         {
             new
@@ -732,7 +732,7 @@ public class AdoApiTests
         var pipeline = "\\some-folder\\another\\foo-pipe";
         var pipelineId = 36383;
 
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions?queryOrder=definitionNameAscending";
         var response = new object[]
         {
             new
@@ -762,7 +762,7 @@ public class AdoApiTests
         var pipeline = "foo-pipe";
         var pipelineId = 36383;
 
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions?queryOrder=definitionNameAscending";
         var response = new object[]
         {
             new
@@ -792,7 +792,7 @@ public class AdoApiTests
         var pipeline = "foo-pipe";
         var pipelineId = 36383;
 
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions?queryOrder=definitionNameAscending";
         var response = new object[]
         {
             new
@@ -823,7 +823,7 @@ public class AdoApiTests
         var pipeline = "\\some-folder\\foo-pipe";
         var pipelineId = 36383;
 
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions?queryOrder=definitionNameAscending";
         var response = new object[]
         {
             new


### PR DESCRIPTION
- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)

Added `queryOrder` parameter to paginated requests works as expected. Fix #1220.