### PR TITLE
Implement `target-api-url` for `generate-script` commands

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,2 @@
-- Add `--target-api-url` to `gh ado2gh migrate-repo`, `gh bbs2gh migrate-repo`, and `gh gei migrate-org` to support newer GitHub migration paths.
+- Add `--target-api-url` to commonly used commands to support newer GitHub migration paths.
 - Fixed `gh ado2gh rewire-pipeline` command for ADO Team Projects with more than 10,000 Build Definitions.

--- a/src/Octoshift/Commands/CreateTeam/CreateTeamCommandBase.cs
+++ b/src/Octoshift/Commands/CreateTeam/CreateTeamCommandBase.cs
@@ -22,7 +22,7 @@ public class CreateTeamCommandBase : CommandBase<CreateTeamCommandArgs, CreateTe
     {
         Description = "Personal access token of the GitHub target. Overrides GH_PAT environment variable."
     };
-    public Option<string> TargetApiUrl { get; } = new("--target-api-url")
+    public virtual Option<string> TargetApiUrl { get; } = new("--target-api-url")
     {
         Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com"
     };

--- a/src/Octoshift/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandBase.cs
+++ b/src/Octoshift/Commands/GenerateMannequinCsv/GenerateMannequinCsvCommandBase.cs
@@ -37,7 +37,7 @@ public class GenerateMannequinCsvCommandBase : CommandBase<GenerateMannequinCsvC
     {
         Description = "Personal access token of the GitHub target. Overrides GH_PAT environment variable."
     };
-    public Option<string> TargetApiUrl { get; } = new("--target-api-url")
+    public virtual Option<string> TargetApiUrl { get; } = new("--target-api-url")
     {
         Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com"
     };

--- a/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBase.cs
@@ -30,7 +30,7 @@ public class GrantMigratorRoleCommandBase : CommandBase<GrantMigratorRoleCommand
         IsRequired = false,
         Description = "The URL of the GitHub Enterprise Server instance, if migrating from GHES. Supports granting access for exports. Can only configure one of --ghes-api-url or --target-api-url at a time."
     };
-    public Option<string> TargetApiUrl { get; } = new("--target-api-url")
+    public virtual Option<string> TargetApiUrl { get; } = new("--target-api-url")
     {
         IsRequired = false,
         Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com. Can only configure one of --ghes-api-url or --target-api-url at a time."

--- a/src/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandBase.cs
+++ b/src/Octoshift/Commands/ReclaimMannequin/ReclaimMannequinCommandBase.cs
@@ -67,7 +67,7 @@ public class ReclaimMannequinCommandBase : CommandBase<ReclaimMannequinCommandAr
         Description = "Reclaim mannequins immediately without sending an invitation to the user. Only available for Enterprise Managed Users (EMU) organizations. Warning: this is irreversible!"
     };
 
-    public Option<string> TargetApiUrl { get; } = new("--target-api-url")
+    public virtual Option<string> TargetApiUrl { get; } = new("--target-api-url")
     {
         Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com"
     };

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
@@ -103,6 +103,34 @@ public class GenerateScriptCommandHandlerTests
     }
 
     [Fact]
+    public async Task SequentialScript_Single_Repo_With_TargetApiUrl()
+    {
+        // Arrange
+        _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+        _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+        _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+        _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+        var targetApiUrl = "https://foo.com/api/v3";
+
+        // Act
+        var args = new GenerateScriptCommandArgs
+        {
+            GithubOrg = GITHUB_ORG,
+            AdoOrg = ADO_ORG,
+            Sequential = true,
+            Output = new FileInfo("unit-test-output"),
+            TargetApiUrl = targetApiUrl
+        };
+        await _handler.Handle(args);
+
+        _scriptOutput = TrimNonExecutableLines(_scriptOutput);
+        var expected = $"Exec {{ gh ado2gh migrate-repo --target-api-url \"{targetApiUrl}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-repo \"{FOO_REPO}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --target-repo-visibility private }}";
+
+        // Assert
+        _scriptOutput.Should().Be(expected);
+    }
+
+    [Fact]
     public async Task SequentialScript_Single_Repo_AdoServer()
     {
         // Arrange

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScript/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScript/GenerateScriptCommandTests.cs
@@ -38,7 +38,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands.GenerateScript
             var command = new GenerateScriptCommand();
             command.Should().NotBeNull();
             command.Name.Should().Be("generate-script");
-            command.Options.Count.Should().Be(17);
+            command.Options.Count.Should().Be(18);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "ado-org", false);
@@ -57,6 +57,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands.GenerateScript
             TestHelpers.VerifyCommandOption(command.Options, "rewire-pipelines", false);
             TestHelpers.VerifyCommandOption(command.Options, "all", false);
             TestHelpers.VerifyCommandOption(command.Options, "repo-list", false);
