### PR TITLE
Update net6.0 to net8.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
       with:
         name: Code Coverage Report
         path: code-coverage-results.md
-    
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       if: matrix.runner-os == 'ubuntu-latest'
@@ -161,7 +161,7 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         global-json-file: global.json
-  
+
 
     - name: Download Binaries
       uses: actions/download-artifact@v4
@@ -214,14 +214,14 @@ jobs:
       working-directory: ./gh-gei
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
+
     - name: Install gh-ado2gh extension
       run: gh extension install .
       shell: pwsh
       working-directory: ./gh-ado2gh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
+
     - name: Install gh-bbs2gh extension
       run: gh extension install .
       shell: pwsh
@@ -230,7 +230,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Integration Test
-      env: 
+      env:
         ADO_PAT: ${{ secrets.ADO_PAT }}
         GHEC_PAT: ${{ secrets.GHEC_PAT }}
         GHES_PAT: ${{ secrets.GHES_PAT }}
@@ -249,7 +249,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
-        LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:${{ github.workspace }}/src/OctoshiftCLI.IntegrationTests/bin/Debug/net6.0/runtimes/ubuntu.18.04-x64/native'
+        LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:${{ github.workspace }}/src/OctoshiftCLI.IntegrationTests/bin/Debug/net8.0/runtimes/ubuntu.18.04-x64/native'
       run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --filter "${{ matrix.source-vcs }}ToGithub" --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
 
     - name: Publish Integration Test Results
@@ -259,7 +259,7 @@ jobs:
         files: "**/*-tests.xml"
         check_name: "Integration Test Results - ${{ matrix.source-vcs }}"
         comment_mode: off
-    
+
     - name: Upload test logs
       uses: actions/upload-artifact@v4
       if: always()
@@ -330,7 +330,7 @@ jobs:
           ./dist/win-x86/gei-windows-386.exe
           ./dist/linux-x64/gei-linux-amd64
           ./dist/osx-x64/gei-darwin-amd64
-    
+
     - name: Create gh-ado2gh Release
       uses: softprops/action-gh-release@v2
       with:
@@ -361,13 +361,13 @@ jobs:
         $TAG_NAME = "${{ github.ref }}".Substring(10)
         Get-Content ./RELEASENOTES.md | Out-File -FilePath ./releasenotes/$TAG_NAME.md
         "" | Out-File ./RELEASENOTES.md
-        
+
     - name: Update LATEST-VERSION.TXT
       shell: pwsh
       run: |
         $TAG_NAME = "${{ github.ref }}".Substring(10)
         $TAG_NAME | Out-File ./LATEST-VERSION.txt
-        
+
     - name: Commit Release Notes and Version
       uses: stefanzweifel/git-auto-commit-action@v5
       with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -74,7 +74,7 @@ jobs:
       with:
         ref: 'refs/pull/${{ github.event.inputs.pr_number }}/merge'
         fetch-depth: 0
-        
+
     - name: Get PR Commit
       if: always() && matrix.runner-os == 'ubuntu-latest'
       run: |
@@ -86,7 +86,7 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         global-json-file: global.json
-        
+
     - name: Download Binaries
       uses: actions/download-artifact@v4
       with:
@@ -138,14 +138,14 @@ jobs:
       working-directory: ./gh-gei
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
+
     - name: Install gh-ado2gh extension
       run: gh extension install .
       shell: pwsh
       working-directory: ./gh-ado2gh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
+
     - name: Install gh-bbs2gh extension
       run: gh extension install .
       shell: pwsh
@@ -154,7 +154,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Integration Test
-      env: 
+      env:
         ADO_PAT: ${{ secrets.ADO_PAT }}
         GHEC_PAT: ${{ secrets.GHEC_PAT }}
         GHES_PAT: ${{ secrets.GHES_PAT }}
@@ -174,7 +174,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
         GEI_DEBUG_MODE: 'true'
-        LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:${{ github.workspace }}/src/OctoshiftCLI.IntegrationTests/bin/Debug/net6.0/runtimes/ubuntu.18.04-x64/native'
+        LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:${{ github.workspace }}/src/OctoshiftCLI.IntegrationTests/bin/Debug/net8.0/runtimes/ubuntu.18.04-x64/native'
       run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --filter "${{ matrix.source-vcs }}ToGithub" --logger:"junit;LogFilePath=integration-tests.xml" /p:VersionPrefix=9.9
 
     - name: Publish Integration Test Results
@@ -185,7 +185,7 @@ jobs:
         check_name: "Integration Test Results - ${{ matrix.source-vcs }}"
         comment_mode: off
         commit: ${{ env.PR_SHA }}
-    
+
     - name: Upload test logs
       uses: actions/upload-artifact@v4
       if: always()

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/gei/bin/Debug/net6.0/gei.dll",
+            "program": "${workspaceFolder}/src/gei/bin/Debug/net8.0/gei.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/gei",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
@@ -26,7 +26,7 @@
             "request": "launch",
             "preLaunchTask": "build-ado2gh",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/ado2gh/bin/Debug/net6.0/ado2gh.dll",
