### PR TITLE
Add retries for archive uploader

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Improve resilience of `gh gei migrate-repo` and `gh bb2gh migrate-repo` commands when uploading migration archives to GitHub owned storage.

--- a/src/Octoshift/Services/ArchiveUploader.cs
+++ b/src/Octoshift/Services/ArchiveUploader.cs
@@ -15,13 +15,15 @@ public class ArchiveUploader
     private readonly GithubClient _client;
     private readonly OctoLogger _log;
     internal int _streamSizeLimit = 100 * 1024 * 1024; // 100 MiB
+    private readonly RetryPolicy _retryPolicy;
 
     private const string BASE_URL = "https://uploads.github.com";
 
-    public ArchiveUploader(GithubClient client, OctoLogger log)
+    public ArchiveUploader(GithubClient client, OctoLogger log, RetryPolicy retryPolicy)
     {
         _client = client;
         _log = log;
+        _retryPolicy = retryPolicy;
     }
     public virtual async Task<string> Upload(Stream archiveContent, string archiveName, string orgDatabaseId)
     {
@@ -48,7 +50,7 @@ public class ArchiveUploader
         {
             var url = $"{BASE_URL}/organizations/{orgDatabaseId.EscapeDataString()}/gei/archive?name={archiveName.EscapeDataString()}";
 
-            response = await _client.PostAsync(url, streamContent);
+            response = await _retryPolicy.Retry(async () => await _client.PostAsync(url, streamContent));
             var data = JObject.Parse(response);
             return (string)data["uri"];
         }
@@ -101,7 +103,7 @@ public class ArchiveUploader
 
         try
         {
-            var (responseContent, headers) = await _client.PostWithFullResponseAsync(uploadUrl, body);
+            var (_, headers) = await _retryPolicy.Retry(async () => await _client.PostWithFullResponseAsync(uploadUrl, body));
             return headers.ToList();
         }
         catch (Exception ex)
@@ -119,7 +121,7 @@ public class ArchiveUploader
         try
         {
             // Make the PATCH request and retrieve headers
-            var (_, headers) = await _client.PatchWithFullResponseAsync(nextUrl, content);
+            var (_, headers) = await _retryPolicy.Retry(async () => await _client.PatchWithFullResponseAsync(nextUrl, content));
 
             // Retrieve the next URL from the response headers
             return GetNextUrl(headers.ToList());
@@ -134,7 +136,7 @@ public class ArchiveUploader
     {
         try
         {
-            await _client.PutAsync(lastUrl, "");
+            await _retryPolicy.Retry(async () => await _client.PutAsync(lastUrl, ""));
             _log.LogInformation("Finished uploading archive");
         }
         catch (Exception ex)

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -59,7 +59,8 @@ public sealed class BbsToGithub : IDisposable
 
         _targetGithubHttpClient = new HttpClient();
         _targetGithubClient = new GithubClient(_logger, _targetGithubHttpClient, new VersionChecker(_versionClient, _logger), new RetryPolicy(_logger), new DateTimeProvider(), targetGithubToken);
-        _archiveUploader = new ArchiveUploader(_targetGithubClient, _logger);
+        var retryPolicy = new RetryPolicy(_logger);
+        _archiveUploader = new ArchiveUploader(_targetGithubClient, _logger, retryPolicy);
         _targetGithubApi = new GithubApi(_targetGithubClient, "https://api.github.com", new RetryPolicy(_logger), _archiveUploader);
 
         _blobServiceClient = new BlobServiceClient(_azureStorageConnectionString);

--- a/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GhesToGithub.cs
@@ -47,7 +47,8 @@ public sealed class GhesToGithub : IDisposable
         };
 
         _versionClient = new HttpClient();
-        _archiveUploader = new ArchiveUploader(_targetGithubClient, logger);
+        var retryPolicy = new RetryPolicy(logger);
+        _archiveUploader = new ArchiveUploader(_targetGithubClient, logger, retryPolicy);
 
         _sourceGithubHttpClient = new HttpClient();
         _sourceGithubClient = new GithubClient(logger, _sourceGithubHttpClient, new VersionChecker(_versionClient, logger), new RetryPolicy(logger), new DateTimeProvider(), sourceGithubToken);

--- a/src/ado2gh/Factories/GithubApiFactory.cs
+++ b/src/ado2gh/Factories/GithubApiFactory.cs
@@ -30,7 +30,7 @@ public class GithubApiFactory : ITargetGithubApiFactory
         apiUrl ??= DEFAULT_API_URL;
         targetPersonalAccessToken ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
         var githubClient = new GithubClient(_octoLogger, _client, _versionProvider, _retryPolicy, _dateTimeProvider, targetPersonalAccessToken);
-        var multipartUploader = new ArchiveUploader(githubClient, _octoLogger);
+        var multipartUploader = new ArchiveUploader(githubClient, _octoLogger, _retryPolicy);
         return new GithubApi(githubClient, apiUrl, _retryPolicy, multipartUploader);
     }
 }