+            TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
@@ -517,7 +517,7 @@ if (-not $env:SMB_PASSWORD) {
         _mockFileSystemProvider.Verify(m => m.WriteAllTextAsync(It.IsAny<string>(), It.Is<string>(script => script.Contains(migrateRepoCommand))));
     }
 
-[Fact]
+    [Fact]
     public async Task One_Repo_With_Smb_And_TargetApiUrl()
     {
         // Arrange

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScript/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScript/GenerateScriptCommandTests.cs
@@ -36,7 +36,7 @@ public class GenerateScriptCommandTests
     {
         _command.Should().NotBeNull();
         _command.Name.Should().Be("generate-script");
-        _command.Options.Count.Should().Be(19);
+        _command.Options.Count.Should().Be(20);
 
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-server-url", true);
         TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
@@ -57,6 +57,7 @@ public class GenerateScriptCommandTests
         TestHelpers.VerifyCommandOption(_command.Options, "aws-region", false);
         TestHelpers.VerifyCommandOption(_command.Options, "keep-archive", false);
         TestHelpers.VerifyCommandOption(_command.Options, "no-ssl-verify", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "target-api-url", false);
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
@@ -154,6 +154,33 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.GenerateScript
         }
 
         [Fact]
+        public async Task Sequential_Github_Single_Repo_With_TargetApiUrl()
+        {
+            // Arrange
+            _mockGithubApi
+                .Setup(m => m.GetRepos(SOURCE_ORG))
+                .ReturnsAsync(new[] { (REPO, "private") });
+            var targetApiUrl = "https://foo.com/api/v3";
+            var expected = $"Exec {{ gh gei migrate-repo --target-api-url \"{targetApiUrl}\" --github-source-org \"{SOURCE_ORG}\" --source-repo \"{REPO}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{REPO}\" --target-repo-visibility private }}";
+
+            // Act
+            var args = new GenerateScriptCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                GithubTargetOrg = TARGET_ORG,
+                Output = new FileInfo("unit-test-output"),
+                Sequential = true,
+                TargetApiUrl = targetApiUrl
+            };
+            await _handler.Handle(args);
+
+            _script = TrimNonExecutableLines(_script);
+
+            // Assert
+            _script.Should().Be(expected);
+        }
+
+        [Fact]
         public async Task Sequential_Github_Multiple_Repos()
         {
             // Arrange

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandTests.cs
@@ -39,7 +39,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.GenerateScript
             var command = new GenerateScriptCommand();
             command.Should().NotBeNull();
             command.Name.Should().Be("generate-script");
-            command.Options.Count.Should().Be(14);
+            command.Options.Count.Should().Be(15);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-source-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "github-target-org", true);
@@ -55,6 +55,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.GenerateScript
             TestHelpers.VerifyCommandOption(command.Options, "aws-bucket-name", false);
             TestHelpers.VerifyCommandOption(command.Options, "aws-region", false);
             TestHelpers.VerifyCommandOption(command.Options, "keep-archive", false);
+            TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
         }
 
         [Fact]

