### PR TITLE
Remove useGithubStorage from GHES version checker method

### DIFF
--- a/src/OctoshiftCLI.Tests/Octoshift/Services/ArchiveUploadersTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/ArchiveUploadersTests.cs
@@ -7,8 +7,9 @@ using FluentAssertions;
 using Moq;
 using OctoshiftCLI.Extensions;
 using OctoshiftCLI.Services;
-using OctoshiftCLI.Tests;
 using Xunit;
+
+namespace OctoshiftCLI.Tests.Octoshift.Services;
 
 public class ArchiveUploaderTests
 {

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
@@ -222,7 +222,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.GenerateScript
             _mockGithubApi
                 .Setup(m => m.GetRepos(SOURCE_ORG))
                 .ReturnsAsync(new[] { (REPO, "private") });
-            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl, false)).ReturnsAsync(true);
+            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(true);
 
             var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{REPO}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{REPO}\" --ghes-api-url \"{ghesApiUrl}\" --target-repo-visibility private }}";
 
@@ -333,7 +333,7 @@ if ($Failed -ne 0) {
                 .ReturnsAsync(new[] { (REPO, "private") });
 
             _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
-            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl, false)).ReturnsAsync(true);
+            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(true);
 
             var expected = new StringBuilder();
             expected.AppendLine("#!/usr/bin/env pwsh");
@@ -502,7 +502,7 @@ if ($Failed -ne 0) {
                 .ReturnsAsync(new[] { (REPO, "private") });
 
             _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
-            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl, false)).ReturnsAsync(true);
+            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(true);
 
             var expected = new StringBuilder();
             expected.AppendLine("#!/usr/bin/env pwsh");
@@ -588,7 +588,7 @@ if ($Failed -ne 0) {
                 .ReturnsAsync(new[] { (REPO, "private") });
 
             _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
-            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl, false)).ReturnsAsync(true);
+            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(true);
 
             var expected = new StringBuilder();
             expected.AppendLine("#!/usr/bin/env pwsh");
@@ -673,7 +673,7 @@ if ($Failed -ne 0) {
                 .ReturnsAsync(new[] { (REPO, "private") });
 
             _mockVersionProvider.Setup(m => m.GetCurrentVersion()).Returns("1.1.1");
-            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl, false)).ReturnsAsync(false);
+            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(false);
 
             var expected = new StringBuilder();
             expected.AppendLine("#!/usr/bin/env pwsh");
@@ -909,7 +909,7 @@ if ($Failed -ne 0) {
             _mockGithubApi
                 .Setup(m => m.GetRepos(SOURCE_ORG))
                 .ReturnsAsync(new[] { (REPO, "private") });
-            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl, false)).ReturnsAsync(true);
+            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(true);
 
             var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{REPO}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{REPO}\" --ghes-api-url \"{ghesApiUrl}\" --aws-bucket-name \"{AWS_BUCKET_NAME}\" --aws-region \"{AWS_REGION}\" --target-repo-visibility private }}";
 
@@ -941,7 +941,7 @@ if ($Failed -ne 0) {
             _mockGithubApi
                 .Setup(m => m.GetRepos(SOURCE_ORG))
                 .ReturnsAsync(new[] { (REPO, "private") });
-            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl, false)).ReturnsAsync(true);
+            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(true);
 
             var expected = $"Exec {{ gh gei migrate-repo --github-source-org \"{SOURCE_ORG}\" --source-repo \"{REPO}\" --github-target-org \"{TARGET_ORG}\" --target-repo \"{REPO}\" --ghes-api-url \"{ghesApiUrl}\" --aws-bucket-name \"{AWS_BUCKET_NAME}\" --aws-region \"{AWS_REGION}\" --keep-archive --target-repo-visibility private }}";
 
