### PR TITLE
Add Support for Archive Uploads to GitHub-Owned Storage with Multipart Upload Option

### DIFF
--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using Azure;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Octoshift.Models;
 using OctoshiftCLI.Extensions;

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1049,12 +1049,12 @@ public class GithubApi
 
     public virtual async Task<string> UploadArchiveToGithubStorage(string org, bool isMultipart, string archiveName, Stream archiveContent)
     {
-        using HttpContent httpContent = new StreamContent(archiveContent);
+        using var httpContent = new StreamContent(archiveContent);
         string response;
 
         if (isMultipart)
         {
-            var url = $"{_apiUrl}/organizations/{org.EscapeDataString()}/gei/archive/blobs/uploads";
+            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive/blobs/uploads";
 
             using var content = new MultipartFormDataContent
             {
@@ -1065,7 +1065,7 @@ public class GithubApi
         }
         else
         {
-            var url = $"{_apiUrl}/organizations/{org.EscapeDataString()}/gei/archive";
+            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive?name={archiveName}";
 
             response = await _client.PostAsync(url, httpContent);
         }

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -759,7 +760,6 @@ public class GithubApi
         });
     }
 
-
     public virtual async Task<string> GetUserId(string login)
     {
         var url = $"{_apiUrl}/graphql";
@@ -1045,6 +1045,24 @@ public class GithubApi
         {
             throw new OctoshiftCliException($"Invalid migration id: {migrationId}", ex);
         }
+    }
+
+    public virtual async Task<string> UploadArchiveToGithubStorage(string org, bool isMultipart, string archiveName, Stream archiveContent)
+    {
+        var multipartRoute = isMultipart ? "/blobs/uploads" : "";
+
+        var url = $"{_apiUrl}/organizations/{org.EscapeDataString()}/gei/archive{multipartRoute}";
+
+        var payload = new
+        {
+            archive_filename = archiveName,
+            archive_Content = archiveContent
+        };
+
+        var response = await _client.PostAsync(url, payload);
+        var data = JObject.Parse(response);
+
+        return "gei://archive/" + (string)data["archiveId"];
     }
 
     private static object GetMannequinsPayload(string orgId)

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1065,8 +1065,8 @@ public class GithubApi
         }
         else
         {
-            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive?name={archiveName}";
-
+            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive\\?name\\={archiveName}";
+            // DEV: var url = $"http://uploads.github.localhost/organizations/{org.EscapeDataString()}/gei/archive?name={archiveName}"
             response = await _client.PostAsync(url, httpContent);
         }
 

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1071,14 +1071,14 @@ public class GithubApi
         }
     }
 