--- a/src/ado2gh/Commands/GenerateScript/GenerateScriptCommand.cs
+++ b/src/ado2gh/Commands/GenerateScript/GenerateScriptCommand.cs
@@ -18,6 +18,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands.GenerateScript
                          "Note: Expects ADO_PAT env variable or --ado-pat option to be set.")
         {
             AddOption(GithubOrg);
+            AddOption(TargetApiUrl);
             AddOption(AdoOrg);
             AddOption(AdoTeamProject);
             AddOption(AdoServerUrl);
@@ -90,6 +91,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands.GenerateScript
         public Option<FileInfo> RepoList { get; } = new("--repo-list")
         {
             Description = "Path to a csv file that contains a list of repos to generate a script for. The CSV file should be generated using the inventory-report command."
+        };
+        public Option<string> TargetApiUrl { get; } = new("--target-api-url")
+        {
+            Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com"
         };
 
         public override GenerateScriptCommandHandler BuildHandler(GenerateScriptCommandArgs args, IServiceProvider sp)

--- a/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandArgs.cs
+++ b/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandArgs.cs
@@ -22,5 +22,6 @@ namespace OctoshiftCLI.AdoToGithub.Commands.GenerateScript
         public bool RewirePipelines { get; set; }
         public bool All { get; set; }
         public FileInfo RepoList { get; set; }
+        public string TargetApiUrl { get; set; }
     }
 }

--- a/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -358,7 +358,7 @@ if ($Failed -ne 0) {
             : null;
 
     private string MigrateRepoScript(string adoOrg, string adoTeamProject, string adoRepo, string githubOrg, string githubRepo, bool wait, string adoServerUrl, string targetApiUrl) =>
-        $"gh ado2gh migrate-repo{(!string.IsNullOrEmpty(targetApiUrl) ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{adoRepo}\" --github-org \"{githubOrg}\" --github-repo \"{githubRepo}\"{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? string.Empty : " --queue-only")} --target-repo-visibility private{(adoServerUrl.IsNullOrWhiteSpace() ? string.Empty : $" --ado-server-url \"{adoServerUrl}\"")}";
+        $"gh ado2gh migrate-repo{(targetApiUrl.HasValue() ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{adoRepo}\" --github-org \"{githubOrg}\" --github-repo \"{githubRepo}\"{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? string.Empty : " --queue-only")} --target-repo-visibility private{(adoServerUrl.IsNullOrWhiteSpace() ? string.Empty : $" --ado-server-url \"{adoServerUrl}\"")}";
 
     private string QueueMigrateRepoScript(string adoOrg, string adoTeamProject, string adoRepo, string githubOrg, string githubRepo, string adoServerUrl, string targetApiUrl) =>
         $"$MigrationID = {ExecAndGetMigrationId(MigrateRepoScript(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, false, adoServerUrl, targetApiUrl))}";

--- a/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -365,7 +365,7 @@ if ($Failed -ne 0) {
 
     private string CreateGithubMaintainersTeamScript(string adoTeamProject, string githubOrg, bool linkIdpGroups, string targetApiUrl) =>
         _generateScriptOptions.CreateTeams
-            ? $"gh ado2gh create-team{(!string.IsNullOrEmpty(targetApiUrl) ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --github-org \"{githubOrg}\" --team-name \"{adoTeamProject.ReplaceInvalidCharactersWithDash()}-Maintainers\"{(_log.Verbose ? " --verbose" : string.Empty)}{(linkIdpGroups ? $" --idp-group \"{adoTeamProject.ReplaceInvalidCharactersWithDash()}-Maintainers\"" : string.Empty)}"
+            ? $"gh ado2gh create-team{(targetApiUrl.HasValue() ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --github-org \"{githubOrg}\" --team-name \"{adoTeamProject.ReplaceInvalidCharactersWithDash()}-Maintainers\"{(_log.Verbose ? " --verbose" : string.Empty)}{(linkIdpGroups ? $" --idp-group \"{adoTeamProject.ReplaceInvalidCharactersWithDash()}-Maintainers\"" : string.Empty)}"
             : null;
 
     private string CreateGithubAdminsTeamScript(string adoTeamProject, string githubOrg, bool linkIdpGroups, string targetApiUrl) =>

