### PR TITLE
Skip not found code scanning analysis migrations

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 - Update validation error messages for `gh bbs2gh migrate-repo` command when generating an archive is not required.
+- `gh gei migrate-code-scanning-alerts` now skips a not found code scanning analysis and continues with the rest. 


### PR DESCRIPTION
Closes https://github.ghe.com/github/octoshift/issues/9761

## Description
This PR gracefully skips migrating a code scanning analysis if it is not found (404) and continues migrating the rest.
Before this change, the entire migration would halt if a 404 occurred when trying to GET the SARIF report for an analysis.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->