-    public virtual async Task<string> UploadArchiveToGithubStorage(string org, bool isMultipart, string archiveName, Stream archiveContent)
+    public virtual async Task<string> UploadArchiveToGithubStorage(string orgDatabaseId, bool isMultipart, string archiveName, Stream archiveContent)
     {
         using var httpContent = new StreamContent(archiveContent);
         string response;
 
         if (isMultipart)
         {
-            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive/blobs/uploads";
+            var url = $"https://uploads.github.com/organizations/{orgDatabaseId.EscapeDataString()}/gei/archive/blobs/uploads";
 
             using var content = new MultipartFormDataContent
             {
@@ -1089,7 +1089,7 @@ public class GithubApi
         }
         else
         {
-            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive\\?name\\={archiveName}";
+            var url = $"https://uploads.github.com/organizations/{orgDatabaseId.EscapeDataString()}/gei/archive\\?name\\={archiveName}";
             // DEV: var url = $"http://uploads.github.localhost/organizations/{org.EscapeDataString()}/gei/archive?name={archiveName}"
             response = await _client.PostAsync(url, httpContent);
         }

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
@@ -207,44 +207,6 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
         }
 
         [Fact]
-        public void Errors_If_BbsServer_Url_Not_Provided_But_Bbs_Username_Is_Provided()
-        {
-            // Act
-            var args = new MigrateRepoCommandArgs
-            {
-                ArchivePath = ARCHIVE_PATH,
-                GithubOrg = GITHUB_ORG,
-                GithubRepo = GITHUB_REPO,
-                BbsUsername = BBS_USERNAME
-            };
-
-            // Assert
-            args.Invoking(x => x.Validate(_mockOctoLogger.Object))
-                .Should()
-                .ThrowExactly<OctoshiftCliException>()
-                .WithMessage("*--bbs-username*--bbs-password*--bbs-server-url*");
-        }
-
-        [Fact]
-        public void Errors_If_BbsServer_Url_Not_Provided_But_Bbs_Password_Is_Provided()
-        {
-            // Act
-            var args = new MigrateRepoCommandArgs
-            {
-                ArchivePath = ARCHIVE_PATH,
-                GithubOrg = GITHUB_ORG,
-                GithubRepo = GITHUB_REPO,
-                BbsPassword = BBS_USERNAME
-            };
-
-            // Assert
-            args.Invoking(x => x.Validate(_mockOctoLogger.Object))
-                .Should()
-                .ThrowExactly<OctoshiftCliException>()
-                .WithMessage("*--bbs-username*--bbs-password*--bbs-server-url*");
-        }
-
-        [Fact]
         public void Errors_If_BbsServer_Url_Not_Provided_But_No_Ssl_Verify_Is_Provided()
         {
             // Act

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
@@ -19,6 +19,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
         private const string AWS_SECRET_ACCESS_KEY = "aws-secret-access-key";
         private const string AWS_SESSION_TOKEN = "aws-session-token";
         private const string AWS_REGION = "aws-region";
+        private const string AWS_BUCKET_NAME = "aws-bucket-name";
         private const string AZURE_STORAGE_CONNECTION_STRING = "azure-storage-connection-string";
 
         private const string BBS_HOST = "our-bbs-server.com";
@@ -68,6 +69,25 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
                 .Should()
                 .ThrowExactly<OctoshiftCliException>()
                 .WithMessage("*AWS S3*--aws-bucket-name*");
+        }
+
+        [Fact]
+        public void It_Throws_When_Aws_Bucket_Name_Provided_With_UseGithubStorage_Option()
+        {
+            var args = new MigrateRepoCommandArgs
+            {
+                ArchivePath = ARCHIVE_PATH,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING,
+                AwsBucketName = AWS_BUCKET_NAME,
+                UseGithubStorage = true
+            };
+
+            args.Invoking(x => x.Validate(_mockOctoLogger.Object))
+                .Should()
+                .ThrowExactly<OctoshiftCliException>()
+                .WithMessage("*--use-github-storage flag was provided with an AWS S3 Bucket name*");
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -357,7 +357,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
 
             var archiveFilePath = "./git_archive";
             File.WriteAllText(archiveFilePath, "I am an archive");
-            var gitContentStream = File.Create(archiveFilePath);
+            using var gitContentStream = File.Create(archiveFilePath);
             _mockFileSystemProvider
                 .SetupSequence(m => m.OpenRead(archiveFilePath))
                 .Returns(gitContentStream);
@@ -382,7 +382,6 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             await _handler.Handle(args);
 
             File.Delete(archiveFilePath);
-            gitContentStream.Close();
 
             // Assert
             _mockGithubApi.Verify(m => m.StartBbsMigration(

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -344,6 +344,56 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
         }
 
         [Fact]
+        public async Task Happy_Path_Uploads_To_Github_Storage()
+        {
+            // Arrange
+            _mockBbsApi.Setup(x => x.StartExport(BBS_PROJECT, BBS_REPO)).ReturnsAsync(BBS_EXPORT_ID);
+            _mockBbsApi.Setup(x => x.GetExport(BBS_EXPORT_ID)).ReturnsAsync(("COMPLETED", "The export is complete", 100));
+            _mockBbsArchiveDownloader.Setup(x => x.Download(BBS_EXPORT_ID, It.IsAny<string>())).ReturnsAsync(ARCHIVE_PATH);
+            _mockFileSystemProvider.Setup(x => x.ReadAllBytesAsync(ARCHIVE_PATH)).ReturnsAsync(ARCHIVE_DATA);
+            _mockGithubApi.SetupSequence(x => x.UploadArchiveToGithubStorage(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<FileStream>()).Result).Returns("gei://archive/");
+
+            var archiveFilePath = "./git_archive";
+            File.WriteAllText(archiveFilePath, "I am an archive");
+            var gitContentStream = File.Create(archiveFilePath);
+            _mockFileSystemProvider
+                .SetupSequence(m => m.OpenRead(archiveFilePath))
+                .Returns(gitContentStream);
+
+            // Act
+            var args = new MigrateRepoCommandArgs
+            {
+                BbsServerUrl = BBS_SERVER_URL,
+                BbsUsername = BBS_USERNAME,
+                BbsPassword = BBS_PASSWORD,
+                BbsProject = BBS_PROJECT,
+                BbsRepo = BBS_REPO,
+                SshUser = SSH_USER,
+                SshPrivateKey = PRIVATE_KEY,
+                ArchivePath = ARCHIVE_PATH,
+                UseGithubStorage = true,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                GithubPat = GITHUB_PAT,
+                QueueOnly = true,
+            };
+            await _handler.Handle(args);
+
+            File.Delete(archiveFilePath);
+
+            // Assert
+            _mockGithubApi.Verify(m => m.StartBbsMigration(
+                MIGRATION_SOURCE_ID,
+                BBS_REPO_URL,
+                GITHUB_ORG_ID,
+                GITHUB_REPO,
+                GITHUB_PAT,
+                ARCHIVE_URL,
+                null
+            ));
+        }
+
+        [Fact]
         public async Task Happy_Path_Deletes_Downloaded_Archive()
         {
             // Arrange

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -382,6 +382,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             await _handler.Handle(args);
 
             File.Delete(archiveFilePath);
+            gitContentStream.Close();
 
             // Assert
             _mockGithubApi.Verify(m => m.StartBbsMigration(

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -351,6 +351,8 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             _mockBbsApi.Setup(x => x.GetExport(BBS_EXPORT_ID)).ReturnsAsync(("COMPLETED", "The export is complete", 100));
             _mockBbsArchiveDownloader.Setup(x => x.Download(BBS_EXPORT_ID, It.IsAny<string>())).ReturnsAsync(ARCHIVE_PATH);
             _mockFileSystemProvider.Setup(x => x.ReadAllBytesAsync(ARCHIVE_PATH)).ReturnsAsync(ARCHIVE_DATA);
+            _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
+            _mockGithubApi.Setup(x => x.CreateBbsMigrationSource(GITHUB_ORG_ID).Result).Returns(MIGRATION_SOURCE_ID);
             _mockGithubApi.SetupSequence(x => x.UploadArchiveToGithubStorage(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<FileStream>()).Result).Returns("gei://archive/");
 
             var archiveFilePath = "./git_archive";
@@ -370,7 +372,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
                 BbsRepo = BBS_REPO,
                 SshUser = SSH_USER,
                 SshPrivateKey = PRIVATE_KEY,
-                ArchivePath = ARCHIVE_PATH,
+                ArchivePath = archiveFilePath,
                 UseGithubStorage = true,
                 GithubOrg = GITHUB_ORG,
                 GithubRepo = GITHUB_REPO,
@@ -388,7 +390,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
                 GITHUB_ORG_ID,
                 GITHUB_REPO,
                 GITHUB_PAT,
-                ARCHIVE_URL,
+                "gei://archive/",
                 null
             ));
         }

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandTests.cs
@@ -56,7 +56,7 @@ public class MigrateRepoCommandTests
         var command = new MigrateRepoCommand();
         command.Should().NotBeNull();
         command.Name.Should().Be("migrate-repo");
-        command.Options.Count.Should().Be(31);
+        command.Options.Count.Should().Be(32);
 
         TestHelpers.VerifyCommandOption(command.Options, "bbs-server-url", true);
         TestHelpers.VerifyCommandOption(command.Options, "bbs-project", true);
@@ -88,6 +88,7 @@ public class MigrateRepoCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "keep-archive", false);
         TestHelpers.VerifyCommandOption(command.Options, "no-ssl-verify", false);
         TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
+        TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false, true);
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
@@ -15,7 +15,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
         private const string TARGET_REPO = "foo-target-repo";
         private const string GITHUB_TARGET_PAT = "github-target-pat";
         private const string AWS_BUCKET_NAME = "aws-bucket-name";
-
+        private const string GHES_API_URL = "foo-ghes-api.com";
         [Fact]
         public void Defaults_TargetRepo_To_SourceRepo()
         {
@@ -65,6 +65,44 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
                  .Should()
                  .ThrowExactly<OctoshiftCliException>()
                  .WithMessage("*--aws-bucket-name*");
+        }
+
+        [Fact]
+        public void UseGithubStorage_Without_Ghes_Api_Url_Throws()
+        {
+            var args = new MigrateRepoCommandArgs
+            {
+                SourceRepo = SOURCE_REPO,
+                GithubSourceOrg = SOURCE_ORG,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                UseGithubStorage = true
+            };
+
+            FluentActions.Invoking(() => args.Validate(_mockOctoLogger.Object))
+                 .Should()
+                 .ThrowExactly<OctoshiftCliException>()
+                 .WithMessage("*--use-github-storage*");
+        }
+
+        [Fact]
+        public void UseGithubStorage_And_Aws_Bucket_Name_Throws()
+        {
+            var args = new MigrateRepoCommandArgs
+            {
+                SourceRepo = SOURCE_REPO,
+                GithubSourceOrg = SOURCE_ORG,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                AwsBucketName = AWS_BUCKET_NAME,
+                GhesApiUrl = GHES_API_URL,
+                UseGithubStorage = true
+            };
+
+            FluentActions.Invoking(() => args.Validate(_mockOctoLogger.Object))
+                 .Should()
+                 .ThrowExactly<OctoshiftCliException>()
+                 .WithMessage("*--use-github-storage flag was provided with an AWS S3 Bucket name*");
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
@@ -424,6 +423,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
 
             File.Delete(gitArchiveFilePath);
             File.Delete(metadataArchiveFilePath);
+            gitContentStream.Close();
+            metaContentStream.Close();
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -346,8 +346,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             File.WriteAllText(gitArchiveFilePath, "I am git archive");
             File.WriteAllText(metadataArchiveFilePath, "I am metadata archive");
 
-            var gitContentStream = File.Create(gitArchiveFilePath);
-            var metaContentStream = File.Create(metadataArchiveFilePath);
+            using var gitContentStream = File.Create(gitArchiveFilePath);
+            using var metaContentStream = File.Create(metadataArchiveFilePath);
 
             _mockFileSystemProvider
                 .SetupSequence(m => m.OpenRead(gitArchiveFilePath))
@@ -424,7 +424,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             File.Delete(gitArchiveFilePath);
             File.Delete(metadataArchiveFilePath);
             gitContentStream.Close();
-            metaContentStream.Close();
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
@@ -323,6 +324,97 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             _mockTargetGithubApi.Verify(x => x.GetMigration(migrationId));
             _mockFileSystemProvider.Verify(x => x.DeleteIfExists(gitArchiveFilePath), Times.Once);
             _mockFileSystemProvider.Verify(x => x.DeleteIfExists(metadataArchiveFilePath), Times.Once);
+        }
+
+        [Fact]
+        public async Task Happy_Path_UseGithubStorage()
+        {
+            var githubOrgId = Guid.NewGuid().ToString();
+            var migrationSourceId = Guid.NewGuid().ToString();
+            var sourceGithubPat = Guid.NewGuid().ToString();
+            var targetGithubPat = Guid.NewGuid().ToString();
+            var githubRepoUrl = $"https://myghes/{SOURCE_ORG}/{SOURCE_REPO}";
+            var migrationId = Guid.NewGuid().ToString();
+            var gitArchiveId = 1;
+            var metadataArchiveId = 2;
+            var gitArchiveUrl = $"https://example.com/{gitArchiveId}";
+            var metadataArchiveUrl = $"https://example.com/{metadataArchiveId}";
+            var uploadedGitArchiveUrl = "gei://archive/1";
+            var uploadedMetadataArchiveUrl = "gei://archive/2";
+            var gitArchiveFilePath = "./git_archive.tar";
+            var metadataArchiveFilePath = "./metadata_archive.tar";
+
+            File.WriteAllText(gitArchiveFilePath, "I am git archive");
+            File.WriteAllText(metadataArchiveFilePath, "I am metadata archive");
+
+            var gitContentStream = File.Create(gitArchiveFilePath);
+            var metaContentStream = File.Create(metadataArchiveFilePath);
+
+            _mockTargetGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
+            _mockTargetGithubApi.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
+            _mockTargetGithubApi
+                .Setup(x => x.StartMigration(
+                    migrationSourceId,
+                    githubRepoUrl,
+                    githubOrgId,
+                    TARGET_REPO,
+                    sourceGithubPat,
+                    targetGithubPat,
+                    uploadedGitArchiveUrl,
+                    uploadedMetadataArchiveUrl,
+                    false,
+                    null,
+                    false).Result)
+                .Returns(migrationId);
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result).Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, null, null));
+            _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
+
+            _mockSourceGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
+            _mockSourceGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false, false).Result).Returns(metadataArchiveId);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
+
+            _mockTargetGithubApi.SetupSequence(x => x.UploadArchiveToGithubStorage(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<FileStream>()).Result).Returns(uploadedGitArchiveUrl).Returns(uploadedMetadataArchiveUrl);
+
+            _mockFileSystemProvider
+                .SetupSequence(m => m.GetTempFileName())
+                .Returns(gitArchiveFilePath)
+                .Returns(metadataArchiveFilePath);
+
+            _mockFileSystemProvider
+                .SetupSequence(m => m.OpenRead(gitArchiveFilePath))
+                .Returns(gitContentStream);
+
+            _mockFileSystemProvider
+                .SetupSequence(m => m.OpenRead(metadataArchiveFilePath))
+                .Returns(metaContentStream);
+
+
+            _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken(It.IsAny<bool>())).Returns(sourceGithubPat);
+            _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
+
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
+
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                TargetApiUrl = TARGET_API_URL,
+                GhesApiUrl = GHES_API_URL,
+                UseGithubStorage = true,
+            };
+            await _handler.Handle(args);
+
+            _mockTargetGithubApi.Verify(x => x.GetMigration(migrationId));
+            _mockFileSystemProvider.Verify(x => x.DeleteIfExists(gitArchiveFilePath), Times.Once);
+            _mockFileSystemProvider.Verify(x => x.DeleteIfExists(metadataArchiveFilePath), Times.Once);
+
+            File.Delete(gitArchiveFilePath);
+            File.Delete(metadataArchiveFilePath);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandTests.cs
@@ -13,7 +13,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
 
             command.Should().NotBeNull();
             command.Name.Should().Be("migrate-repo");