--- a/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -358,7 +358,7 @@ if ($Failed -ne 0) {
             : null;
 
     private string MigrateRepoScript(string adoOrg, string adoTeamProject, string adoRepo, string githubOrg, string githubRepo, bool wait, string adoServerUrl, string targetApiUrl) =>
-        $"gh ado2gh migrate-repo{(targetApiUrl.HasValue() ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{adoRepo}\" --github-org \"{githubOrg}\" --github-repo \"{githubRepo}\"{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? string.Empty : " --queue-only")} --target-repo-visibility private{(adoServerUrl.IsNullOrWhiteSpace() ? string.Empty : $" --ado-server-url \"{adoServerUrl}\"")}";
+        $"gh ado2gh migrate-repo{(targetApiUrl.HasValue() ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-repo \"{adoRepo}\" --github-org \"{githubOrg}\" --github-repo \"{githubRepo}\"{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? string.Empty : " --queue-only")} --target-repo-visibility private{(adoServerUrl.HasValue() ? $" --ado-server-url \"{adoServerUrl}\"" : string.Empty)}";
 
     private string QueueMigrateRepoScript(string adoOrg, string adoTeamProject, string adoRepo, string githubOrg, string githubRepo, string adoServerUrl, string targetApiUrl) =>
         $"$MigrationID = {ExecAndGetMigrationId(MigrateRepoScript(adoOrg, adoTeamProject, adoRepo, githubOrg, githubRepo, false, adoServerUrl, targetApiUrl))}";

--- a/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -370,7 +370,7 @@ if ($Failed -ne 0) {
 
     private string CreateGithubAdminsTeamScript(string adoTeamProject, string githubOrg, bool linkIdpGroups, string targetApiUrl) =>
         _generateScriptOptions.CreateTeams
-            ? $"gh ado2gh create-team{(!string.IsNullOrEmpty(targetApiUrl) ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --github-org \"{githubOrg}\" --team-name \"{adoTeamProject.ReplaceInvalidCharactersWithDash()}-Admins\"{(_log.Verbose ? " --verbose" : string.Empty)}{(linkIdpGroups ? $" --idp-group \"{adoTeamProject.ReplaceInvalidCharactersWithDash()}-Admins\"" : string.Empty)}"
+            ? $"gh ado2gh create-team{(targetApiUrl.HasValue() ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --github-org \"{githubOrg}\" --team-name \"{adoTeamProject.ReplaceInvalidCharactersWithDash()}-Admins\"{(_log.Verbose ? " --verbose" : string.Empty)}{(linkIdpGroups ? $" --idp-group \"{adoTeamProject.ReplaceInvalidCharactersWithDash()}-Admins\"" : string.Empty)}"
             : null;
 
     private string AddMaintainersToGithubRepoScript(string adoTeamProject, string githubOrg, string githubRepo) =>

