### PR TITLE
PART 2:`use-github-storage` option validation

### DIFF
--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
@@ -20,7 +20,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
         private const string AWS_SESSION_TOKEN = "aws-session-token";
         private const string AWS_REGION = "aws-region";
         private const string AZURE_STORAGE_CONNECTION_STRING = "azure-storage-connection-string";
-
+        private const string AWS_BUCKET_NAME = "aws-bucket-name";
         private const string BBS_HOST = "our-bbs-server.com";
         private const string BBS_SERVER_URL = $"https://{BBS_HOST}";
         private const string BBS_USERNAME = "bbs-username";
@@ -68,6 +68,25 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
                 .Should()
                 .ThrowExactly<OctoshiftCliException>()
                 .WithMessage("*AWS S3*--aws-bucket-name*");
+        }
+
+        [Fact]
+        public void It_Throws_When_Aws_Bucket_Name_Provided_With_UseGithubStorage_Option()
+        {
+            var args = new MigrateRepoCommandArgs
+            {
+                ArchivePath = ARCHIVE_PATH,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING,
+                AwsBucketName = AWS_BUCKET_NAME,
+                UseGithubStorage = true
+            };
+
+            args.Invoking(x => x.Validate(_mockOctoLogger.Object))
+                .Should()
+                .ThrowExactly<OctoshiftCliException>()
+                .WithMessage("*--use-github-storage flag was provided with an AWS S3 Bucket name*");
         }
 
         [Fact]
@@ -184,25 +203,6 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
                 .Should()
                 .ThrowExactly<OctoshiftCliException>()
                 .WithMessage("*--bbs-username*--kerberos*");
-        }
-
-        [Fact]
-        public void Errors_If_BbsServer_Url_Not_Provided_But_Bbs_Username_Is_Provided()
-        {
-            // Act
-            var args = new MigrateRepoCommandArgs
-            {
-                ArchivePath = ARCHIVE_PATH,
-                GithubOrg = GITHUB_ORG,
-                GithubRepo = GITHUB_REPO,
-                BbsUsername = BBS_USERNAME
-            };
-
-            // Assert
-            args.Invoking(x => x.Validate(_mockOctoLogger.Object))
-                .Should()
-                .ThrowExactly<OctoshiftCliException>()
-                .WithMessage("*--bbs-username*--bbs-password*--bbs-server-url*");
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
@@ -90,6 +90,25 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
         }
 
         [Fact]
+        public void It_Throws_When_Aws_Bucket_Name_Provided_With_AzureStorageConnectionString_Option()
+        {
+            var args = new MigrateRepoCommandArgs
+            {
+                ArchivePath = ARCHIVE_PATH,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                AzureStorageConnectionString = AZURE_STORAGE_CONNECTION_STRING,
+                AwsBucketName = AWS_BUCKET_NAME,
+                UseGithubStorage = true
+            };
+
+            args.Invoking(x => x.Validate(_mockOctoLogger.Object))
+                .Should()
+                .ThrowExactly<OctoshiftCliException>()
+                .WithMessage("*--use-github-storage flag was provided with a connection string for an Azure storage account*");
+        }
+
+        [Fact]
         public void It_Throws_When_Aws_Bucket_Name_Not_Provided_But_Aws_Secret_Key_Provided()
         {
             var args = new MigrateRepoCommandArgs

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
@@ -105,6 +105,25 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
                  .ThrowExactly<OctoshiftCliException>()
                  .WithMessage("*--use-github-storage flag was provided with an AWS S3 Bucket name*");
         }
+
+        [Fact]
+        public void It_Throws_When_Aws_Bucket_Name_Provided_With_AzureStorageConnectionString_Option()
+        {
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                AwsBucketName = AWS_BUCKET_NAME,
+                GhesApiUrl = GHES_API_URL,
+                UseGithubStorage = true
+            };
+
+            args.Invoking(x => x.Validate(_mockOctoLogger.Object))
+                .Should()
+                .ThrowExactly<OctoshiftCliException>()
+                .WithMessage("*--use-github-storage flag was provided with a connection string for an Azure storage account*");
+        }
         [Fact]
         public void No_Ssl_Verify_Without_Ghes_Api_Url_Throws()
         {

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
@@ -15,6 +15,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
         private const string TARGET_REPO = "foo-target-repo";
         private const string GITHUB_TARGET_PAT = "github-target-pat";
         private const string AWS_BUCKET_NAME = "aws-bucket-name";
+        private const string GHES_API_URL = "foo-ghes-api.com";
 
         [Fact]
         public void Defaults_TargetRepo_To_SourceRepo()
@@ -67,6 +68,43 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
                  .WithMessage("*--aws-bucket-name*");
         }
 
