### PR TITLE
PART1: Add `use-github-storage` option

### DIFF
--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandTests.cs
@@ -56,7 +56,7 @@ public class MigrateRepoCommandTests
         var command = new MigrateRepoCommand();
         command.Should().NotBeNull();
         command.Name.Should().Be("migrate-repo");
-        command.Options.Count.Should().Be(31);
+        command.Options.Count.Should().Be(32);
 
         TestHelpers.VerifyCommandOption(command.Options, "bbs-server-url", true);
         TestHelpers.VerifyCommandOption(command.Options, "bbs-project", true);
@@ -88,6 +88,7 @@ public class MigrateRepoCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "keep-archive", false);
         TestHelpers.VerifyCommandOption(command.Options, "no-ssl-verify", false);
         TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
+        TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false, true);
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandTests.cs
@@ -13,7 +13,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
 
             command.Should().NotBeNull();
             command.Name.Should().Be("migrate-repo");
-            command.Options.Count.Should().Be(23);
+            command.Options.Count.Should().Be(24);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-source-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "source-repo", true);
@@ -37,6 +37,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
             TestHelpers.VerifyCommandOption(command.Options, "keep-archive", false);
+            TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false, true);
         }
     }
 }

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -194,7 +194,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
                      "If your Bitbucket instance has a self-signed SSL certificate then setting this flag will allow the migration archive to be exported.");
     public Option<bool> UseGithubStorage { get; } = new(
         name: "--use-github-storage",
-        description: "enables multipart uploads to GitHub-owned storage for use during migration")
+        description: "Enables multipart uploads to a GitHub owned storage for use during migration")
     { IsHidden = true };
 
     public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, IServiceProvider sp)

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -48,6 +48,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         AddOption(KeepArchive);
         AddOption(NoSslVerify);
         AddOption(TargetApiUrl);
+        AddOption(UseGithubStorage);
     }
 
     public Option<string> BbsServerUrl { get; } = new(
@@ -191,6 +192,10 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
         name: "--no-ssl-verify",
         description: "Disables SSL verification when communicating with your Bitbucket Server/Data Center instance. All other migration steps will continue to verify SSL. " +
                      "If your Bitbucket instance has a self-signed SSL certificate then setting this flag will allow the migration archive to be exported.");
+    public Option<bool> UseGithubStorage { get; } = new(
+        name: "--use-github-storage",
+        description: "enables multipart uploads to GitHub-owned storage for use during migration")
+    { IsHidden = true };
 
     public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, IServiceProvider sp)
     {

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -106,7 +106,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
         public Option<bool> UseGithubStorage { get; } = new("--use-github-storage")
         {
             IsHidden = true,
-            Description = "enables multipart uploads to GitHub-owned storage for use during migration",
+            Description = "Enables multipart uploads to a GitHub owned storage for use during migration",
         };
 
         // Pre-uploaded archive urls, hidden by default

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -43,6 +43,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
             AddOption(GithubTargetPat);
             AddOption(Verbose);
             AddOption(KeepArchive);
+            AddOption(UseGithubStorage);
         }
 
         public Option<string> GithubSourceOrg { get; } = new("--github-source-org")
@@ -101,6 +102,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
         public Option<bool> NoSslVerify { get; } = new("--no-ssl-verify")
         {
             Description = "Only effective if migrating from GHES. Disables SSL verification when communicating with your GHES instance. All other migration steps will continue to verify SSL. If your GHES instance has a self-signed SSL certificate then setting this flag will allow data to be extracted."
+        };
+        public Option<bool> UseGithubStorage { get; } = new("--use-github-storage")
+        {
+            IsHidden = true,
+            Description = "enables multipart uploads to GitHub-owned storage for use during migration",
         };
 
         // Pre-uploaded archive urls, hidden by default


### PR DESCRIPTION
Breaking up[ larger PR](https://github.com/github/gh-gei/pull/1261) into smaller chunks. Using @hfishback01 as a feature branch.

The feature will introduce the ability for the GEI CLI to upload archives to GitHub-owned storage using multipart uploads. 

To enable this, a new CLI option, `--use-github-storage`, has been added. This option allows users to explicitly specify that their archives should be uploaded to GitHub's managed storage instead of their own.

Closes: https://github.ghe.com/github/octoshift/issues/9321
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->