--- a/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -397,7 +397,7 @@ if ($Failed -ne 0) {
 
     private string DownloadMigrationLogScript(string githubOrg, string githubRepo, string targetApiUrl) =>
         _generateScriptOptions.DownloadMigrationLogs
-        ? $"gh ado2gh download-logs{(!string.IsNullOrEmpty(targetApiUrl) ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --github-org \"{githubOrg}\" --github-repo \"{githubRepo}\""
+        ? $"gh ado2gh download-logs{(targetApiUrl.HasValue() ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --github-org \"{githubOrg}\" --github-repo \"{githubRepo}\""
         : null;
 
     private string Exec(string script) => Wrap(script, "Exec");

--- a/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -393,7 +393,7 @@ if ($Failed -ne 0) {
             ? $"gh ado2gh integrate-boards --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --github-org \"{githubOrg}\" --github-repo \"{githubRepo}\"{(_log.Verbose ? " --verbose" : string.Empty)}"
             : null;
 
-    private string WaitForMigrationScript(string repoMigrationKey, string targetApiUrl) => $"gh ado2gh wait-for-migration{(!string.IsNullOrEmpty(targetApiUrl) ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --migration-id $RepoMigrations[\"{repoMigrationKey}\"]";
+    private string WaitForMigrationScript(string repoMigrationKey, string targetApiUrl) => $"gh ado2gh wait-for-migration{(targetApiUrl.HasValue() ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --migration-id $RepoMigrations[\"{repoMigrationKey}\"]";
 
     private string DownloadMigrationLogScript(string githubOrg, string githubRepo, string targetApiUrl) =>
         _generateScriptOptions.DownloadMigrationLogs

--- a/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommand.cs
@@ -17,6 +17,7 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
     {
         AddOption(BbsServerUrl);
         AddOption(GithubOrg);
+        AddOption(TargetApiUrl);
         AddOption(BbsUsername);
         AddOption(BbsPassword);
         AddOption(BbsProject);
@@ -118,6 +119,10 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
         name: "--no-ssl-verify",
         description: "Disables SSL verification when communicating with your Bitbucket Server/Data Center instance. All other migration steps will continue to verify SSL. " +
                      "If your Bitbucket instance has a self-signed SSL certificate then setting this flag will allow the migration archive to be exported.");
+    public Option<string> TargetApiUrl { get; } = new("--target-api-url")
+    {
+        Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com"
+    };
 
     public override GenerateScriptCommandHandler BuildHandler(GenerateScriptCommandArgs args, IServiceProvider sp)
     {

--- a/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommandArgs.cs
+++ b/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommandArgs.cs
@@ -26,6 +26,7 @@ public class GenerateScriptCommandArgs : CommandArgs
     public string AwsRegion { get; set; }
     public bool KeepArchive { get; set; }
     public bool NoSslVerify { get; set; }
+    public string TargetApiUrl { get; set; }
 
     public override void Validate(OctoLogger log)
     {

--- a/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -134,8 +134,9 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         var keepArchive = args.KeepArchive ? " --keep-archive" : "";
         var noSslVerify = args.NoSslVerify ? " --no-ssl-verify" : "";
         var targetRepoVisibility = " --target-repo-visibility private";
+        var targetApiUrlOption = args.TargetApiUrl.HasValue() ? $" --target-api-url \"{args.TargetApiUrl}\"" : "";
 
-        return $"gh bbs2gh migrate-repo{bbsServerUrlOption}{bbsUsernameOption}{bbsSharedHomeOption}{bbsProjectOption}{bbsRepoOption}{sshArchiveDownloadOptions}" +
+        return $"gh bbs2gh migrate-repo{targetApiUrlOption}{bbsServerUrlOption}{bbsUsernameOption}{bbsSharedHomeOption}{bbsProjectOption}{bbsRepoOption}{sshArchiveDownloadOptions}" +
                $"{smbArchiveDownloadOptions}{githubOrgOption}{githubRepoOption}{verboseOption}{waitOption}{kerberosOption}{awsBucketNameOption}{awsRegionOption}{keepArchive}{noSslVerify}{targetRepoVisibility}";
     }
 

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommand.cs
@@ -21,6 +21,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
             AddOption(GithubSourceOrg);
             AddOption(GithubTargetOrg);
 
+            AddOption(TargetApiUrl);
             AddOption(GhesApiUrl);
             AddOption(AwsBucketName);
             AddOption(AwsRegion);
@@ -93,6 +94,10 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
         public Option<bool> KeepArchive { get; } = new("--keep-archive")
         {
             Description = "Keeps the archive on this machine after uploading to the blob storage account. Only applicable for migrations from GitHub Enterprise Server versions before 3.8.0."
+        };
+        public Option<string> TargetApiUrl { get; } = new("--target-api-url")
+        {
+            Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com"
         };
 
         public override GenerateScriptCommandHandler BuildHandler(GenerateScriptCommandArgs args, IServiceProvider sp)

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandArgs.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandArgs.cs
@@ -22,6 +22,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
         [Secret]
         public string GithubSourcePat { get; set; }
         public bool KeepArchive { get; set; }
+        public string TargetApiUrl { get; set; }
 
         public override void Validate(OctoLogger log)
         {

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -203,7 +203,7 @@ if ($Failed -ne 0) {
     {
         var ghesRepoOptions = ghesApiUrl.HasValue() ? GetGhesRepoOptions(ghesApiUrl, awsBucketName, awsRegion, noSslVerify, keepArchive) : null;
 
-        return $"gh gei migrate-repo{(!string.IsNullOrEmpty(targetApiUrl) ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\"{(!string.IsNullOrEmpty(ghesRepoOptions) ? $" {ghesRepoOptions}" : string.Empty)}{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? string.Empty : " --queue-only")}{(skipReleases ? " --skip-releases" : string.Empty)}{(lockSourceRepo ? " --lock-source-repo" : string.Empty)} --target-repo-visibility {repoVisibility}";
+        return $"gh gei migrate-repo{(targetApiUrl.HasValue() ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\"{(!string.IsNullOrEmpty(ghesRepoOptions) ? $" {ghesRepoOptions}" : string.Empty)}{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? string.Empty : " --queue-only")}{(skipReleases ? " --skip-releases" : string.Empty)}{(lockSourceRepo ? " --lock-source-repo" : string.Empty)} --target-repo-visibility {repoVisibility}";
     }
 
     private string GetGhesRepoOptions(string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool keepArchive)

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -44,7 +44,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
 
         _log.LogInformation("Generating Script...");
 
-        var script = await GenerateScript(args.GithubSourceOrg, args.GithubTargetOrg, args.GhesApiUrl, args.AwsBucketName, args.AwsRegion, args.NoSslVerify, args.Sequential, args.SkipReleases, args.LockSourceRepo, args.DownloadMigrationLogs, args.KeepArchive);
+        var script = await GenerateScript(args.GithubSourceOrg, args.GithubTargetOrg, args.GhesApiUrl, args.AwsBucketName, args.AwsRegion, args.NoSslVerify, args.Sequential, args.SkipReleases, args.LockSourceRepo, args.DownloadMigrationLogs, args.KeepArchive, args.TargetApiUrl);
 
         if (script.HasValue() && args.Output.HasValue())
         {
@@ -52,7 +52,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         }
     }
 
-    private async Task<string> GenerateScript(string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool sequential, bool skipReleases, bool lockSourceRepo, bool downloadMigrationLogs, bool keepArchive)
+    private async Task<string> GenerateScript(string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool sequential, bool skipReleases, bool lockSourceRepo, bool downloadMigrationLogs, bool keepArchive, string targetApiUrl)
     {
         var repos = await GetGithubRepos(_sourceGithubApi, githubSourceOrg);
         if (!repos.Any())
@@ -62,8 +62,8 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         }
 
         return sequential
-            ? await GenerateSequentialGithubScript(repos, githubSourceOrg, githubTargetOrg, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, skipReleases, lockSourceRepo, downloadMigrationLogs, keepArchive)
-            : await GenerateParallelGithubScript(repos, githubSourceOrg, githubTargetOrg, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, skipReleases, lockSourceRepo, downloadMigrationLogs, keepArchive);
+            ? await GenerateSequentialGithubScript(repos, githubSourceOrg, githubTargetOrg, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, skipReleases, lockSourceRepo, downloadMigrationLogs, keepArchive, targetApiUrl)
+            : await GenerateParallelGithubScript(repos, githubSourceOrg, githubTargetOrg, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, skipReleases, lockSourceRepo, downloadMigrationLogs, keepArchive, targetApiUrl);
     }
 
     private async Task<IEnumerable<(string Name, string Visibility)>> GetGithubRepos(GithubApi github, string githubOrg)
@@ -83,7 +83,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         return repos;
     }
 
-    private async Task<string> GenerateSequentialGithubScript(IEnumerable<(string Name, string Visibility)> repos, string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool skipReleases, bool lockSourceRepo, bool downloadMigrationLogs, bool keepArchive)
+    private async Task<string> GenerateSequentialGithubScript(IEnumerable<(string Name, string Visibility)> repos, string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool skipReleases, bool lockSourceRepo, bool downloadMigrationLogs, bool keepArchive, string targetApiUrl)
     {
         var content = new StringBuilder();
 
@@ -110,18 +110,18 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
 
         foreach (var (name, visibility) in repos)
         {
-            content.AppendLine(Exec(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, name, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, true, skipReleases, lockSourceRepo, keepArchive, visibility)));
+            content.AppendLine(Exec(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, name, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, true, skipReleases, lockSourceRepo, keepArchive, visibility, targetApiUrl)));
 
             if (downloadMigrationLogs)
             {
-                content.AppendLine(Exec(DownloadMigrationLogScript(githubTargetOrg, name)));
+                content.AppendLine(Exec(DownloadMigrationLogScript(githubTargetOrg, name, targetApiUrl)));
             }
         }
 
         return content.ToString();
     }
 
