### PR TITLE
Add integration tests for Github owned storage

### DIFF
--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -67,10 +67,11 @@ public sealed class BbsToGithub : IDisposable
     }
 
     [Theory]
-    [InlineData("http://e2e-bbs-8-5-0-linux-2204.eastus.cloudapp.azure.com:7990", true, true)]
-    [InlineData("http://e2e-bbs-7-21-9-win-2019.eastus.cloudapp.azure.com:7990", false, true)]
-    [InlineData("http://e2e-bbs-8-5-0-linux-2204.eastus.cloudapp.azure.com:7990", true, false)]
-    public async Task Basic(string bbsServer, bool useSshForArchiveDownload, bool useAzureForArchiveUpload)
+    [InlineData("http://e2e-bbs-8-5-0-linux-2204.eastus.cloudapp.azure.com:7990", true, true, false)]
+    [InlineData("http://e2e-bbs-7-21-9-win-2019.eastus.cloudapp.azure.com:7990", false, true, false)]
+    [InlineData("http://e2e-bbs-8-5-0-linux-2204.eastus.cloudapp.azure.com:7990", true, false, false)]
+    [InlineData("http://e2e-bbs-8-5-0-linux-2204.eastus.cloudapp.azure.com:7990", false, false, true)]
+    public async Task Basic(string bbsServer, bool useSshForArchiveDownload, bool useAzureForArchiveUpload, bool useGithubStorage)
     {
         var bbsProjectKey = $"E2E-{TestHelper.GetOsName().ToUpper()}";
         var githubTargetOrg = $"octoshift-e2e-bbs-{TestHelper.GetOsName()}";
@@ -119,7 +120,7 @@ public sealed class BbsToGithub : IDisposable
             _tokens.Add("AWS_ACCESS_KEY_ID", Environment.GetEnvironmentVariable("AWS_ACCESS_KEY_ID"));
             _tokens.Add("AWS_SECRET_ACCESS_KEY", Environment.GetEnvironmentVariable("AWS_SECRET_ACCESS_KEY"));
             var awsBucketName = Environment.GetEnvironmentVariable("AWS_BUCKET_NAME");
-            archiveUploadOptions = $" --aws-bucket-name {awsBucketName} --aws-region {AWS_REGION}";
+            archiveUploadOptions = $" --aws-bucket-name {awsBucketName} --aws-region {AWS_REGION} --use-github-storage {useGithubStorage}";
         }
 
         await _targetHelper.RunBbsCliMigration(

--- a/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
@@ -63,7 +63,10 @@ public sealed class GhesToGithub : IDisposable
         _targetHelper = new TestHelper(_output, _targetGithubApi, _targetGithubClient, _blobServiceClient);
     }
 
-    public async Task Basic()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Basic(bool useGithubStorage)
     {
         var githubSourceOrg = $"e2e-testing-{TestHelper.GetOsName()}";
         var githubTargetOrg = $"octoshift-e2e-ghes-{TestHelper.GetOsName()}";
@@ -84,7 +87,7 @@ public sealed class GhesToGithub : IDisposable
         });
 
         await _targetHelper.RunGeiCliMigration(
-            $"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --ghes-api-url {GHES_API_URL} --download-migration-logs", _tokens);
+            $"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --ghes-api-url {GHES_API_URL} --use-github-storage {useGithubStorage} --download-migration-logs", _tokens);
 
         _targetHelper.AssertNoErrorInLogs(_startTime);
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
@@ -20,6 +20,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.GenerateScript
         private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
         private readonly Mock<IVersionProvider> _mockVersionProvider = new();
         private readonly Mock<GhesVersionChecker> _mockGhesVersionCheckerService = TestHelpers.CreateMock<GhesVersionChecker>();
+        private readonly Mock<FileSystemProvider> _mockFileSystemProvider = TestHelpers.CreateMock<FileSystemProvider>();
 
         private readonly GenerateScriptCommandHandler _handler;
 
@@ -36,6 +37,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.GenerateScript
                 _mockOctoLogger.Object,
                 _mockGithubApi.Object,
                 _mockVersionProvider.Object,
+                _mockFileSystemProvider.Object,
                 _mockGhesVersionCheckerService.Object
                 )
             {

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommand.cs
@@ -123,6 +123,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
             var ghesVersionCheckerFactory = sp.GetRequiredService<GhesVersionCheckerFactory>();
 
             var sourceGithubApiFactory = sp.GetRequiredService<ISourceGithubApiFactory>();
+            var fileSystemProvider = sp.GetRequiredService<FileSystemProvider>();
 
             var sourceGithubApi = args.GhesApiUrl.HasValue() && args.NoSslVerify ?
                 sourceGithubApiFactory.CreateClientNoSsl(args.GhesApiUrl, args.GithubSourcePat) :
@@ -130,7 +131,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
 
             var ghesVersionChecker = ghesVersionCheckerFactory.Create(sourceGithubApi);
 
-            return new GenerateScriptCommandHandler(log, sourceGithubApi, versionProvider, ghesVersionChecker);
+            return new GenerateScriptCommandHandler(log, sourceGithubApi, versionProvider, fileSystemProvider, ghesVersionChecker);
         }
     }
 }

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommand.cs
@@ -36,6 +36,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
             AddOption(GithubSourcePat);
             AddOption(Verbose);
             AddOption(KeepArchive);
+            AddOption(UseGithubStorage);
         }
         public Option<string> GithubSourceOrg { get; } = new("--github-source-org")
         {
@@ -98,6 +99,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
         public Option<string> TargetApiUrl { get; } = new("--target-api-url")
         {
             Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com"
+        };
+
+        public Option<bool> UseGithubStorage { get; } = new("--use-github-storage")
+        {
+            Description = "Enables multipart uploads to a GitHub owned storage for use during migration"
         };
 
         public override GenerateScriptCommandHandler BuildHandler(GenerateScriptCommandArgs args, IServiceProvider sp)

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandArgs.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandArgs.cs
@@ -23,6 +23,9 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
         public string GithubSourcePat { get; set; }
         public bool KeepArchive { get; set; }
         public string TargetApiUrl { get; set; }
+        public bool UseGithubStorage { get; set; }
+        public string ArchiveUrl { get; set; }
+        public string ArchivePath { get; set; }
 
         public override void Validate(OctoLogger log)
         {
@@ -45,6 +48,11 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
                 {
                     throw new OctoshiftCliException("--ghes-api-url is invalid. Please check URL before trying again.");
                 }
+            }
+
+            if (UseGithubStorage && AwsBucketName.HasValue())
+            {
+                throw new OctoshiftCliException("The --use-github-storage flag was provided with an AWS S3 Bucket name. Archive cannot be uploaded to both locations.");
             }
         }
     }


### PR DESCRIPTION
Closes https://github.ghe.com/github/octoshift/issues/9592!

In order to add Integration tests for the Github owned storage work we needed to add `--use-github-storage` to the GenerateScript command. 

1. Add `--use-github-storage` to the GenerateScript command 
2. Update integration tests to use `--use-github-storage` command


<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->