--- a/src/bbs2gh/Factories/GithubApiFactory.cs
+++ b/src/bbs2gh/Factories/GithubApiFactory.cs
@@ -30,7 +30,7 @@ public class GithubApiFactory : ITargetGithubApiFactory
         apiUrl ??= DEFAULT_API_URL;
         targetPersonalAccessToken ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
         var githubClient = new GithubClient(_octoLogger, _client, _versionProvider, _retryPolicy, _dateTimeProvider, targetPersonalAccessToken);
-        var multipartUploader = new ArchiveUploader(githubClient, _octoLogger);
+        var multipartUploader = new ArchiveUploader(githubClient, _octoLogger, _retryPolicy);
         return new GithubApi(githubClient, apiUrl, _retryPolicy, multipartUploader);
     }
 }

--- a/src/gei/Factories/GithubApiFactory.cs
+++ b/src/gei/Factories/GithubApiFactory.cs
@@ -30,7 +30,7 @@ public sealed class GithubApiFactory : ISourceGithubApiFactory, ITargetGithubApi
         apiUrl ??= DEFAULT_API_URL;
         sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
         var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), _versionProvider, _retryPolicy, _dateTimeProvider, sourcePersonalAccessToken);
-        var multipartUploader = new ArchiveUploader(githubClient, _octoLogger);
+        var multipartUploader = new ArchiveUploader(githubClient, _octoLogger, _retryPolicy);
         return new GithubApi(githubClient, apiUrl, _retryPolicy, multipartUploader);
     }
 
@@ -39,7 +39,7 @@ public sealed class GithubApiFactory : ISourceGithubApiFactory, ITargetGithubApi
         apiUrl ??= DEFAULT_API_URL;
         sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
         var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("NoSSL"), _versionProvider, _retryPolicy, _dateTimeProvider, sourcePersonalAccessToken);
-        var multipartUploader = new ArchiveUploader(githubClient, _octoLogger);
+        var multipartUploader = new ArchiveUploader(githubClient, _octoLogger, _retryPolicy);
         return new GithubApi(githubClient, apiUrl, _retryPolicy, multipartUploader);
     }
 
@@ -48,7 +48,7 @@ public sealed class GithubApiFactory : ISourceGithubApiFactory, ITargetGithubApi
         apiUrl ??= DEFAULT_API_URL;
         targetPersonalAccessToken ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
         var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), _versionProvider, _retryPolicy, _dateTimeProvider, targetPersonalAccessToken);
-        var multipartUploader = new ArchiveUploader(githubClient, _octoLogger);
+        var multipartUploader = new ArchiveUploader(githubClient, _octoLogger, _retryPolicy);
         return new GithubApi(githubClient, apiUrl, _retryPolicy, multipartUploader);
     }
 }


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->
Adding retries for the archive uploader to handle network issues and improve the reliability of the upload process.

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->