### PR TITLE
Add call to get org database id

### DIFF
--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1082,36 +1082,6 @@ public class GithubApi
         }
     }
 
-<<<<<<< Updated upstream
-=======
-    public virtual async Task<string> UploadArchiveToGithubStorage(string org, bool isMultipart, string archiveName, Stream archiveContent)
-    {
-        using var httpContent = new StreamContent(archiveContent);
-        string response;
-
-        if (isMultipart)
-        {
-            var url = $"https://uploads.github.com/organizations/{org.EscapeDataString()}/gei/archive/blobs/uploads";
-
-            using var content = new MultipartFormDataContent
-            {
-                { httpContent, "archive", archiveName }
-            };
-
-            response = await _client.PostAsync(url, content);
-        }
-        else
-        {
-            var url = $"https://uploads.github.com/organizations/93741352/gei/archive?name={archiveName}";
-            // DEV: var url = $"http://uploads.github.localhost/organizations/{org.EscapeDataString()}/gei/archive?name={archiveName}"
-            response = await _client.PostAsync(url, httpContent);
-        }
-
-        var data = JObject.Parse(response);
-        return "gei://archive/" + (string)data["archiveId"];
-    }
-
->>>>>>> Stashed changes
     private static object GetMannequinsPayload(string orgId)
     {
         var query = "query($id: ID!, $first: Int, $after: String)";

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Linq;
 using Octoshift.Models;
 using OctoshiftCLI.Extensions;
 using OctoshiftCLI.Models;
+using System.Diagnostics;
 
 namespace OctoshiftCLI.Services;
 
@@ -225,7 +226,7 @@ public class GithubApi
         }
     }
 
-    public virtual async Task<string> GetOrganizationIdWithDatabaseId(string org)
+    public virtual async Task<string> GetOrganizationDatabaseId(string org)
     {
         var url = $"{_apiUrl}/graphql";
 
@@ -249,14 +250,14 @@ public class GithubApi
             {
                 var data = await _client.PostGraphQLAsync(url, payload);
 
-                var databaseId = (string)data["data"]["organization"]["databaseId"];
+                var databaseId = data["data"]["organization"]["databaseId"].ToString();
 
                 return databaseId;
             });
         }
         catch (Exception ex)
         {
-            throw new OctoshiftCliException($"Failed to lookup the Organization ID for organization '{org}'", ex);
+            throw new OctoshiftCliException($"Failed to lookup the Organization database ID for organization '{org}'", ex);
         }
     }
 

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -250,7 +250,7 @@ public class GithubApi
             {
                 var data = await _client.PostGraphQLAsync(url, payload);
 
-                var databaseId = data["data"]["organization"]["databaseId"].ToString();
+                var databaseId = (string)data["data"]["organization"]["databaseId"];
 
                 return databaseId;
             });

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -8,7 +8,6 @@ using Newtonsoft.Json.Linq;
 using Octoshift.Models;
 using OctoshiftCLI.Extensions;
 using OctoshiftCLI.Models;
-using System.Diagnostics;
 
 namespace OctoshiftCLI.Services;
 

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -266,8 +266,7 @@ public class GithubApi
             {
                 var data = await _client.PostGraphQLAsync(url, payload);
 
-                var entireprise_id = (string)data["data"]["enterprise"]["id"];
-                return entireprise_id;
+                return (string)data["data"]["enterprise"]["id"];
             });
         }
         catch (Exception ex)

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -249,7 +249,7 @@ public class GithubApi
             {
                 var data = await _client.PostGraphQLAsync(url, payload);
 
-                var databaseId = data["data"]["organization"]["databaseId"].ToString();
+                var databaseId = (string)data["data"]["organization"]["databaseId"];
 
                 return databaseId;
             });

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -231,15 +231,7 @@ public class GithubApi
 
         var payload = new
         {
-            query = @"
-            query($login: String!) {
-                organization(login: $login) {
-                    login
-                    id
-                    name
-                    databaseId
-                }
-            }",
+            query = "query($login: String!) {organization(login: $login) { login, databaseId, name } }",
             variables = new { login = org }
         };
 
