### PR TITLE
Fix secret scanning alert matching logic for locations

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Fixed secret scanning logic to match when the target alert has the same or less locations than the source alert.

--- a/src/Octoshift/Services/SecretScanningAlertService.cs
+++ b/src/Octoshift/Services/SecretScanningAlertService.cs
@@ -92,7 +92,7 @@ public class SecretScanningAlertService
                 && source.Alert.Secret == target.Alert.Secret)
             {
                 _log.LogVerbose(
-                    $"Secret type and value match between source:{source.Alert.Number} and target:{source.Alert.Number}");
+                    $"Secret type and value match between source:{source.Alert.Number} and target:{target.Alert.Number}");
                 var locationMatch = true;
                 foreach (var sourceLocation in source.Locations)
                 {


### PR DESCRIPTION
- Reversed secret scanning location matching to loop through target locations instead of source locations. As mentioned in #1238, it is expected that this tool will be used at the back of a repo or org migration, and therefore, the number of alerts and number of locations for each alert at the source will always be greater or equal to the ones at the target as not everything gets migrated.
- Fixed a secret scanning debug traces showing incorrect target alert number
- Separated the logic doing the location matching into its own function.
- Added 2 test cases to test the logic for location matching

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->

Fixes #1238