@@ -974,7 +974,7 @@ if ($Failed -ne 0) {
             _mockGithubApi
                 .Setup(m => m.GetRepos(SOURCE_ORG))
                 .ReturnsAsync(new[] { (REPO, "private") });
-            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl, false)).ReturnsAsync(true);
+            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(true);
 
             var expected = @"
 if (-not $env:GH_PAT) {
@@ -1019,7 +1019,7 @@ if (-not $env:AZURE_STORAGE_CONNECTION_STRING) {
             _mockGithubApi
                 .Setup(m => m.GetRepos(SOURCE_ORG))
                 .ReturnsAsync(new[] { (REPO, "private") });
-            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl, false)).ReturnsAsync(true);
+            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(true);
 
             var expected = @"
 if (-not $env:GH_PAT) {
@@ -1072,7 +1072,7 @@ if (-not $env:AWS_SECRET_ACCESS_KEY) {
             _mockGithubApi
                 .Setup(m => m.GetRepos(SOURCE_ORG))
                 .ReturnsAsync(new[] { (REPO, "private") });
-            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl, false)).ReturnsAsync(true);
+            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(true);
 
             var expected = @"
 if (-not $env:AZURE_STORAGE_CONNECTION_STRING) {
@@ -1173,7 +1173,7 @@ if (-not $env:AZURE_STORAGE_CONNECTION_STRING) {
             _mockGithubApi
                 .Setup(m => m.GetRepos(SOURCE_ORG))
                 .ReturnsAsync(new[] { (REPO, "private") });
-            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl, false)).ReturnsAsync(false);
+            _mockGhesVersionCheckerService.Setup(m => m.AreBlobCredentialsRequired(ghesApiUrl)).ReturnsAsync(false);
 
             var expected = @"
 if (-not $env:GH_PAT) {

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -1712,7 +1712,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
                 .Setup(x => x.UploadArchiveToGithubStorage(githubOrgDatabaseId, It.Is<string>(a => a.EndsWith("metadata_archive.tar.gz")), metaContentStream).Result)
                 .Returns(uploadedMetadataArchiveUrl);
 
-            Console.WriteLine($"MigrationSourceId: {migrationSourceId}, MigrationId: {migrationId}");
 
             var args = new MigrateRepoCommandArgs
             {

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -67,7 +67,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
         {
             // Arrange
             _mockTargetGithubApi.Setup(x => x.DoesRepoExist(TARGET_ORG, TARGET_REPO)).ReturnsAsync(true);
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             // Act
             var args = new MigrateRepoCommandArgs
@@ -306,7 +306,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken(It.IsAny<bool>())).Returns(sourceGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
 
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             var args = new MigrateRepoCommandArgs
             {
@@ -365,7 +365,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
                 .Setup(m => m.OpenRead(metadataArchiveDownloadFilePath))
                 .Returns(metaContentStream);
 
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, true)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
 
@@ -482,7 +482,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken(It.IsAny<bool>())).Returns(sourceGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
 
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             var args = new MigrateRepoCommandArgs
             {
@@ -635,7 +635,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.AzureStorageConnectionString(It.IsAny<bool>())).Returns(azureConnectionStringEnv);
 
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             var args = new MigrateRepoCommandArgs
             {
@@ -699,7 +699,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken(It.IsAny<bool>())).Returns(sourceGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
 
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             var args = new MigrateRepoCommandArgs
             {
@@ -762,7 +762,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken(It.IsAny<bool>())).Returns(sourceGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
 
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(false);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(false);
 
             var args = new MigrateRepoCommandArgs
             {
@@ -789,7 +789,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             _mockSourceGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false, false).Result).Returns(metadataArchiveId);
             _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Failed);
 
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             await FluentActions
                 .Invoking(async () => await _handler.Handle(new MigrateRepoCommandArgs
@@ -881,7 +881,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken(It.IsAny<bool>())).Returns(sourceGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
 
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             var args = new MigrateRepoCommandArgs
             {
@@ -1065,7 +1065,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
 
             _mockAzureApi.Setup(x => x.UploadToBlob(It.IsAny<string>(), It.IsAny<Stream>()).Result).Returns(new Uri("https://example.com/resource"));
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             // Act
             var args = new MigrateRepoCommandArgs
@@ -1329,7 +1329,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
 
             _mockAwsApi.Setup(m => m.UploadToBucket(awsBucketName, It.IsAny<Stream>(), It.IsAny<string>())).ReturnsAsync(archiveUrl);
 
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             var handler = new MigrateRepoCommandHandler(
                 _mockOctoLogger.Object,
@@ -1368,7 +1368,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
         [Fact]
         public async Task Ghes_With_Both_Azure_Storage_Connection_String_And_Aws_Bucket_Name_Throws()
         {
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
             {
@@ -1387,7 +1387,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
         [Fact]
         public async Task Ghes_When_Aws_Bucket_Name_Is_Provided_But_No_Aws_Access_Key_Id_Throws()
         {
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
             {
@@ -1407,7 +1407,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
         [Fact]
         public async Task Ghes_When_Aws_Bucket_Name_Is_Provided_But_No_Aws_Secret_Key_Throws()
         {
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
             {
@@ -1427,7 +1427,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
         [Fact]
         public async Task Ghes_When_Aws_Bucket_Name_Is_Provided_But_No_Aws_Region_Throws()
         {
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
             {
@@ -1449,7 +1449,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
         [Fact]
         public async Task Ghes_When_Aws_Bucket_Name_Not_Provided_But_Aws_Access_Key_Provided()
         {
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
             {
@@ -1469,7 +1469,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
         [Fact]
         public async Task Ghes_When_Aws_Bucket_Name_Not_Provided_But_Aws_Secret_Key_Provided()
         {
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
             {
@@ -1489,7 +1489,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
         [Fact]
         public async Task Ghes_When_Aws_Bucket_Name_Not_Provided_But_Aws_Session_Token_Provided()
         {
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
             {
@@ -1509,7 +1509,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
         [Fact]
         public async Task Ghes_When_Aws_Bucket_Name_Not_Provided_But_Aws_Region_Provided()
         {
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
             {
@@ -1581,7 +1581,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             _mockEnvironmentVariableProvider.Setup(m => m.SourceGithubPersonalAccessToken(It.IsAny<bool>())).Returns(sourceGithubPat);
             _mockEnvironmentVariableProvider.Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>())).Returns(targetGithubPat);
 
-            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL, false)).ReturnsAsync(true);
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(true);
 
             var args = new MigrateRepoCommandArgs
             {

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -1632,5 +1632,107 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
                 targetRepoVisibility,
                 It.IsAny<bool>()));
         }
+        [Fact]
+        public async Task GenerateAndUploadArchive_UsesGithubStorage_When_UseGithubStorageIsTrue_And_BlobCredentialsRequiredIsFalse()
+        {
+            var githubOrgId = Guid.NewGuid().ToString();
+            var githubOrgDatabaseId = Guid.NewGuid().ToString();
+            var migrationSourceId = Guid.NewGuid().ToString();
+            var sourceGithubPat = Guid.NewGuid().ToString();
+            var targetGithubPat = Guid.NewGuid().ToString();
+            var githubRepoUrl = $"https://myghes/{SOURCE_ORG}/{SOURCE_REPO}";
+            var migrationId = "valid-migration-id";  // Ensure a valid migration ID is returned
+            var gitArchiveId = 1;
+            var metadataArchiveId = 2;
+            var gitArchiveUrl = $"https://example.com/{gitArchiveId}";
+            var metadataArchiveUrl = $"https://example.com/{metadataArchiveId}";
+            var uploadedGitArchiveUrl = "gei://archive/1";
+            var uploadedMetadataArchiveUrl = "gei://archive/2";
+            var gitArchiveFilePath = "./gitdata_archive";
+            var metadataArchiveFilePath = "./metadata_archive";
+            var gitArchiveDownloadFilePath = "git_archive_downaloded.tmp";
+            var metadataArchiveDownloadFilePath = "metadata_archive_downloaded.tmp";
+
+            File.WriteAllText(gitArchiveFilePath, "I am git archive");
+            File.WriteAllText(metadataArchiveFilePath, "I am metadata archive");
+
+            using var gitContentStream = File.OpenRead(gitArchiveFilePath);
+            using var metaContentStream = File.OpenRead(metadataArchiveFilePath);
+
+            _mockFileSystemProvider
+                .SetupSequence(m => m.GetTempFileName())
+                .Returns(gitArchiveDownloadFilePath)
+                .Returns(metadataArchiveDownloadFilePath);
+
+            _mockFileSystemProvider
+                .Setup(m => m.OpenRead(gitArchiveDownloadFilePath))
+                .Returns(gitContentStream);
+
+            _mockFileSystemProvider
+                .Setup(m => m.OpenRead(metadataArchiveDownloadFilePath))
+                .Returns(metaContentStream);
+
+            _mockGhesVersionChecker.Setup(m => m.AreBlobCredentialsRequired(GHES_API_URL)).ReturnsAsync(false);
+
+            _mockTargetGithubApi.Setup(x => x.DoesOrgExist(TARGET_ORG).Result).Returns(true);
+
+            _mockTargetGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(githubOrgId);
+            _mockTargetGithubApi.Setup(x => x.GetOrganizationDatabaseId(TARGET_ORG).Result).Returns(githubOrgDatabaseId);
+            _mockTargetGithubApi.Setup(x => x.CreateGhecMigrationSource(githubOrgId).Result).Returns(migrationSourceId);
+
+            _mockTargetGithubApi.Setup(x => x.StartMigration(
+                migrationSourceId,
+                githubRepoUrl,
+                githubOrgId,
+                TARGET_REPO,
+                sourceGithubPat,
+                targetGithubPat,
+                uploadedGitArchiveUrl,
+                uploadedMetadataArchiveUrl,
+                false,
+                null,
+                false).Result)
+                .Returns(migrationId);
+
+            _mockTargetGithubApi.Setup(x => x.GetMigration(migrationId).Result)
+                .Returns((State: RepositoryMigrationStatus.Succeeded, TARGET_REPO, 0, null, null));
+
+            _mockSourceGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
+            _mockSourceGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false, false).Result).Returns(metadataArchiveId);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
+            _mockSourceGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
+
+            _mockTargetGithubApi
+                .Setup(x => x.UploadArchiveToGithubStorage(githubOrgDatabaseId, It.Is<string>(a => a.EndsWith("git_archive.tar.gz")), gitContentStream).Result)
+                .Returns(uploadedGitArchiveUrl);
+
+            _mockTargetGithubApi
+                .Setup(x => x.UploadArchiveToGithubStorage(githubOrgDatabaseId, It.Is<string>(a => a.EndsWith("metadata_archive.tar.gz")), metaContentStream).Result)
+                .Returns(uploadedMetadataArchiveUrl);
+
+            Console.WriteLine($"MigrationSourceId: {migrationSourceId}, MigrationId: {migrationId}");
+
+            var args = new MigrateRepoCommandArgs
+            {
+                GithubSourceOrg = SOURCE_ORG,
+                SourceRepo = SOURCE_REPO,
+                GithubTargetOrg = TARGET_ORG,
+                TargetRepo = TARGET_REPO,
+                GithubSourcePat = sourceGithubPat,
+                GithubTargetPat = targetGithubPat,
+                TargetApiUrl = TARGET_API_URL,
+                GhesApiUrl = GHES_API_URL,
+                UseGithubStorage = true,
+            };
+
+            await _handler.Handle(args);
+
+            _mockTargetGithubApi.Verify(x => x.GetMigration(migrationId));
+            _mockFileSystemProvider.Verify(x => x.DeleteIfExists(gitArchiveDownloadFilePath), Times.Once);
+            _mockFileSystemProvider.Verify(x => x.DeleteIfExists(metadataArchiveDownloadFilePath), Times.Once);
+        }
+
     }
 }

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -138,7 +138,6 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
                 content.AppendLine(VALIDATE_AWS_ACCESS_KEY_ID);
                 content.AppendLine(VALIDATE_AWS_SECRET_ACCESS_KEY);
             }
-            else if (!useGithubStorage)
             {
                 content.AppendLine(VALIDATE_AZURE_STORAGE_CONNECTION_STRING);
             }

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -101,6 +101,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
                 content.AppendLine(VALIDATE_AWS_ACCESS_KEY_ID);
                 content.AppendLine(VALIDATE_AWS_SECRET_ACCESS_KEY);
             }
+            else
             {
                 content.AppendLine(VALIDATE_AZURE_STORAGE_CONNECTION_STRING);
             }
@@ -138,6 +139,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
                 content.AppendLine(VALIDATE_AWS_ACCESS_KEY_ID);
                 content.AppendLine(VALIDATE_AWS_SECRET_ACCESS_KEY);
             }
+            else
             {
                 content.AppendLine(VALIDATE_AZURE_STORAGE_CONNECTION_STRING);
             }

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -94,7 +94,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
 
         content.AppendLine(VALIDATE_GH_PAT);
 
-        if (await _ghesVersionChecker.AreBlobCredentialsRequired(ghesApiUrl))
+        if (!useGithubStorage && await _ghesVersionChecker.AreBlobCredentialsRequired(ghesApiUrl))
         {
             if (awsBucketName.HasValue() || awsRegion.HasValue())
             {
@@ -132,7 +132,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         content.AppendLine(EXEC_AND_GET_MIGRATION_ID_FUNCTION_BLOCK);
 
         content.AppendLine(VALIDATE_GH_PAT);
-        if (await _ghesVersionChecker.AreBlobCredentialsRequired(ghesApiUrl))
+        if (!useGithubStorage && await _ghesVersionChecker.AreBlobCredentialsRequired(ghesApiUrl))
         {
             if (awsBucketName.HasValue() || awsRegion.HasValue())
             {

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -94,7 +94,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
 
         content.AppendLine(VALIDATE_GH_PAT);
 
-        if (await _ghesVersionChecker.AreBlobCredentialsRequired(ghesApiUrl, useGithubStorage))
+        if (await _ghesVersionChecker.AreBlobCredentialsRequired(ghesApiUrl))
         {
             if (awsBucketName.HasValue() || awsRegion.HasValue())
             {
@@ -132,7 +132,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         content.AppendLine(EXEC_AND_GET_MIGRATION_ID_FUNCTION_BLOCK);
 
         content.AppendLine(VALIDATE_GH_PAT);
-        if (await _ghesVersionChecker.AreBlobCredentialsRequired(ghesApiUrl, useGithubStorage))
+        if (await _ghesVersionChecker.AreBlobCredentialsRequired(ghesApiUrl))
         {
             if (awsBucketName.HasValue() || awsRegion.HasValue())
             {

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -101,7 +101,6 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
                 content.AppendLine(VALIDATE_AWS_ACCESS_KEY_ID);
                 content.AppendLine(VALIDATE_AWS_SECRET_ACCESS_KEY);
             }
-            else if (!useGithubStorage)
             {
                 content.AppendLine(VALIDATE_AZURE_STORAGE_CONNECTION_STRING);
             }

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -93,14 +93,15 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         content.AppendLine(EXEC_FUNCTION_BLOCK);
 
         content.AppendLine(VALIDATE_GH_PAT);
-        if (await _ghesVersionChecker.AreBlobCredentialsRequired(ghesApiUrl))
+
+        if (await _ghesVersionChecker.AreBlobCredentialsRequired(ghesApiUrl, useGithubStorage))
         {
             if (awsBucketName.HasValue() || awsRegion.HasValue())
             {
                 content.AppendLine(VALIDATE_AWS_ACCESS_KEY_ID);
                 content.AppendLine(VALIDATE_AWS_SECRET_ACCESS_KEY);
             }
-            else
+            else if (!useGithubStorage)
             {
                 content.AppendLine(VALIDATE_AZURE_STORAGE_CONNECTION_STRING);
             }
@@ -131,14 +132,14 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         content.AppendLine(EXEC_AND_GET_MIGRATION_ID_FUNCTION_BLOCK);
 
         content.AppendLine(VALIDATE_GH_PAT);
-        if (await _ghesVersionChecker.AreBlobCredentialsRequired(ghesApiUrl))
+        if (await _ghesVersionChecker.AreBlobCredentialsRequired(ghesApiUrl, useGithubStorage))
         {
             if (awsBucketName.HasValue() || awsRegion.HasValue())
             {
                 content.AppendLine(VALIDATE_AWS_ACCESS_KEY_ID);
                 content.AppendLine(VALIDATE_AWS_SECRET_ACCESS_KEY);
             }
-            else
+            else if (!useGithubStorage)
             {
                 content.AppendLine(VALIDATE_AZURE_STORAGE_CONNECTION_STRING);
             }

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -221,7 +221,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         var (gitArchiveUrl, metadataArchiveUrl, gitArchiveId, metadataArchiveId) = await _retryPolicy.Retry(
             async () => await GenerateArchive(githubSourceOrg, sourceRepo, skipReleases, lockSourceRepo));
 
-        if (!blobCredentialsRequired)
+        if (!useGithubStorage && !blobCredentialsRequired)
         {
             return (gitArchiveUrl, metadataArchiveUrl);
         }

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -116,7 +116,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
               args.UseGithubStorage
             );
 
-            if (args.UseGithubStorage && blobCredentialsRequired)
+            if (args.UseGithubStorage || blobCredentialsRequired)
             {
                 _log.LogInformation("Archives uploaded to blob storage, now starting migration...");
             }

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -64,7 +64,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         _log.LogInformation("Migrating Repo...");
 
-        var blobCredentialsRequired = await _ghesVersionChecker.AreBlobCredentialsRequired(args.GhesApiUrl);
+        var blobCredentialsRequired = !args.UseGithubStorage || (await _ghesVersionChecker.AreBlobCredentialsRequired(args.GhesApiUrl));
 
         if (args.GhesApiUrl.HasValue())
         {

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -116,7 +116,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
               args.UseGithubStorage
             );
 
-            if (blobCredentialsRequired)
+            if (args.UseGithubStorage && blobCredentialsRequired)
             {
                 _log.LogInformation("Archives uploaded to blob storage, now starting migration...");
             }

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -396,7 +396,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
             if (args.UseGithubStorage)
             {
-                _log.LogWarning("Provding the --use-github-storage flag will supersede any credentials you have configured in your GitHub Enterprise Server (GHES) Management Console.");
+                _log.LogWarning("Providing the --use-github-storage flag will supersede any credentials you have configured in your GitHub Enterprise Server (GHES) Management Console.");
             }
 
             if (args.KeepArchive)

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -64,7 +64,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         _log.LogInformation("Migrating Repo...");
 
-        var blobCredentialsRequired = await _ghesVersionChecker.AreBlobCredentialsRequired(args.GhesApiUrl, args.UseGithubStorage);
+        var blobCredentialsRequired = await _ghesVersionChecker.AreBlobCredentialsRequired(args.GhesApiUrl);
 
         if (args.GhesApiUrl.HasValue())
         {

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -396,7 +396,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
             if (args.UseGithubStorage)
             {
-                _log.LogWarning("Ignoring --use-github-storage flag because you are running GitHub Enterprise Server (GHES) 3.8.0 or later. The blob storage credentials configured in your GHES Management Console will be used instead.");
+                _log.LogWarning("Provding the --use-github-storage flag will supersede any credentials you have configured in your GitHub Enterprise Server (GHES) Management Console.");
             }
 
             if (args.KeepArchive)

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -64,7 +64,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         _log.LogInformation("Migrating Repo...");
 
-        var blobCredentialsRequired = !args.UseGithubStorage || (await _ghesVersionChecker.AreBlobCredentialsRequired(args.GhesApiUrl));
+        var blobCredentialsRequired = await _ghesVersionChecker.AreBlobCredentialsRequired(args.GhesApiUrl);
 
         if (args.GhesApiUrl.HasValue())
         {

--- a/src/gei/Services/GhesVersionChecker.cs
+++ b/src/gei/Services/GhesVersionChecker.cs
@@ -16,14 +16,10 @@ public class GhesVersionChecker
         _githubApi = githubApi;
     }
 
-    public virtual async Task<bool> AreBlobCredentialsRequired(string ghesApiUrl, bool useGithubStorage = false)
+    public virtual async Task<bool> AreBlobCredentialsRequired(string ghesApiUrl)
     {
         var blobCredentialsRequired = false;
 
-        if (useGithubStorage)
-        {
-            return true;
-        }
 
         if (ghesApiUrl.HasValue())
         {


### PR DESCRIPTION
Closes https://github.ghe.com/github/octoshift/issues/9649!

This pull request simplifies the method calls to AreBlobCredentialsRequired by removing the boolean parameter that checks for gitHubOwnedStorage.

While this produces the correct result, it is confusing for a reader. This PR refactors out that logic and adds the checks in the correct spots.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->