### PR TITLE
Log the git and metadata archive paths after the download is complete

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- `gh gei migrate-repo` logs the git and metadata archive download paths when `--keep-archive` is used.

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -1680,7 +1680,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
         }
 
         [Fact]
-        public async Task Keep_Archive_Does_Not_Call_DeleteIfExists()
+        public async Task Keep_Archive_Does_Not_Call_DeleteIfExists_And_Logs_Downloaded_Archive_Paths()
         {
             _mockTargetGithubApi.Setup(x => x.GetOrganizationId(TARGET_ORG).Result).Returns(GITHUB_ORG_ID);
             _mockTargetGithubApi.Setup(x => x.CreateGhecMigrationSource(GITHUB_ORG_ID).Result).Returns(MIGRATION_SOURCE_ID);
@@ -1737,6 +1737,9 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
 
             _mockFileSystemProvider.Verify(x => x.DeleteIfExists(GIT_ARCHIVE_FILE_PATH), Times.Never);
             _mockFileSystemProvider.Verify(x => x.DeleteIfExists(METADATA_ARCHIVE_FILE_PATH), Times.Never);
+
+            _mockOctoLogger.Verify(x => x.LogInformation($"Git archive was successfully downloaded at \"{GIT_ARCHIVE_FILE_PATH}\""));
+            _mockOctoLogger.Verify(x => x.LogInformation($"Metadata archive was successfully downloaded at \"{METADATA_ARCHIVE_FILE_PATH}\""));
         }
 
         [Fact]

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -150,7 +150,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
 
         public Option<bool> KeepArchive { get; } = new("--keep-archive")
         {
-            Description = "Keeps the archive on this machine after uploading to the blob storage account. Only applicable for migrations from GitHub Enterprise Server versions before 3.8.0."
+            Description = "Keeps the archive on this machine after uploading to the blob storage account. Only applicable for migrations from GitHub Enterprise Server versions before 3.8.0 or when used with --use-github-storage."
         };
 
         public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, IServiceProvider sp)

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -262,11 +262,11 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         {
             _log.LogInformation($"Downloading archive from {gitArchiveUrl}");
             await _httpDownloadService.DownloadToFile(gitArchiveUrl, gitArchiveDownloadFilePath);
-            _log.LogInformation("Download complete");
+            _log.LogInformation(keepArchive ? $"Git archive was successfully downloaded at \"{gitArchiveDownloadFilePath}\"" : "Download complete");
 
             _log.LogInformation($"Downloading archive from {metadataArchiveUrl}");
             await _httpDownloadService.DownloadToFile(metadataArchiveUrl, metadataArchiveDownloadFilePath);
-            _log.LogInformation("Download complete");
+            _log.LogInformation(keepArchive ? $"Metadata archive was successfully downloaded at \"{metadataArchiveDownloadFilePath}\"" : "Download complete");
 
             return (
                 await UploadArchive(


### PR DESCRIPTION
Closes https://github.ghe.com/github/octoshift/issues/9868

## Description

This PR logs the git and metadata archive paths after their downloads are complete if the `--keep-archive` flag is passed. 

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)