-            command.Options.Count.Should().Be(23);
+            command.Options.Count.Should().Be(24);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-source-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "source-repo", true);
@@ -37,6 +37,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
             TestHelpers.VerifyCommandOption(command.Options, "keep-archive", false);
+            TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false, true);
         }
     }
 }

--- a/src/ado2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
+++ b/src/ado2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
@@ -17,5 +17,6 @@ namespace OctoshiftCLI.AdoToGithub.Commands.MigrateRepo
         [Secret]
         public string GithubPat { get; set; }
         public string TargetApiUrl { get; set; }
+        public bool UseGithubStorage { get; set; }
     }
 }

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -48,6 +48,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         AddOption(KeepArchive);
         AddOption(NoSslVerify);
         AddOption(TargetApiUrl);
+        AddOption(UseGithubStorage);
     }
 
     public Option<string> BbsServerUrl { get; } = new(
@@ -191,6 +192,11 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         name: "--no-ssl-verify",
         description: "Disables SSL verification when communicating with your Bitbucket Server/Data Center instance. All other migration steps will continue to verify SSL. " +
                      "If your Bitbucket instance has a self-signed SSL certificate then setting this flag will allow the migration archive to be exported.");
+
+    public Option<bool> UseGithubStorage { get; } = new(
+        name: "--use-github-storage",
+        description: "enables multipart uploads to Github-owned storage for use during migration")
+    { IsHidden = true };
 
     public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, IServiceProvider sp)
     {

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -195,7 +195,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
 
     public Option<bool> UseGithubStorage { get; } = new(
         name: "--use-github-storage",
-        description: "enables multipart uploads to Github-owned storage for use during migration")
+        description: "enables multipart uploads to GitHub-owned storage for use during migration")
     { IsHidden = true };
 
     public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, IServiceProvider sp)

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
@@ -51,6 +51,7 @@ public class MigrateRepoCommandArgs : CommandArgs
     public string SmbDomain { get; set; }
 
     public bool KeepArchive { get; set; }