-    private async Task<string> GenerateParallelGithubScript(IEnumerable<(string Name, string Visibility)> repos, string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool skipReleases, bool lockSourceRepo, bool downloadMigrationLogs, bool keepArchive)
+    private async Task<string> GenerateParallelGithubScript(IEnumerable<(string Name, string Visibility)> repos, string githubSourceOrg, string githubTargetOrg, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool skipReleases, bool lockSourceRepo, bool downloadMigrationLogs, bool keepArchive, string targetApiUrl)
     {
         var content = new StringBuilder();
 
@@ -158,7 +158,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         // Queuing migrations
         foreach (var (name, visibility) in repos)
         {
-            content.AppendLine($"$MigrationID = {ExecAndGetMigrationId(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, name, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, false, skipReleases, lockSourceRepo, keepArchive, visibility))}");
+            content.AppendLine($"$MigrationID = {ExecAndGetMigrationId(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, name, ghesApiUrl, awsBucketName, awsRegion, noSslVerify, false, skipReleases, lockSourceRepo, keepArchive, visibility, targetApiUrl))}");
             content.AppendLine($"$RepoMigrations[\"{name}\"] = $MigrationID");
             content.AppendLine();
         }
@@ -171,12 +171,12 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         // Query each migration's status
         foreach (var (name, _) in repos)
         {
-            content.AppendLine(Wrap(WaitForMigrationScript(name), $"if ($RepoMigrations[\"{name}\"])"));
+            content.AppendLine(Wrap(WaitForMigrationScript(targetApiUrl, name), $"if ($RepoMigrations[\"{name}\"])"));
             content.AppendLine($"if ($RepoMigrations[\"{name}\"] -and $lastexitcode -eq 0) {{ $Succeeded++ }} else {{ $Failed++ }}");
 
             if (downloadMigrationLogs)
             {
-                content.AppendLine(DownloadMigrationLogScript(githubTargetOrg, name));
+                content.AppendLine(DownloadMigrationLogScript(githubTargetOrg, name, targetApiUrl));
             }
 
             content.AppendLine();
@@ -199,11 +199,11 @@ if ($Failed -ne 0) {
         return content.ToString();
     }
 
-    private string MigrateGithubRepoScript(string githubSourceOrg, string githubTargetOrg, string repo, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool wait, bool skipReleases, bool lockSourceRepo, bool keepArchive, string repoVisibility)
+    private string MigrateGithubRepoScript(string githubSourceOrg, string githubTargetOrg, string repo, string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool wait, bool skipReleases, bool lockSourceRepo, bool keepArchive, string repoVisibility, string targetApiUrl)
     {
         var ghesRepoOptions = ghesApiUrl.HasValue() ? GetGhesRepoOptions(ghesApiUrl, awsBucketName, awsRegion, noSslVerify, keepArchive) : null;
 
-        return $"gh gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\"{(!string.IsNullOrEmpty(ghesRepoOptions) ? $" {ghesRepoOptions}" : string.Empty)}{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? string.Empty : " --queue-only")}{(skipReleases ? " --skip-releases" : string.Empty)}{(lockSourceRepo ? " --lock-source-repo" : string.Empty)} --target-repo-visibility {repoVisibility}";
+        return $"gh gei migrate-repo{(!string.IsNullOrEmpty(targetApiUrl) ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\"{(!string.IsNullOrEmpty(ghesRepoOptions) ? $" {ghesRepoOptions}" : string.Empty)}{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? string.Empty : " --queue-only")}{(skipReleases ? " --skip-releases" : string.Empty)}{(lockSourceRepo ? " --lock-source-repo" : string.Empty)} --target-repo-visibility {repoVisibility}";
     }
 
     private string GetGhesRepoOptions(string ghesApiUrl, string awsBucketName, string awsRegion, bool noSslVerify, bool keepArchive)
@@ -211,11 +211,11 @@ if ($Failed -ne 0) {
         return $"--ghes-api-url \"{ghesApiUrl}\"{(awsBucketName.HasValue() ? $" --aws-bucket-name \"{awsBucketName}\"" : "")}{(awsRegion.HasValue() ? $" --aws-region \"{awsRegion}\"" : "")}{(noSslVerify ? " --no-ssl-verify" : string.Empty)}{(keepArchive ? " --keep-archive" : string.Empty)}";
     }
 
