### PR TITLE
Update no generate validation error messages for bbs2gh migrate-repo

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-- Improve validation error messages for `gh bbs2gh migrate-repo` command when generating an archive is not required.
+- Update validation error messages for `gh bbs2gh migrate-repo` command when generating an archive is not required.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Improve validation error messages for `gh bbs2gh migrate-repo` command when generating an archive is not required.

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgsTests.cs
@@ -225,11 +225,12 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
         }
 
         [Fact]
-        public void Errors_If_BbsServer_Url_Not_Provided_But_Bbs_Password_Is_Provided()
+        public void Errors_If_Bbs_Password_Is_Provided_With_Archive_Path()
         {
             // Act
             var args = new MigrateRepoCommandArgs
             {
+                BbsServerUrl = BBS_SERVER_URL,
                 ArchivePath = ARCHIVE_PATH,
                 GithubOrg = GITHUB_ORG,
                 GithubRepo = GITHUB_REPO,
@@ -240,15 +241,36 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             args.Invoking(x => x.Validate(_mockOctoLogger.Object))
                 .Should()
                 .ThrowExactly<OctoshiftCliException>()
-                .WithMessage("*--bbs-username*--bbs-password*--bbs-server-url*");
+                .WithMessage("*--bbs-username*--bbs-password*--archive-path*");
         }
 
         [Fact]
-        public void Errors_If_BbsServer_Url_Not_Provided_But_No_Ssl_Verify_Is_Provided()
+        public void Errors_If_Bbs_Password_Is_Provided_With_Archive_Url()
         {
             // Act
             var args = new MigrateRepoCommandArgs
             {
+                BbsServerUrl = BBS_SERVER_URL,
+                ArchiveUrl = ARCHIVE_URL,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                BbsPassword = BBS_USERNAME
+            };
+
+            // Assert
+            args.Invoking(x => x.Validate(_mockOctoLogger.Object))
+                .Should()
+                .ThrowExactly<OctoshiftCliException>()
+                .WithMessage("*--bbs-username*--bbs-password*--archive-url*");
+        }
+
+        [Fact]
+        public void Errors_If_No_Ssl_Verify_Is_Provided_With_Archive_Path()
+        {
+            // Act
+            var args = new MigrateRepoCommandArgs
+            {
+                BbsServerUrl = BBS_SERVER_URL,
                 ArchivePath = ARCHIVE_PATH,
                 GithubOrg = GITHUB_ORG,
                 GithubRepo = GITHUB_REPO,
@@ -259,15 +281,36 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             args.Invoking(x => x.Validate(_mockOctoLogger.Object))
                 .Should()
                 .ThrowExactly<OctoshiftCliException>()
-                .WithMessage("*--no-ssl-verify*--bbs-server-url*");
+                .WithMessage("*--no-ssl-verify*--archive-path*");
         }
 
         [Fact]
-        public void Errors_If_BbsServer_Url_Not_Provided_But_Ssh_User_Is_Provided()
+        public void Errors_If_No_Ssl_Verify_Is_Provided_With_Archive_Url()
         {
             // Act
             var args = new MigrateRepoCommandArgs
             {
+                BbsServerUrl = BBS_SERVER_URL,
+                ArchiveUrl = ARCHIVE_URL,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                NoSslVerify = true
+            };
+
+            // Assert
+            args.Invoking(x => x.Validate(_mockOctoLogger.Object))
+                .Should()
+                .ThrowExactly<OctoshiftCliException>()
+                .WithMessage("*--no-ssl-verify*--archive-url*");
+        }
+
+        [Fact]
+        public void Errors_If_Ssh_User_Is_Provided_With_Archive_Path()
+        {
+            // Act
+            var args = new MigrateRepoCommandArgs
+            {
+                BbsServerUrl = BBS_SERVER_URL,
                 ArchivePath = ARCHIVE_PATH,
                 GithubOrg = GITHUB_ORG,
                 GithubRepo = GITHUB_REPO,
@@ -279,15 +322,37 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             args.Invoking(x => x.Validate(_mockOctoLogger.Object))
                 .Should()
                 .ThrowExactly<OctoshiftCliException>()
-                .WithMessage("*SSH*SMB*--bbs-server-url*");
+                .WithMessage("*SSH*SMB*--archive-path*");
         }
 
         [Fact]
-        public void Errors_If_BbsServer_Url_Not_Provided_But_Smb_User_Is_Provided()
+        public void Errors_If_Ssh_User_Is_Provided_With_Archive_Url()
         {
             // Act
             var args = new MigrateRepoCommandArgs
             {
+                BbsServerUrl = BBS_SERVER_URL,
+                ArchiveUrl = ARCHIVE_URL,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                SshUser = SSH_USER,
+                SshPrivateKey = PRIVATE_KEY,
+            };
+
+            // Assert
+            args.Invoking(x => x.Validate(_mockOctoLogger.Object))
+                .Should()
+                .ThrowExactly<OctoshiftCliException>()
+                .WithMessage("*SSH*SMB*--archive-url*");
+        }
+
+        [Fact]
+        public void Errors_If_Smb_User_Is_Provided_With_Archive_Path()
+        {
+            // Act
+            var args = new MigrateRepoCommandArgs
+            {
+                BbsServerUrl = BBS_SERVER_URL,
                 ArchivePath = ARCHIVE_PATH,
                 GithubOrg = GITHUB_ORG,
                 GithubRepo = GITHUB_REPO,
@@ -299,7 +364,28 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
             args.Invoking(x => x.Validate(_mockOctoLogger.Object))
                 .Should()
                 .ThrowExactly<OctoshiftCliException>()
-                .WithMessage("*SSH*SMB*--bbs-server-url*");
+                .WithMessage("*SSH*SMB*--archive-path*");
+        }
+
+        [Fact]
+        public void Errors_If_Smb_User_Is_Provided_With_Archive_Url()
+        {
+            // Act
+            var args = new MigrateRepoCommandArgs
+            {
+                BbsServerUrl = BBS_SERVER_URL,
+                ArchiveUrl = ARCHIVE_URL,
+                GithubOrg = GITHUB_ORG,
+                GithubRepo = GITHUB_REPO,
+                SmbUser = SMB_USER,
+                SmbPassword = SMB_PASSWORD,
+            };
+
+            // Assert
+            args.Invoking(x => x.Validate(_mockOctoLogger.Object))
+                .Should()
+                .ThrowExactly<OctoshiftCliException>()
+                .WithMessage("*SSH*SMB*--archive-url*");
         }
 
         [Fact]

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandArgs.cs
@@ -95,17 +95,17 @@ public class MigrateRepoCommandArgs : CommandArgs
     {
         if (BbsUsername.HasValue() || BbsPassword.HasValue())
         {
-            throw new OctoshiftCliException("--bbs-username and --bbs-password can only be provided with --bbs-server-url.");
+            throw new OctoshiftCliException("--bbs-username and --bbs-password cannot be provided with --archive-path or --archive-url.");
         }
 
         if (NoSslVerify)
         {
-            throw new OctoshiftCliException("--no-ssl-verify can only be provided with --bbs-server-url.");
+            throw new OctoshiftCliException("--no-ssl-verify cannot be provided with --archive-path or --archive-url.");
         }
 
         if (new[] { SshUser, SshPrivateKey, ArchiveDownloadHost, SmbUser, SmbPassword, SmbDomain }.Any(obj => obj.HasValue()))
         {
-            throw new OctoshiftCliException("SSH or SMB download options can only be provided with --bbs-server-url.");
+            throw new OctoshiftCliException("SSH or SMB download options cannot be provided with --archive-path or --archive-url.");
         }
     }
 


### PR DESCRIPTION
Closes #1317 

## Description

The error messages for migration paths where archive generation is not required have not been updated since `--bbs-server-url` was made required. This PR updates the error message for clarification.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->