+    public bool UseGithubStorage { get; set; }
 
     public override void Validate(OctoLogger log)
     {
@@ -158,6 +159,10 @@ public class MigrateRepoCommandArgs : CommandArgs
         if (AwsBucketName.IsNullOrWhiteSpace() && new[] { AwsAccessKey, AwsSecretKey, AwsSessionToken, AwsRegion }.Any(x => x.HasValue()))
         {
             throw new OctoshiftCliException("The AWS S3 bucket name must be provided with --aws-bucket-name if other AWS S3 upload options are set.");
+        }
+        if (UseGithubStorage && AwsBucketName.HasValue())
+        {
+            throw new OctoshiftCliException("The --use-github-storage flag was provided with an AWS S3 Bucket name. Archive cannot be uploaded to both locations.");
         }
     }
 

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
@@ -93,11 +93,6 @@ public class MigrateRepoCommandArgs : CommandArgs
 
     private void ValidateNoGenerateOptions()
     {
-        if (BbsUsername.HasValue() || BbsPassword.HasValue())
-        {
-            throw new OctoshiftCliException("--bbs-username and --bbs-password can only be provided with --bbs-server-url.");
-        }
-
         if (NoSslVerify)
         {
             throw new OctoshiftCliException("--no-ssl-verify can only be provided with --bbs-server-url.");

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using OctoshiftCLI.BbsToGithub.Services;

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -20,6 +20,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
     private readonly FileSystemProvider _fileSystemProvider;
     private readonly WarningsCountLogger _warningsCountLogger;
     private const int CHECK_STATUS_DELAY_IN_MILLISECONDS = 10000;
+    private const int STEAM_SIZE_LIMIT = 100 * 1024 * 1024;
 
     public MigrateRepoCommandHandler(
         OctoLogger log,
@@ -206,7 +207,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         await using (var archiveData = _fileSystemProvider.OpenRead(archivePath))
 #pragma warning restore IDE0063
         {
-            var isMultipart = archiveData.Length > 100 * 1024 * 1024; ; // Determines if stream size is greater than 100MB
+            var isMultipart = archiveData.Length > STEAM_SIZE_LIMIT; // Determines if stream size is greater than 100MB
 
             _log.LogInformation($"Uploading archive to GitHub Storage");
             var keyName = GenerateArchiveName();

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -43,6 +43,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
             AddOption(GithubTargetPat);
             AddOption(Verbose);
             AddOption(KeepArchive);
+            AddOption(UseGithubStorage);
         }
 
         public Option<string> GithubSourceOrg { get; } = new("--github-source-org")
@@ -139,6 +140,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
             Description = "Keeps the archive on this machine after uploading to the blob storage account. Only applicable for migrations from GitHub Enterprise Server versions before 3.8.0."
         };
 
+        public Option<bool> UseGithubStorage { get; } = new("--use-github-storage")
+        {
+            IsHidden = true,
+            Description = "Enables multipart upload of a user-specified filepath to Github-owned storage for use during migration",
+        };
         public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, IServiceProvider sp)
         {
             if (args is null)

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -143,7 +143,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
         public Option<bool> UseGithubStorage { get; } = new("--use-github-storage")
         {
             IsHidden = true,
-            Description = "Enables multipart upload of a user-specified filepath to Github-owned storage for use during migration",
+            Description = "enables multipart uploads to GitHub-owned storage for use during migration",
         };
         public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, IServiceProvider sp)
         {

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
@@ -34,6 +34,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
         [Secret]
         public string GithubTargetPat { get; set; }
         public bool KeepArchive { get; set; }
+        public bool UseGithubStorage { get; set; }
 
         public override void Validate(OctoLogger log)
         {
@@ -61,6 +62,16 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
                 {
                     throw new OctoshiftCliException("--ghes-api-url must be specified when --keep-archive is specified.");
                 }
+
+                if (UseGithubStorage)
+                {
+                    throw new OctoshiftCliException("--ghes-api-url must be specified when --use-github-storage is specified.");
+                }
+            }
+
+            if (AwsBucketName.HasValue() && UseGithubStorage)
+            {
+                throw new OctoshiftCliException("The --use-github-storage flag was provided with an AWS S3 Bucket name. Archive cannot be uploaded to both locations.");
             }
         }
 

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -65,7 +65,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         _log.LogInformation("Migrating Repo...");
 
-        var blobCredentialsRequired = await _ghesVersionChecker.AreBlobCredentialsRequired(args.GhesApiUrl);
+        var blobCredentialsRequired = await _ghesVersionChecker.AreBlobCredentialsRequired(args.GhesApiUrl, args.UseGithubStorage);
 
         if (args.GhesApiUrl.HasValue())
         {

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -106,12 +106,14 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         {
             (args.GitArchiveUrl, args.MetadataArchiveUrl) = await GenerateAndUploadArchive(
               args.GithubSourceOrg,
+              args.GithubTargetOrg,
               args.SourceRepo,
               args.AwsBucketName,
               args.SkipReleases,
               args.LockSourceRepo,
               blobCredentialsRequired,
-              args.KeepArchive
+              args.KeepArchive,
+              args.UseGithubStorage
             );
 
             if (blobCredentialsRequired)
@@ -204,12 +206,14 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
     private async Task<(string GitArchiveUrl, string MetadataArchiveUrl)> GenerateAndUploadArchive(
       string githubSourceOrg,
+      string githubTargetOrg,
       string sourceRepo,
       string awsBucketName,
       bool skipReleases,
       bool lockSourceRepo,
       bool blobCredentialsRequired,
-      bool keepArchive)
+      bool keepArchive,
+      bool UseGithubStorage)
     {
         var (gitArchiveUrl, metadataArchiveUrl, gitArchiveId, metadataArchiveId) = await _retryPolicy.Retry(
             async () => await GenerateArchive(githubSourceOrg, sourceRepo, skipReleases, lockSourceRepo));
@@ -237,9 +241,12 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             await using (var metadataArchiveContent = _fileSystemProvider.OpenRead(metadataArchiveDownloadFilePath))
 #pragma warning restore IDE0063
             {
-                return _awsApi.HasValue()
+                return UseGithubStorage
+                    ? ((string GitArchiveUrl, string MetadataArchiveUrl))
+                      await UploadArchivesToGithub(githubTargetOrg, gitArchiveUploadFileName, gitArchiveContent, metadataArchiveUploadFileName, metadataArchiveContent)
+                    : ((string GitArchiveUrl, string MetadataArchiveUrl))(_awsApi.HasValue()
                     ? await UploadArchivesToAws(awsBucketName, gitArchiveUploadFileName, gitArchiveContent, metadataArchiveUploadFileName, metadataArchiveContent)
-                    : await UploadArchivesToAzure(gitArchiveUploadFileName, gitArchiveContent, metadataArchiveUploadFileName, metadataArchiveContent);
+                    : await UploadArchivesToAzure(gitArchiveUploadFileName, gitArchiveContent, metadataArchiveUploadFileName, metadataArchiveContent));
             }
         }
         finally
@@ -307,6 +314,21 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         return (authenticatedGitArchiveUri.ToString(), authenticatedMetadataArchiveUri.ToString());
     }
 
+    private async Task<(string, string)> UploadArchivesToGithub(string org, string gitArchiveUploadFileName, Stream gitArchiveContent, string metadataArchiveUploadFileName, Stream metadataArchiveContent)
+    {
+        var isMultipart = gitArchiveContent.Length > 100 * 1024 * 1024; ; // Determines if stream size is greater than 100MB
+
+        _log.LogInformation($"Uploading git archive to GitHub Storage");
+        var uploadedGitArchiveUrl = await _targetGithubApi.UploadArchiveToGithubStorage(org, isMultipart, gitArchiveUploadFileName, gitArchiveContent);
+
+        isMultipart = metadataArchiveContent.Length > 100 * 1024 * 1024; ; // Determines if stream size is greater than 100MB
+
+        _log.LogInformation($"Uploading metadata archive to GitHub Storage");
+        var uploadedMetadataArchiveUrl = await _targetGithubApi.UploadArchiveToGithubStorage(org, isMultipart, metadataArchiveUploadFileName, metadataArchiveContent);
+
+        return (uploadedGitArchiveUrl, uploadedMetadataArchiveUrl);
+    }
+
     private async Task<string> WaitForArchiveGeneration(GithubApi githubApi, string githubSourceOrg, int archiveId)
     {
         var timeout = DateTime.Now.AddHours(ARCHIVE_GENERATION_TIMEOUT_IN_HOURS);
@@ -346,6 +368,11 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
                 _log.LogWarning("Ignoring provided AWS S3 credentials because you are running GitHub Enterprise Server (GHES) 3.8.0 or later. The blob storage credentials configured in your GHES Management Console will be used instead.");
             }
 
+            if (args.UseGithubStorage)
+            {
+                _log.LogWarning("Ignoring --use-github-storage flag because you are running GitHub Enterprise Server (GHES) 3.8.0 or later. The blob storage credentials configured in your GHES Management Console will be used instead.");
+            }
+
             if (args.KeepArchive)
             {
                 _log.LogWarning("Ignoring --keep-archive option because there is no downloaded archive to keep");
@@ -354,11 +381,12 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             return;
         }
 
-        if (!shouldUseAzureStorage && !shouldUseAwsS3)
+        if (!shouldUseAzureStorage && !shouldUseAwsS3 && !args.UseGithubStorage)
         {
             throw new OctoshiftCliException(
                 "Either Azure storage connection (--azure-storage-connection-string or AZURE_STORAGE_CONNECTION_STRING env. variable) or " +
-                "AWS S3 connection (--aws-bucket-name, --aws-access-key (or AWS_ACCESS_KEY_ID env. variable), --aws-secret-key (or AWS_SECRET_ACCESS_KEY env.variable)) " +
+                "AWS S3 connection (--aws-bucket-name, --aws-access-key (or AWS_ACCESS_KEY_ID env. variable), --aws-secret-key (or AWS_SECRET_ACCESS_KEY env.variable)) or " +
+                "GitHub Storage Option (--use-github-storage) " +
                 "must be provided.");
         }
 

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -242,11 +242,10 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 #pragma warning restore IDE0063
             {
                 return UseGithubStorage
-                    ? ((string GitArchiveUrl, string MetadataArchiveUrl))
-                      await UploadArchivesToGithub(githubTargetOrg, gitArchiveUploadFileName, gitArchiveContent, metadataArchiveUploadFileName, metadataArchiveContent)
-                    : ((string GitArchiveUrl, string MetadataArchiveUrl))(_awsApi.HasValue()
+                    ? await UploadArchivesToGithub(githubTargetOrg, gitArchiveUploadFileName, gitArchiveContent, metadataArchiveUploadFileName, metadataArchiveContent)
+                    : _awsApi.HasValue()
                     ? await UploadArchivesToAws(awsBucketName, gitArchiveUploadFileName, gitArchiveContent, metadataArchiveUploadFileName, metadataArchiveContent)
-                    : await UploadArchivesToAzure(gitArchiveUploadFileName, gitArchiveContent, metadataArchiveUploadFileName, metadataArchiveContent));
+                    : await UploadArchivesToAzure(gitArchiveUploadFileName, gitArchiveContent, metadataArchiveUploadFileName, metadataArchiveContent);
             }
         }
         finally

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -317,14 +317,15 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
     private async Task<(string, string)> UploadArchivesToGithub(string org, string gitArchiveUploadFileName, Stream gitArchiveContent, string metadataArchiveUploadFileName, Stream metadataArchiveContent)
     {
         var isMultipart = gitArchiveContent.Length > STEAM_SIZE_LIMIT; // Determines if stream size is greater than 100MB
+        var githubOrgDatabaseId = await _targetGithubApi.GetOrganizationDatabaseId(org);
 
         _log.LogInformation($"Uploading git archive to GitHub Storage");
-        var uploadedGitArchiveUrl = await _targetGithubApi.UploadArchiveToGithubStorage(org, isMultipart, gitArchiveUploadFileName, gitArchiveContent);
+        var uploadedGitArchiveUrl = await _targetGithubApi.UploadArchiveToGithubStorage(githubOrgDatabaseId, isMultipart, gitArchiveUploadFileName, gitArchiveContent);
 
         isMultipart = metadataArchiveContent.Length > STEAM_SIZE_LIMIT; // Determines if stream size is greater than 100MB
 
         _log.LogInformation($"Uploading metadata archive to GitHub Storage");
-        var uploadedMetadataArchiveUrl = await _targetGithubApi.UploadArchiveToGithubStorage(org, isMultipart, metadataArchiveUploadFileName, metadataArchiveContent);
+        var uploadedMetadataArchiveUrl = await _targetGithubApi.UploadArchiveToGithubStorage(githubOrgDatabaseId, isMultipart, metadataArchiveUploadFileName, metadataArchiveContent);
 
         return (uploadedGitArchiveUrl, uploadedMetadataArchiveUrl);
     }