@@ -249,9 +241,7 @@ public class GithubApi
             {
                 var data = await _client.PostGraphQLAsync(url, payload);
 
-                var databaseId = (string)data["data"]["organization"]["databaseId"];
-
-                return databaseId;
+                return (string)data["data"]["organization"]["databaseId"];
             });
         }
         catch (Exception ex)
@@ -276,7 +266,8 @@ public class GithubApi
             {
                 var data = await _client.PostGraphQLAsync(url, payload);
 
-                return (string)data["data"]["enterprise"]["id"];
+                var entireprise_id = (string)data["data"]["enterprise"]["id"];
+                return entireprise_id;
             });
         }
         catch (Exception ex)

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -606,7 +606,6 @@ public class GithubApiTests
     {
         // Arrange
         const string databaseId = "DATABASE_ID";
-        const string orgId = "ORG_ID";
 
         var url = $"https://api.github.com/graphql";
         var payload =

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -610,14 +610,12 @@ public class GithubApiTests
 
         var url = $"https://api.github.com/graphql";
         var payload =
-            $"{{\"query\":\"query($login: String!) {{organization(login: $login) {{ login, id, databaseId, name }} }}\",\"variables\":{{\"login\":\"{GITHUB_ORG}\"}}}}";
-
+            $"{{\"query\":\"query($login: String!) {{organization(login: $login) {{ login, databaseId, name }} }}\",\"variables\":{{\"login\":\"{GITHUB_ORG}\"}}}}";
         var response = JObject.Parse($@"
         {{
             ""data"": {{
                 ""organization"": {{
                     ""login"": ""{GITHUB_ORG}"",
-                    ""id"": ""{orgId}"",
                     ""name"": ""github"",
                     ""databaseId"": ""{databaseId}""
                 }}

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -605,26 +605,27 @@ public class GithubApiTests
     public async Task GetOrganizationDatabaseId_Returns_The_Database_Id()
     {
         // Arrange
-        const string GITHUB_ORG = "ORG_LOGIN"; // Adjust the organization login as needed
         const string databaseId = "DATABASE_ID";
+        const string orgId = "ORG_ID";
 
         var url = $"https://api.github.com/graphql";
         var payload =
-            $"{{\"query\":\"query($login: String!) {{organization(login: $login) {{ login, databaseId, name }} }}\",\"variables\":{{\"login\":\"{GITHUB_ORG}\"}}}}";
+            $"{{\"query\":\"query($login: String!) {{organization(login: $login) {{ login, id, databaseId, name }} }}\",\"variables\":{{\"login\":\"{GITHUB_ORG}\"}}}}";
 
         var response = JObject.Parse($@"
         {{
             ""data"": {{
                 ""organization"": {{
                     ""login"": ""{GITHUB_ORG}"",
-                    ""databaseId"": ""{databaseId}"",
-                    ""name"": ""github""
+                    ""id"": ""{orgId}"",
+                    ""name"": ""github"",
+                    ""databaseId"": ""{databaseId}""
                 }}
             }}
         }}");
 
         _githubClientMock
-            .Setup(m => m.PostGraphQLAsync(It.Is<string>(u => u == url), It.Is<object>(p => p.ToJson() == payload), null))
+            .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
             .ReturnsAsync(response);
 
         // Act

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -602,6 +602,76 @@ public class GithubApiTests
     }
 
     [Fact]
+    public async Task GetOrganizationIdWithDatabaseId_Returns_The_Database_Id()
+    {
+        // Arrange
+        const string databaseId = "DATABASE_ID";
+
+        var url = $"https://api.github.com/graphql";
+        var payload =
+            $"{{\"query\":\"query($login: String!) {{organization(login: $login) {{ login, databaseId, name }} }}\",\"variables\":{{\"login\":\"{GITHUB_ORG}\"}}}}";
+        var response = JObject.Parse($@"
+            {{
+                ""data"": 
+                    {{
+                        ""organization"": 
+                            {{
+                                ""login"": ""{GITHUB_ORG}"",
+                                ""databaseId"": ""{databaseId}"",
+                                ""name"": ""github"" 
+                            }} 
+                    }} 
+            }}");
+
+        _githubClientMock
+            .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+            .ReturnsAsync(response);
+
+        // Act
+        var result = await _githubApi.GetOrganizationIdWithDatabaseId(GITHUB_ORG);
+
+        // Assert
+        result.Should().Be(databaseId);
+    }
+
+    [Fact]
+    public async Task GetOrganizationIdWithDatabaseId_Retries_On_GQL_Error()
+    {
+        // Arrange
+        const string databaseId = "DATABASE_ID";
+
+        var url = $"https://api.github.com/graphql";
+        var payload =
+            $"{{\"query\":\"query($login: String!) {{organization(login: $login) {{ login, databaseId, name }} }}\",\"variables\":{{\"login\":\"{GITHUB_ORG}\"}}}}";
+
+        var response = JObject.Parse($@"
+           {{
+                ""data"": 
+                    {{
+                        ""organization"": 
+                            {{
+                                ""login"": ""{GITHUB_ORG}"",
+                                ""databaseId"": ""{databaseId}"",
+                                ""name"": ""github"" 
+                            }} 
+                    }} 
+            }}");
+
+        _githubClientMock
+            .SetupSequence(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+            .ReturnsAsync(GQL_ERROR_RESPONSE)
+            .ReturnsAsync(GQL_ERROR_RESPONSE)
+            .ReturnsAsync(response);
+
+        // Act
+        var result = await _githubApi.GetEnterpriseId(GITHUB_ENTERPRISE);
+
+        // Assert
+        result.Should().Be(databaseId);
+    }
+
+
+    [Fact]
     public async Task GetEnterpriseId_Returns_The_Enterprise_Id()
     {
         // Arrange

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -602,40 +602,40 @@ public class GithubApiTests
     }
 
     [Fact]
-    public async Task GetOrganizationIdWithDatabaseId_Returns_The_Database_Id()
+    public async Task GetOrganizationDatabaseId_Returns_The_Database_Id()
     {
         // Arrange
+        const string GITHUB_ORG = "ORG_LOGIN"; // Adjust the organization login as needed
         const string databaseId = "DATABASE_ID";
 
         var url = $"https://api.github.com/graphql";
         var payload =
             $"{{\"query\":\"query($login: String!) {{organization(login: $login) {{ login, databaseId, name }} }}\",\"variables\":{{\"login\":\"{GITHUB_ORG}\"}}}}";
+
         var response = JObject.Parse($@"
-            {{
-                ""data"": 
-                    {{
-                        ""organization"": 
-                            {{
-                                ""login"": ""{GITHUB_ORG}"",
-                                ""databaseId"": ""{databaseId}"",
-                                ""name"": ""github"" 
-                            }} 
-                    }} 
-            }}");
+        {{
+            ""data"": {{
+                ""organization"": {{
+                    ""login"": ""{GITHUB_ORG}"",
+                    ""databaseId"": ""{databaseId}"",
+                    ""name"": ""github""
+                }}
+            }}
+        }}");
 
         _githubClientMock
-            .Setup(m => m.PostGraphQLAsync(url, It.Is<object>(x => x.ToJson() == payload), null))
+            .Setup(m => m.PostGraphQLAsync(It.Is<string>(u => u == url), It.Is<object>(p => p.ToJson() == payload), null))
             .ReturnsAsync(response);
 
         // Act
-        var result = await _githubApi.GetOrganizationIdWithDatabaseId(GITHUB_ORG);
+        var result = await _githubApi.GetOrganizationDatabaseId(GITHUB_ORG);
 
         // Assert
         result.Should().Be(databaseId);
     }
 
     [Fact]
-    public async Task GetOrganizationIdWithDatabaseId_Retries_On_GQL_Error()
+    public async Task GetOrganizationDatabaseId_Retries_On_GQL_Error()
     {
         // Arrange
         const string databaseId = "DATABASE_ID";
@@ -664,7 +664,7 @@ public class GithubApiTests
             .ReturnsAsync(response);
 
         // Act
-        var result = await _githubApi.GetEnterpriseId(GITHUB_ENTERPRISE);
+        var result = await _githubApi.GetOrganizationDatabaseId(GITHUB_ORG);
 
         // Assert
         result.Should().Be(databaseId);


### PR DESCRIPTION
This pull request introduces new methods to the `GithubApi` service and adds corresponding tests to ensure their functionality. 

We need this method that fetches the organization's database ID, so it can be used in part to upload archives to GitHub storage. 

We will need this for the GitHub owned storage support 

- [x] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->