+            "program": "${workspaceFolder}/src/ado2gh/bin/Debug/net8.0/ado2gh.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/ado2gh",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
@@ -47,7 +47,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/bbs2gh/bin/Debug/net6.0/bbs2gh.dll",
+            "program": "${workspaceFolder}/src/bbs2gh/bin/Debug/net8.0/bbs2gh.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/bbs2gh",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Use the [Discussions](https://github.com/github/gh-gei/discussions) tab in this 
 
 All work done by the maintainers of this repo is tracked in this repo using Issues. We have a hierarchical backlog with Epics at the top, broken down into Batches then broken down to Tasks (epic/batch/task is indicated via labels on the issues). You can see an example Epic and navigate down from there [here](https://github.com/github/gh-gei/issues/101).
 
-## Running tests 
+## Running tests
 
 ### In the terminal
 If you want to run tests selectively in the terminal, you can use dotnet test with `--filter` option.
@@ -36,31 +36,31 @@ Here are some examples:
 dotnet test --filter AdoApiTests.GetUserId_Should_Return_UserId
 ```
 
-### Debugger 
+### Debugger
 
-If you are using VS code, you can install the [C# dev kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) which will add the testing extension. 
-- Press the play to run the entire test suite, or navigate to the specific test you would like to run. 
-- If you set a breakpoint within your code and press the play button with the bug next to it you will be able to inspect your code in more detial. 
+If you are using VS code, you can install the [C# dev kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) which will add the testing extension.
+- Press the play to run the entire test suite, or navigate to the specific test you would like to run.
+- If you set a breakpoint within your code and press the play button with the bug next to it you will be able to inspect your code in more detial.
 
-### Useful links 
+### Useful links
 1. [Dotnet test commands](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test#filter-option-details)
 2. [Run selective unit tests](https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=mstest)
 3. [C# dev kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit)
- 
 
 
-## Debugging code 
 
-There are two ways to debug code within VS code. 
+## Debugging code
+
+There are two ways to debug code within VS code.
 
 ### Run GH-GEI command locally
-Run the following commands in your terminal depending on the provider you are looking to run the commands for. 
+Run the following commands in your terminal depending on the provider you are looking to run the commands for.
 
-Azure DevOps: 
+Azure DevOps:
 - Generic: `dotnet run --project src/ado2gh/ado2gh.csproj -- [command]`
 - Example: `dotnet run --project src/ado2gh/ado2gh.csproj -- migrate-repo --help`
 
-Bitbucket Server: 
+Bitbucket Server:
 - Generic: `dotnet run --project src/bbs2gh/bbs2gh.csproj -- [command]`
 - Example: `dotnet run --project src/bbs2gh/bbs2gh.csproj -- migrate-repo --help`
 
@@ -77,7 +77,7 @@ In your terminal:
 (v0.4.0 is the latest version compatible with .NET 6.0)
 
 Run it:
-`csharprepl -r src/bbs2gh/bin/Debug/net6.0/Octoshift.dll`
+`csharprepl -r src/bbs2gh/bin/Debug/net8.0/Octoshift.dll`
 
 Then load up assemblies:
 ```csharp
@@ -96,7 +96,7 @@ var aws = new AwsApi("access-key-id", "secret-access-key");
 
 ### Use debugger
 
-If you use the built in debugger you are able to set breakpoints and inspect the code within VS Code. 
+If you use the built in debugger you are able to set breakpoints and inspect the code within VS Code.
 
 1. Navigate to `.vs_code/launch.json`.
 2. Find the command you are looking to run, for example: `Launch ado2gh`.
@@ -107,7 +107,7 @@ If you use the built in debugger you are able to set breakpoints and inspect the
 6. Navigate to the drop down menu and select the command you would like to run, for example: `Launch ado2gh`.
 7. Press the play button
 
-### Useful links 
+### Useful links
 
 1. [Run a .NET app](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-run)
 2. [Debugging using vscode](https://code.visualstudio.com/docs/editor/debugging)

--- a/docs/ContributingCode.md
+++ b/docs/ContributingCode.md
@@ -97,7 +97,7 @@ Alternatively, you can use for gei
  dotnet watch build --project  src/gei/gei.csproj
 ```
 to run builds automatically.
-- If you're doing this, you can run the binaries with `./src/gei/bin/Debug/net6.0/gei`
+- If you're doing this, you can run the binaries with `./src/gei/bin/Debug/net8.0/gei`
 
 If you aren't using watch, run **after** building with:
 ```bash


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

In https://github.com/github/gh-gei/pull/1287 the runtime was changed to .NET 8.0. There were a few additional updates that were needed relating to this change.

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->