### PR TITLE
Fixed the Validation for bbs-shared-home and archive-path

### DIFF
--- a/src/Octoshift/Services/FileSystemProvider.cs
+++ b/src/Octoshift/Services/FileSystemProvider.cs
@@ -46,4 +46,6 @@ public class FileSystemProvider
             await source.CopyToAsync(target);
         }
     }
+
+    public virtual bool DirectoryExists(string path) => Directory.Exists(path);
 }

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/AdoApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/AdoApiTests.cs
@@ -455,7 +455,7 @@ public class AdoApiTests
             }
         };
 
-        await sut.AddRepoToBoardsGithubConnection(ADO_ORG, ADO_TEAM_PROJECT, connectionId, connectionName, endpointId, new List<string>() { ADO_REPO, repo2 });
+        await sut.AddRepoToBoardsGithubConnection(ADO_ORG, ADO_TEAM_PROJECT, connectionId, connectionName, endpointId, [ADO_REPO, repo2]);
 
         _mockAdoClient.Verify(m => m.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result);
     }
@@ -551,7 +551,7 @@ public class AdoApiTests
         {
             value = new[]
             {
-                new { date = expectedDate.ToShortDateString() }
+                new { date = expectedDate.ToString("o") }
             }
         };
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -278,6 +278,36 @@ public class MigrateRepoCommandHandlerTests
     }
 
     [Fact]
+    public async Task Throws_Decorated_Error_When_Create_Migration_Source_Fails_With_Permissions_Error_New()
+    {
+        // Arrange
+        _mockEnvironmentVariableProvider
+        .Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>()))
+        .Returns(GITHUB_TOKEN);
+        _mockEnvironmentVariableProvider
+            .Setup(m => m.AdoPersonalAccessToken(It.IsAny<bool>()))
+            .Returns(ADO_TOKEN);
+
+        _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
+        _mockGithubApi
+            .Setup(x => x.CreateAdoMigrationSource(GITHUB_ORG_ID, null).Result)
+            .Throws(new OctoshiftCliException("monalisa does not have the correct permissions to execute `CreateMigrationSource`"));
+
+        // Act
+        await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
+        {
+            AdoOrg = ADO_ORG,
+            AdoTeamProject = ADO_TEAM_PROJECT,
+            AdoRepo = ADO_REPO,
+            GithubOrg = GITHUB_ORG,
+            GithubRepo = GITHUB_REPO,
+        }))
+            .Should()
+            .ThrowAsync<OctoshiftCliException>()
+            .WithMessage($"monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that:\n  (a) you are a member of the `{GITHUB_ORG}` organization,\n  (b) you are an organization owner or you have been granted the migrator role and\n  (c) your personal access token has the correct scopes.\nFor more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
+    }
+
+    [Fact]
     public async Task Sets_Target_Repo_Visibility_When_Specified()
     {
         // Arrange

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -278,36 +278,6 @@ public class MigrateRepoCommandHandlerTests
     }
 
     [Fact]