--- a/src/gei/Services/GhesVersionChecker.cs
+++ b/src/gei/Services/GhesVersionChecker.cs
@@ -16,9 +16,14 @@ public class GhesVersionChecker
         _githubApi = githubApi;
     }
 
-    public virtual async Task<bool> AreBlobCredentialsRequired(string ghesApiUrl)
+    public virtual async Task<bool> AreBlobCredentialsRequired(string ghesApiUrl, bool useGithubStorage = false)
     {
         var blobCredentialsRequired = false;
+
+        if (useGithubStorage == true)
+        {
+            return true;
+        }
 
         if (ghesApiUrl.HasValue())
         {


### PR DESCRIPTION
### Summary:

This PR introduces the ability for the GEI CLI to upload archives to GitHub-owned storage using multipart uploads. To enable this, a new CLI option, --use-github-storage, has been added. This option allows users to explicitly specify that their archives should be uploaded to GitHub's managed storage instead of their own.

### **Key Features:**
Multipart Upload Support: Leveraging multipart upload for reliable and efficient large file uploads. This ensures the robustness of the uploads, minimizing the chances of failure during transmission. We're investigating libraries to handle multipart uploads, but for now, this feature is not rolled by hand unless necessary.

New Option: --use-github-storage:

This option is required to upload archives to GitHub-owned storage and will be hidden until GitHub-owned storage reaches general availability (GA).
By default, archives are still uploaded to user-specified storage locations unless the --use-github-storage flag is explicitly set.

### **Motivation:**
As discussed during our EDR, we want to allow users to utilize GitHub-owned storage as an option without making it the default. This approach lets us roll out GitHub-managed storage in stages and gather feedback while providing an explicit way to opt-in to this feature.

Check in BBS MigrateRepoCommandArgs removed, relating to changes in this PR: https://github.com/github/gh-gei/pull/1057

Take it out for a 🚗 :

**Migrating from GitHub Enterprise Server:**
```
dotnet run --project src/gei/gei.csproj -- migrate-repo --github-source-org valet-testing --source-repo integration-tests --github-target-org octoshift-staging --target-repo YOU_ADD_NEW_NAME--use-github-storage true --ghes-api-url https://octoshift-ghe.westus2.cloudapp.azure.com/api/v3 --verbose
```
Successful migration_id: `RM_kgHaACQxMWNjY2RlMi1hNTAzLTQwMWItOTA1OS1kM2NkZjBiYjM4Y2Q`

Closes: https://github.ghe.com/github/octoshift/issues/8969

- [x] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->