-    private string WaitForMigrationScript(string repoMigrationKey = null) => $"gh gei wait-for-migration --migration-id $RepoMigrations[\"{repoMigrationKey}\"]";
+    private string WaitForMigrationScript(string targetApiUrl, string repoMigrationKey = null) => $"gh gei wait-for-migration{(!string.IsNullOrEmpty(targetApiUrl) ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --migration-id $RepoMigrations[\"{repoMigrationKey}\"]";
 
-    private string DownloadMigrationLogScript(string githubTargetOrg, string targetRepo)
+    private string DownloadMigrationLogScript(string githubTargetOrg, string targetRepo, string targetApiUrl)
     {
-        return $"gh gei download-logs --github-target-org \"{githubTargetOrg}\" --target-repo \"{targetRepo}\"";
+        return $"gh gei download-logs{(!string.IsNullOrEmpty(targetApiUrl) ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --github-target-org \"{githubTargetOrg}\" --target-repo \"{targetRepo}\"";
     }
 
     private string Exec(string script) => Wrap(script, "Exec");

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -211,7 +211,7 @@ if ($Failed -ne 0) {
         return $"--ghes-api-url \"{ghesApiUrl}\"{(awsBucketName.HasValue() ? $" --aws-bucket-name \"{awsBucketName}\"" : "")}{(awsRegion.HasValue() ? $" --aws-region \"{awsRegion}\"" : "")}{(noSslVerify ? " --no-ssl-verify" : string.Empty)}{(keepArchive ? " --keep-archive" : string.Empty)}";
     }
 