-    public async Task Throws_Decorated_Error_When_Create_Migration_Source_Fails_With_Permissions_Error_New()
-    {
-        // Arrange
-        _mockEnvironmentVariableProvider
-        .Setup(m => m.TargetGithubPersonalAccessToken(It.IsAny<bool>()))
-        .Returns(GITHUB_TOKEN);
-        _mockEnvironmentVariableProvider
-            .Setup(m => m.AdoPersonalAccessToken(It.IsAny<bool>()))
-            .Returns(ADO_TOKEN);
-
-        _mockGithubApi.Setup(x => x.GetOrganizationId(GITHUB_ORG).Result).Returns(GITHUB_ORG_ID);
-        _mockGithubApi
-            .Setup(x => x.CreateAdoMigrationSource(GITHUB_ORG_ID, null).Result)
-            .Throws(new OctoshiftCliException("monalisa does not have the correct permissions to execute `CreateMigrationSource`"));
-
-        // Act
-        await _handler.Invoking(async x => await x.Handle(new MigrateRepoCommandArgs
-        {
-            AdoOrg = ADO_ORG,
-            AdoTeamProject = ADO_TEAM_PROJECT,
-            AdoRepo = ADO_REPO,
-            GithubOrg = GITHUB_ORG,
-            GithubRepo = GITHUB_REPO,
-        }))
-            .Should()
-            .ThrowAsync<OctoshiftCliException>()
-            .WithMessage($"monalisa does not have the correct permissions to execute `CreateMigrationSource`. Please check that:\n  (a) you are a member of the `{GITHUB_ORG}` organization,\n  (b) you are an organization owner or you have been granted the migrator role and\n  (c) your personal access token has the correct scopes.\nFor more information, see https://docs.github.com/en/migrations/using-github-enterprise-importer/preparing-to-migrate-with-github-enterprise-importer/managing-access-for-github-enterprise-importer.");
-    }
-
-    [Fact]
     public async Task Sets_Target_Repo_Visibility_When_Specified()
     {
         // Arrange

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -995,7 +995,6 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
         public async Task Does_Not_Throw_Exception_If_ArchivePath_Exists()
         {
             // Arrange
-            const string ARCHIVE_PATH = "valid/path/to/archive.tar";
             _mockFileSystemProvider.Setup(x => x.FileExists(ARCHIVE_PATH)).Returns(true);
 
             var args = new MigrateRepoCommandArgs
@@ -1013,7 +1012,6 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands.MigrateRepo
         {
             // Arrange
             const string BBS_SHARED_HOME = "valid/path";
-            const string ARCHIVE_PATH = "valid/path/to/archive.tar";
 
             _mockFileSystemProvider.Setup(x => x.DirectoryExists(BBS_SHARED_HOME)).Returns(true);
             _mockFileSystemProvider.Setup(x => x.FileExists(ARCHIVE_PATH)).Returns(true);

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -386,7 +386,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         // Validate BbsSharedHome
         if (!string.IsNullOrEmpty(args.BbsSharedHome))
         {
-            if (args.ShouldUploadArchive() && args.ArchivePath.IsNullOrWhiteSpace())
+            if (args.ArchivePath.IsNullOrWhiteSpace())  // Removed the ShouldUploadArchive Since we are checking it already
             {
                 if (args.BbsSharedHome.HasValue() && !_fileSystemProvider.DirectoryExists(args.BbsSharedHome))
                 {

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using OctoshiftCLI.BbsToGithub.Services;
@@ -384,7 +383,6 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
                 throw new OctoshiftCliException("Either --aws-region or AWS_REGION environment variable must be set.");
             }
         }
-        
         // Validate BbsSharedHome
         if (!string.IsNullOrEmpty(args.BbsSharedHome))
         {

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -52,8 +52,6 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         }
 
         ValidateOptions(args);
-        ValidateBbsSharedHome(args);
-        ValidateArchivePath(args);
         var exportId = 0L;
         var migrationSourceId = "";
 
@@ -124,46 +122,6 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             await ImportArchive(args, migrationSourceId, args.ArchiveUrl);
         }
     }
-
-    private void ValidateBbsSharedHome(MigrateRepoCommandArgs args)
-    {
-        if (!string.IsNullOrEmpty(args.BbsSharedHome))
-        {
-            if (IsRunningOnBitbucketServer())
-            {
-                if (!Directory.Exists(args.BbsSharedHome))
-                {
-                    throw new OctoshiftCliException($"Invalid --bbs-shared-home path: '{args.BbsSharedHome}'. Directory does not exist.");
-                }
-            }
-            else
-            {
-                if (!Directory.Exists(args.BbsSharedHome))
-                {
-                    throw new OctoshiftCliException($"Invalid --bbs-shared-home path: '{args.BbsSharedHome}'. Directory does not exist.");
-                }
-            }
-        }
-    }
-
-    private void ValidateArchivePath(MigrateRepoCommandArgs args)
-    {
-        if (!string.IsNullOrEmpty(args.ArchivePath))
-        {
-            if (!File.Exists(args.ArchivePath))
-            {
-                throw new OctoshiftCliException($"Invalid --archive-path: '{args.ArchivePath}'. File does not exist.");
-            }
-            _log.LogInformation($"Archive path for upload: {args.ArchivePath}");
-        }
-    }
-
-
-    private bool IsRunningOnBitbucketServer()
-    {
-        return Environment.GetEnvironmentVariable("BITBUCKET_SERVER") != null;
-    }
-
 
     private string GetSourceExportArchiveAbsolutePath(string bbsSharedHomeDirectory, long exportId)
     {
@@ -424,6 +382,27 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             if (GetAwsRegion(args).IsNullOrWhiteSpace())
             {
                 throw new OctoshiftCliException("Either --aws-region or AWS_REGION environment variable must be set.");
+            }
+        }
+        
+        // Validate BbsSharedHome
+        if (!string.IsNullOrEmpty(args.BbsSharedHome))
+        {
+            if (args.ShouldUploadArchive() && args.ArchivePath.IsNullOrWhiteSpace())
+            {
+                if (args.BbsSharedHome.HasValue() && !_fileSystemProvider.DirectoryExists(args.BbsSharedHome))
+                {
+                    throw new OctoshiftCliException($"Invalid --bbs-shared-home path: '{args.BbsSharedHome}'. Directory does not exist.");
+                }
+            }
+        }
+
+        // Validate ArchivePath
+        if (!string.IsNullOrEmpty(args.ArchivePath))
+        {
+            if (!_fileSystemProvider.FileExists(args.ArchivePath))
+            {
+                throw new OctoshiftCliException($"Invalid --archive-path: '{args.ArchivePath}'. File does not exist.");
             }
         }
     }

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -384,24 +384,19 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
             }
         }
         // Validate BbsSharedHome
