### PR TITLE
Update both upload and download artifact dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -161,18 +161,13 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         global-json-file: global.json
-    
-    - name: Create dist directory
-      run: mkdir -p ./dist
-
-    - name: Create dist directory
-      run: mkdir -p ./dist
+  
 
     - name: Download Binaries
       uses: actions/download-artifact@v4
       with:
         name: binaries-${{ matrix.runner-os }}
-        path: ./dist
+        path: dist
 
     - name: Copy binary to root (linux)
       if: matrix.runner-os == 'ubuntu-latest'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -161,6 +161,9 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         global-json-file: global.json
+    
+    - name: Create dist directory
+      run: mkdir -p ./dist
 
     - name: Download Binaries
       uses: actions/download-artifact@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,7 @@ jobs:
     # This is used by the subsequent publish-test-results.yml
     - name: Upload Unit Test Results
       if: always() && matrix.runner-os == 'ubuntu-latest'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Unit Test Results
         path: src/OctoshiftCLI.Tests/unit-tests.xml
@@ -71,7 +71,7 @@ jobs:
     # This is used by the subsequent publish-test-results.yml
     - name: Upload Code Coverage Report
       if: always() && matrix.runner-os == 'ubuntu-latest'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Code Coverage Report
         path: code-coverage-results.md
@@ -85,7 +85,7 @@ jobs:
     steps:
     # This is used by the subsequent publish-test-results.yaml
     - name: Upload Event File
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Event File
         path: ${{ github.event_path }}
@@ -130,7 +130,7 @@ jobs:
         SKIP_LINUX: "true"
 
     - name: Upload Binaries
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: binaries-${{ matrix.target-os }}
         path: |
@@ -259,7 +259,7 @@ jobs:
         comment_mode: off
     
     - name: Upload test logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: integration-test-logs-${{ matrix.source-vcs }}-${{ matrix.runner-os }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,7 +47,7 @@ jobs:
         SKIP_LINUX: "true"
 
     - name: Upload Binaries
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: binaries-${{ matrix.target-os }}
         path: |
@@ -186,7 +186,7 @@ jobs:
         commit: ${{ env.PR_SHA }}
     
     - name: Upload test logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: integration-test-logs-${{ matrix.source-vcs }}-${{ matrix.runner-os }}


### PR DESCRIPTION
They were dependent on each other. 
- Bump actions/upload-artifact from 3 to 4 
- Bump actions/download-artifact from 3 to 4

Related to: https://github.com/github/gh-gei/pull/1194
Related to: https://github.com/github/gh-gei/pull/1193

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->