+        [Fact]
+        public void UseGithubStorage_Without_Ghes_Api_Url_Throws()
+        {
+            var args = new MigrateRepoCommandArgs
+            {
+                SourceRepo = SOURCE_REPO,
+                GithubSourceOrg = SOURCE_ORG,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                UseGithubStorage = true
+            };
+
+            FluentActions.Invoking(() => args.Validate(_mockOctoLogger.Object))
+                 .Should()
+                 .ThrowExactly<OctoshiftCliException>()
+                 .WithMessage("*--use-github-storage*");
+        }
+
+        [Fact]
+        public void UseGithubStorage_And_Aws_Bucket_Name_Throws()
+        {
+            var args = new MigrateRepoCommandArgs
+            {
+                SourceRepo = SOURCE_REPO,
+                GithubSourceOrg = SOURCE_ORG,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                AwsBucketName = AWS_BUCKET_NAME,
+                GhesApiUrl = GHES_API_URL,
+                UseGithubStorage = true
+            };
+
+            FluentActions.Invoking(() => args.Validate(_mockOctoLogger.Object))
+                 .Should()
+                 .ThrowExactly<OctoshiftCliException>()
+                 .WithMessage("*--use-github-storage flag was provided with an AWS S3 Bucket name*");
+        }
         [Fact]
         public void No_Ssl_Verify_Without_Ghes_Api_Url_Throws()
         {

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
@@ -51,6 +51,7 @@ public class MigrateRepoCommandArgs : CommandArgs
     public string SmbDomain { get; set; }
 
     public bool KeepArchive { get; set; }
+    public bool UseGithubStorage { get; set; }
 
     public override void Validate(OctoLogger log)
     {
@@ -158,6 +159,10 @@ public class MigrateRepoCommandArgs : CommandArgs
         if (AwsBucketName.IsNullOrWhiteSpace() && new[] { AwsAccessKey, AwsSecretKey, AwsSessionToken, AwsRegion }.Any(x => x.HasValue()))
         {
             throw new OctoshiftCliException("The AWS S3 bucket name must be provided with --aws-bucket-name if other AWS S3 upload options are set.");
+        }
+        if (UseGithubStorage && AwsBucketName.HasValue())
+        {
+            throw new OctoshiftCliException("The --use-github-storage flag was provided with an AWS S3 Bucket name. Archive cannot be uploaded to both locations.");
         }
     }
 

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
@@ -164,6 +164,10 @@ public class MigrateRepoCommandArgs : CommandArgs
         {
             throw new OctoshiftCliException("The --use-github-storage flag was provided with an AWS S3 Bucket name. Archive cannot be uploaded to both locations.");
         }
+        if (AzureStorageConnectionString.HasValue() && UseGithubStorage)
+        {
+            throw new OctoshiftCliException("The --use-github-storage flag was provided with a connection string for an Azure storage account. Archive cannot be uploaded to both locations.");
+        }
     }
 
     private void ValidateImportOptions()

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
@@ -34,6 +34,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
         [Secret]
         public string GithubTargetPat { get; set; }
         public bool KeepArchive { get; set; }
+        public bool UseGithubStorage { get; set; }
 
         public override void Validate(OctoLogger log)
         {
@@ -61,6 +62,15 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
                 {
                     throw new OctoshiftCliException("--ghes-api-url must be specified when --keep-archive is specified.");
                 }
+                if (UseGithubStorage)
+                {
+                    throw new OctoshiftCliException("--ghes-api-url must be specified when --use-github-storage is specified.");
+                }
+            }
+
+            if (AwsBucketName.HasValue() && UseGithubStorage)
+            {
+                throw new OctoshiftCliException("The --use-github-storage flag was provided with an AWS S3 Bucket name. Archive cannot be uploaded to both locations.");
             }
         }
 

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
@@ -72,6 +72,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
             {
                 throw new OctoshiftCliException("The --use-github-storage flag was provided with an AWS S3 Bucket name. Archive cannot be uploaded to both locations.");
             }
+
+            if (AzureStorageConnectionString.HasValue() && UseGithubStorage)
+            {
+                throw new OctoshiftCliException("The --use-github-storage flag was provided with a connection string for an Azure storage account. Archive cannot be uploaded to both locations.");
+            }
         }
 
         private void DefaultTargetRepo(OctoLogger log)


### PR DESCRIPTION
This pull request ensures proper validation of the `--use-github-storage` option.

Closes: https://github.ghe.com/github/octoshift/issues/9326

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->