-        if (!string.IsNullOrEmpty(args.BbsSharedHome))
+        if (!string.IsNullOrEmpty(args.BbsSharedHome) &&
+            args.ArchivePath.IsNullOrWhiteSpace() &&
+            args.BbsSharedHome.HasValue() &&
+            !_fileSystemProvider.DirectoryExists(args.BbsSharedHome))
         {
-            if (args.ArchivePath.IsNullOrWhiteSpace())  // Removed the ShouldUploadArchive Since we are checking it already
-            {
-                if (args.BbsSharedHome.HasValue() && !_fileSystemProvider.DirectoryExists(args.BbsSharedHome))
-                {
-                    throw new OctoshiftCliException($"Invalid --bbs-shared-home path: '{args.BbsSharedHome}'. Directory does not exist.");
-                }
-            }
+            throw new OctoshiftCliException($"Invalid --bbs-shared-home path: '{args.BbsSharedHome}'. Directory does not exist.");
         }
 
         // Validate ArchivePath
-        if (!string.IsNullOrEmpty(args.ArchivePath))
+        if (!string.IsNullOrEmpty(args.ArchivePath) && !_fileSystemProvider.FileExists(args.ArchivePath))
         {
-            if (!_fileSystemProvider.FileExists(args.ArchivePath))
-            {
-                throw new OctoshiftCliException($"Invalid --archive-path: '{args.ArchivePath}'. File does not exist.");
-            }
+            throw new OctoshiftCliException($"Invalid --archive-path: '{args.ArchivePath}'. File does not exist.");
         }
+
     }
 }


### PR DESCRIPTION
This PR refines the validation for `BbsSharedHome` and `ArchivePath` inputs.

#### Validation Enhancements:
- Validated that the `BbsSharedHome` directory exists if provided and `ArchivePath` is not set.
- Ensured that the `ArchivePath` file exists if provided.

---
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->
- [x] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->