### PR TITLE
Add the missing ref to the checkout action for the build job

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: 'refs/pull/${{ github.event.inputs.pr_number }}/merge'
+        fetch-depth: 0
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v2


### PR DESCRIPTION
Currently when running the manual `integration-tests` workflow, the `build-for-e2e-test` job in `integration-tests.yaml` doesn't have the `ref` option so it won't work for forked refs! This PR adds the missing ref.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

