### PR TITLE
Add pagination support to GetIdpGroupId method

### DIFF
--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -574,11 +574,10 @@ public class GithubApi
     {
         var url = $"{_apiUrl}/orgs/{org.EscapeDataString()}/external-groups";
 
-        // TODO: Need to implement paging
-        var response = await _client.GetAsync(url);
-        var data = JObject.Parse(response);
+        var group = await _client.GetAllAsync(url, data => (JArray)data["groups"])
+            .SingleAsync(x => string.Equals((string)x["group_name"], groupName, StringComparison.OrdinalIgnoreCase));
 
-        return (int)data["groups"].Children().Single(x => ((string)x["group_name"]).ToUpper() == groupName.ToUpper())["group_id"];
+        return (int)group["group_id"];
     }
 
     public virtual async Task<string> GetTeamSlug(string org, string teamName)

--- a/src/Octoshift/Services/GithubClient.cs
+++ b/src/Octoshift/Services/GithubClient.cs
@@ -47,13 +47,25 @@ public class GithubClient
 
     public virtual async Task<string> GetAsync(string url, Dictionary<string, string> customHeaders = null) => (await GetWithRetry(url, customHeaders)).Content;
 
-    public virtual async IAsyncEnumerable<JToken> GetAllAsync(string url, Dictionary<string, string> customHeaders = null)
+    public virtual IAsyncEnumerable<JToken> GetAllAsync(string url, Dictionary<string, string> customHeaders = null) =>
+        GetAllAsync(url, jToken => (JArray)jToken, customHeaders);
+
+    public virtual async IAsyncEnumerable<JToken> GetAllAsync(
+        string url,
+        Func<JToken, JArray> resultCollectionSelector,
+        Dictionary<string, string> customHeaders = null)
     {
+        if (resultCollectionSelector is null)
+        {
+            throw new ArgumentNullException(nameof(resultCollectionSelector));
+        }
+
         var nextUrl = url;
         do
         {
             var (content, headers) = await GetWithRetry(nextUrl, customHeaders: customHeaders);
-            foreach (var jToken in JArray.Parse(content))
+            var jContent = JToken.Parse(content);
+            foreach (var jToken in resultCollectionSelector(jContent))
             {
                 yield return jToken;
             }

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -1606,25 +1606,27 @@ public class GithubApiTests
 
         var url = $"https://api.github.com/orgs/{GITHUB_ORG}/external-groups";
         const int expectedGroupId = 123;
-        var response = $@"
-            {{
-                ""groups"": [
-                    {{
-                       ""group_id"": ""{expectedGroupId}"",
-                       ""group_name"": ""{groupName}"",
-                       ""updated_at"": ""2021-01-24T11:31:04-06:00""
-                    }},
-                    {{
-                       ""group_id"": ""456"",
-                       ""group_name"": ""Octocat admins"",
-                       ""updated_at"": ""2021-03-24T11:31:04-06:00""
-                    }},
-                ]
-            }}";
+
+        var group1 = new
+        {
+            group_id = expectedGroupId,
+            group_name = groupName,
+            updated_at = DateTime.Parse("2021-01-24T11:31:04-06:00")
+        };
+        var group2 = new
+        {
+            group_id = "456",
+            group_name = "Octocat admins",
+            updated_at = DateTime.Parse("2021-03-24T11:31:04-06:00")
+        };
 
         _githubClientMock
-            .Setup(m => m.GetAsync(url, null))
-            .ReturnsAsync(response);
+            .Setup(m => m.GetAllAsync(url, It.IsAny<Func<JToken, JArray>>(), null))
+            .Returns(new[]
+            {
+                JToken.FromObject(group1),
+                JToken.FromObject(group2)
+            }.ToAsyncEnumerable());
 
         // Act
         var actualGroupId = await _githubApi.GetIdpGroupId(GITHUB_ORG, groupName);


### PR DESCRIPTION
The `GetIdpGroupId` method hasn't been using pagination to get all groups so far. This PR adds pagination support to the `GetIdpGroupId` method by using the new `GetAllAsync` overload that accepts a result collection selector.

The new overload was necessary because the [List extrernal groups API](https://docs.github.com/en/enterprise-cloud@latest/rest/teams/external-groups?apiVersion=2022-11-28#list-external-groups-in-an-organization) is returning a Json object instead of an Array. With the new selector it'd be now possible to specify the desired field which is the result collection.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->