-    private string WaitForMigrationScript(string targetApiUrl, string repoMigrationKey = null) => $"gh gei wait-for-migration{(!string.IsNullOrEmpty(targetApiUrl) ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --migration-id $RepoMigrations[\"{repoMigrationKey}\"]";
+    private string WaitForMigrationScript(string targetApiUrl, string repoMigrationKey = null) => $"gh gei wait-for-migration{(targetApiUrl.HasValue() ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --migration-id $RepoMigrations[\"{repoMigrationKey}\"]";
 
     private string DownloadMigrationLogScript(string githubTargetOrg, string targetRepo, string targetApiUrl)
     {

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -215,7 +215,7 @@ if ($Failed -ne 0) {
 
     private string DownloadMigrationLogScript(string githubTargetOrg, string targetRepo, string targetApiUrl)
     {
-        return $"gh gei download-logs{(!string.IsNullOrEmpty(targetApiUrl) ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --github-target-org \"{githubTargetOrg}\" --target-repo \"{targetRepo}\"";
+        return $"gh gei download-logs{(targetApiUrl.HasValue() ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --github-target-org \"{githubTargetOrg}\" --target-repo \"{targetRepo}\"";
     }
 
     private string Exec(string script) => Wrap(script, "Exec");


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

Implement `target-api-url` for `generate-script` commands that leverages prev work for `migrate-repo` `download-logs` `wait-for-migration`. 

last one for https://github.com/github/gh-gei/issues/1094 and https://github.ghe.com/github/octoshift/issues/7956
 
_Note: These unit tests were extremely tricky for me, I did some functional testing in original issue but spending over a day on unit tests is my limit._ 


- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->