### PR TITLE
catches exception when Target is not a member of the organization

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- catches exception when Target is not a member of the organization and the `--skip-invitation` flag is enabled

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -878,6 +879,17 @@ public class GithubApi
         catch (OctoshiftCliException ex) when (ex.Message.Contains("Field 'reattributeMannequinToUser' doesn't exist on type 'Mutation'"))
         {
             throw new OctoshiftCliException($"Reclaiming mannequins with the--skip - invitation flag is not enabled for your GitHub organization.For more details, contact GitHub Support.", ex);
+        }
+        catch (OctoshiftCliException ex) when (ex.Message.Contains("Target must be a member"))
+        {
+            var result = new ReattributeMannequinToUserResult
+            {
+                Errors = new Collection<ErrorData>
+            {
+              new ErrorData { Message = ex.Message }
+            }
+            };
+            return result;
         }
     }
 

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -884,10 +883,10 @@ public class GithubApi
         {
             var result = new ReattributeMannequinToUserResult
             {
-                Errors = new Collection<ErrorData>
-            {
+                Errors =
+            [
               new ErrorData { Message = ex.Message }
-            }
+            ]
             };
             return result;
         }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

When Skipping invitations to reclaim mannequin and the target was not a member of the Org, the process will simply not return WHO the member was not part of the org providing no details on who potentially needs to be added to the org, and it will fail-fast and stopped processing any further users.

![image](https://github.com/user-attachments/assets/a4d4025f-2324-4f38-91b2-4cca094d7a4e)

I've added a catch Exception for then "Target must be a member" so that the [`HandleReclaimationResult`](https://github.com/github/gh-gei/blob/7dda41fa5b582fbdea6a0d6e8ce519f8bb83a943/src/Octoshift/Services/ReclaimService.cs#L270) will log that and continue processing accordingly.

Now the `HandleReclaimationResult` will output this:

```
[2024-11-25 22:28:54] [WARNING] Failed to reattribute content belonging to mannequin <user> (<user-id>) to <targe-user-d>: Target must be a member of the <targe-org> organization
```

Enhancements to error handling:

* [`src/Octoshift/Services/GithubApi.cs`](diffhunk://#diff-39fcbf0d595bae69dbe47f142c61ca32212a097d22eaa575b4bc07ba0e4cd466R883-R893): Added a new `catch` block to handle `OctoshiftCliException` with a specific message and return a structured error result.

Code improvements:

* [`src/Octoshift/Services/GithubApi.cs`](diffhunk://#diff-39fcbf0d595bae69dbe47f142c61ca32212a097d22eaa575b4bc07ba0e4cd466R3): Imported the `System.Collections.ObjectModel` namespace to use the `Collection` class.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate) 
- [x] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->