### PR TITLE
PART 3: Add UploadArchiveToGithubStorageWithMultiPart method

### DIFF
--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1066,7 +1066,7 @@ public class GithubApi
         }
         else
         {
-            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive?name={archiveName}";
+            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive?name={archiveName.EscapeDataString()}";
 
             response = await _client.PostAsync(url, httpContent);
         }

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1066,7 +1066,7 @@ public class GithubApi
         }
         else
         {
-            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive\\?name\\={archiveName}";
+            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive?name={archiveName}";
 
             response = await _client.PostAsync(url, httpContent);
         }

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -1045,6 +1046,33 @@ public class GithubApi
         {
             throw new OctoshiftCliException($"Invalid migration id: {migrationId}", ex);
         }
+    }
+
+    public virtual async Task<string> UploadArchiveToGithubStorage(string org, bool isMultipart, string archiveName, Stream archiveContent)
+    {
+        using var httpContent = new StreamContent(archiveContent);
+        string response;
+
+        if (isMultipart)
+        {
+            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive/blobs/uploads";
+
+            using var content = new MultipartFormDataContent
+            {
+                { httpContent, "archive", archiveName }
+            };
+
+            response = await _client.PostAsync(url, content);
+        }
+        else
+        {
+            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive\\?name\\={archiveName}";
+
+            response = await _client.PostAsync(url, httpContent);
+        }
+
+        var data = JObject.Parse(response);
+        return "gei://archive/" + (string)data["archiveId"];
     }
 
     private static object GetMannequinsPayload(string orgId)

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1072,14 +1072,14 @@ public class GithubApi
         }
     }
 
-    public virtual async Task<string> UploadArchiveToGithubStorage(string org, bool isMultipart, string archiveName, Stream archiveContent)
+    public virtual async Task<string> UploadArchiveToGithubStorage(string orgDatabaseId, bool isMultipart, string archiveName, Stream archiveContent)
     {
         using var httpContent = new StreamContent(archiveContent);
         string response;
 
         if (isMultipart)
         {
-            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive/blobs/uploads";
+            var url = $"https://uploads.github.com/organizations/{orgDatabaseId.EscapeDataString()}/gei/archive/blobs/uploads";
 
             using var content = new MultipartFormDataContent
             {
@@ -1090,7 +1090,7 @@ public class GithubApi
         }
         else
         {
-            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive?name={archiveName.EscapeDataString()}";
+            var url = $"https://uploads.github.com/organizations/{orgDatabaseId.EscapeDataString()}/gei/archive?name={archiveName.EscapeDataString()}";
 
             response = await _client.PostAsync(url, httpContent);
         }

--- a/src/Octoshift/Services/GithubClient.cs
+++ b/src/Octoshift/Services/GithubClient.cs
@@ -151,9 +151,14 @@ public class GithubClient
 
         if (body != null)
         {
-            _log.LogVerbose($"HTTP BODY: {body.ToJson()}");
+            _log.LogVerbose(body is MultipartFormDataContent or StreamContent ? "HTTP BODY: BLOB" : $"HTTP BODY: {body.ToJson()}");
 
-            request.Content = body.ToJson().ToStringContent();
+            request.Content = body switch
+            {
+                MultipartFormDataContent multipartFormDataContent => multipartFormDataContent,
+                StreamContent streamContent => streamContent,
+                _ => body.ToJson().ToStringContent()
+            };
         }
 
         using var response = await _httpClient.SendAsync(request);

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -1,7 +1,7 @@
 using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -3408,6 +3408,7 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
 
         var expectedArchiveId = "123456";
         var jsonResponse = $"{{ \"archiveId\": \"{expectedArchiveId}\" }}";
+
         var payload = new
         {
             token = $"repoV2/{123}/{123}",
@@ -3431,7 +3432,7 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
         };
 
         _githubClientMock
-            .Setup(m => m.PostAsync(url, It.IsAny<HttpContent>()))
+            .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<HttpContent>(), null))
             .ReturnsAsync(jsonResponse);
 
         var expectedStringResponse = "gei://archive/" + expectedArchiveId;
@@ -3443,6 +3444,8 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
         expectedStringResponse.Should().Be(actualStringResponse);
 
     }
+
+
 
     [Fact]
     public async Task UploadArchiveToGithubStorageWithMultiPart()
@@ -3482,7 +3485,7 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
         };
 
         _githubClientMock
-            .Setup(m => m.PostAsync(url, It.IsAny<HttpContent>()))
+            .Setup(m => m.PostAsync(url, It.Is<StreamContent>(x => x.ToJson() == payload.ToJson()), null))
             .ReturnsAsync(jsonResponse);
 
         var expectedStringResponse = "gei://archive/" + expectedArchiveId;
@@ -3494,4 +3497,13 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
         expectedStringResponse.Should().Be(actualStringResponse);
 
     }
+    private string Compact(string source) =>
+        source
+            .Replace("\r", "")
+            .Replace("\n", "")
+            .Replace("\t", "")
+            .Replace("\\r", "")
+            .Replace("\\n", "")
+            .Replace("\\t", "")
+            .Replace(" ", "");
 }

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -3473,9 +3473,6 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
 
         // Using a MemoryStream as a valid stream implementation
         using var archiveContent = new MemoryStream(new byte[] { 1, 2, 3 });
-
-        var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive\\?name\\={archiveName}";
-
         var expectedArchiveId = "123456";
         var jsonResponse = $"{{ \"archiveId\": \"{expectedArchiveId}\" }}";
 
@@ -3505,31 +3502,8 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
         // Using a MemoryStream as a valid stream implementation
         using var archiveContent = new MemoryStream(new byte[] { 1, 2, 3 });
 
-        var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive\\?name\\={archiveName}";
-
         var expectedArchiveId = "123456";
         var jsonResponse = $"{{ \"archiveId\": \"{expectedArchiveId}\" }}";
-        var payload = new
-        {
-            token = $"repoV2/{123}/{123}",
-            merge = true,
-            accessControlEntries = new[]
-            {
-                new
-                {
-                    descriptor = "",
-                    allow = 0,
-                    deny = 56828,
-                    extendedInfo = new
-                    {
-                        effectiveAllow = 0,
-                        effectiveDeny = 56828,
-                        inheritedAllow = 0,
-                        inheritedDeny = 56828
-                    }
-                }
-            }
-        };
 
         _githubClientMock
             .Setup(m => m.PostAsync(It.IsAny<string>(), It.IsAny<HttpContent>(), null))


### PR DESCRIPTION
This pull request introduces a new feature for uploading archives to GitHub storage and includes corresponding unit tests. 

We are also updating the content types of Stream and Multipart uploads in the SendAsync method. 

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->