### PR TITLE
Add original resolver name in migrated Secret Scanning alerts 

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- `gh gei migrate-secret-alerts` copies the resolver name from the original alert to the resolution comment of the matching target alert. The comment follows this format: `[@actorname] original comment`.

--- a/src/Octoshift/Models/GithubSecretScanningAlert.cs
+++ b/src/Octoshift/Models/GithubSecretScanningAlert.cs
@@ -7,6 +7,7 @@ public class GithubSecretScanningAlert
     public string ResolutionComment { get; set; }
     public string SecretType { get; set; }
     public string Secret { get; set; }
+    public string ResolverName { get; set; }
 }
 
 public class GithubSecretScanningAlertLocation

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -1182,6 +1182,9 @@ public class GithubApi
             ResolutionComment = (string)secretAlert["resolution_comment"],
             SecretType = (string)secretAlert["secret_type"],
             Secret = (string)secretAlert["secret"],
+            ResolverName = secretAlert["resolved_by"]?.Type != JTokenType.Null 
+                ? (string)secretAlert["resolved_by"]["login"] 
+                : null
         };
 
     private static GithubSecretScanningAlertLocation BuildSecretScanningAlertLocation(JToken alertLocation)

--- a/src/Octoshift/Services/SecretScanningAlertService.cs
+++ b/src/Octoshift/Services/SecretScanningAlertService.cs
@@ -74,9 +74,11 @@ public class SecretScanningAlertService
 
                         _log.LogInformation($"  updating target alert:{targetAlert.Alert.Number} to state:{sourceAlert.Alert.State} and resolution:{sourceAlert.Alert.Resolution}");
 
+                        var targetResolutionComment = $"[@{sourceAlert.Alert.ResolverName}] {sourceAlert.Alert.ResolutionComment}";
+
                         await _targetGithubApi.UpdateSecretScanningAlert(targetOrg, targetRepo, targetAlert.Alert.Number, sourceAlert.Alert.State,
-                            sourceAlert.Alert.Resolution, sourceAlert.Alert.ResolutionComment);
-                        _log.LogSuccess($"  target alert successfully updated to {sourceAlert.Alert.Resolution}.");
+                            sourceAlert.Alert.Resolution, targetResolutionComment);
+                        _log.LogSuccess($"  target alert successfully updated to {sourceAlert.Alert.Resolution} with comment {targetResolutionComment}.");
                     }
                     else
                     {

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -3805,6 +3805,83 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
         location.IssueCommentUrl.Should().Be("https://api.github.com/repos/ORG/REPO/issues/comments/2758578142");
     }
 
+    [Fact]
+    public async Task GetSecretScanningAlertsForRepository_Populates_ResolverName()
+    {
+        // Arrange
+        const string url =
+            $"https://api.github.com/repos/{GITHUB_ORG}/{GITHUB_REPO}/secret-scanning/alerts?per_page=100";
+
+        var alertWithNoResolver = @"
+            {
+                ""number"": 10,
+                ""state"": ""open"",
+                ""secret_type"": ""pattern"",
+                ""secret"": ""secret1"",
+                ""resolution"": null,
+                ""resolved_by"": null
+            }
+        ";
+        var alertWithResolver = @"
+            {
+                ""number"": 11,
+                ""state"": ""resolved"",
+                ""secret_type"": ""pattern"",
+                ""secret"": ""secret2"",
+                ""resolution"": ""false_positive"",
+                ""resolved_by"": { ""login"": ""resolverUser"" }
+            }
+        ";
+
+        var alerts = new[]
+        {
+            JToken.Parse(alertWithNoResolver),
+            JToken.Parse(alertWithResolver)
+        }.ToAsyncEnumerable();
+
+        _githubClientMock
+            .Setup(m => m.GetAllAsync(url, null))
+            .Returns(alerts);
+
+        // Act
+        var results = await _githubApi.GetSecretScanningAlertsForRepository(GITHUB_ORG, GITHUB_REPO);
+        var array = results.ToArray();
+
+        // Assert
+        array.Should().HaveCount(2);
+        array[0].ResolverName.Should().BeNull();
+        array[1].ResolverName.Should().Be("resolverUser");
+    }
+
+    [Fact]
+    public async Task GetSecretScanningAlertsForRepository_Populates_ResolutionComment_And_ResolverName()
+    {
+        // Arrange
+        var url = $"https://api.github.com/repos/{GITHUB_ORG}/{GITHUB_REPO}/secret-scanning/alerts?per_page=100";
+        var json = @"
+        {
+        ""number"": 5,
+        ""state"": ""resolved"",
+        ""secret_type"": ""pattern"",
+        ""secret"": ""secretX"",
+        ""resolution"": ""false_positive"",
+        ""resolution_comment"": ""This is a test"",
+        ""resolved_by"": { ""login"": ""actor"" }
+        }";
+        _githubClientMock
+        .Setup(m => m.GetAllAsync(url, null))
+        .Returns(new[] { JToken.Parse(json) }.ToAsyncEnumerable());
+
+        // Act
+        var results = await _githubApi.GetSecretScanningAlertsForRepository(GITHUB_ORG, GITHUB_REPO);
+        var array = results.ToArray();
+
+        // Assert
+        array.Should().HaveCount(1);
+        array[0].ResolutionComment.Should().Be("This is a test");
+        array[0].ResolverName     .Should().Be("actor");
+    }
+
     private string Compact(string source) =>
         source
             .Replace("\r", "")

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/SecretScanningAlertServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/SecretScanningAlertServiceTests.cs
@@ -42,6 +42,8 @@ public class SecretScanningAlertServiceTests
             SecretType = secretType,
             Secret = secret,
             Resolution = SecretScanningAlert.ResolutionRevoked,
+            ResolutionComment = "This token was revoked during migration",
+            ResolverName = "actor"
         };
 
         var sourceLocation = new GithubSecretScanningAlertLocation()
@@ -95,7 +97,7 @@ public class SecretScanningAlertServiceTests
             100,
             SecretScanningAlert.AlertStateResolved,
             SecretScanningAlert.ResolutionRevoked,
-            null)
+            $"[@{sourceSecret.ResolverName}] {sourceSecret.ResolutionComment}")
         );
     }
 
@@ -105,6 +107,7 @@ public class SecretScanningAlertServiceTests
         var secretType = "custom";
         var secret = "my-password";
         var resolutionComment = "This secret was revoked and replaced";
+        var resolverName = "actor";
 
         // Arrange
         var sourceSecret = new GithubSecretScanningAlert()
@@ -114,7 +117,8 @@ public class SecretScanningAlertServiceTests
             SecretType = secretType,
             Secret = secret,
             Resolution = SecretScanningAlert.ResolutionRevoked,
-            ResolutionComment = resolutionComment
+            ResolutionComment = resolutionComment,
+            ResolverName     = resolverName
         };
 
         var sourceLocation = new GithubSecretScanningAlertLocation()
@@ -168,7 +172,7 @@ public class SecretScanningAlertServiceTests
             100,
             SecretScanningAlert.AlertStateResolved,
             SecretScanningAlert.ResolutionRevoked,
-            resolutionComment)
+            $"[@{sourceSecret.ResolverName}] {sourceSecret.ResolutionComment}")
         );
     }
 
@@ -186,6 +190,8 @@ public class SecretScanningAlertServiceTests
             SecretType = secretType,
             Secret = secret,
             Resolution = SecretScanningAlert.ResolutionRevoked,
+            ResolutionComment = "This token was revoked during migration",
+            ResolverName = "actor"
         };
 
         var sourceLocation = new GithubSecretScanningAlertLocation()
@@ -256,6 +262,8 @@ public class SecretScanningAlertServiceTests
             SecretType = secretType,
             Secret = secret,
             Resolution = SecretScanningAlert.ResolutionRevoked,
+            ResolutionComment = "This token was revoked during migration",
+            ResolverName = "actor"
         };
 
         var sourceLocation = new GithubSecretScanningAlertLocation()
@@ -375,6 +383,8 @@ public class SecretScanningAlertServiceTests
             SecretType = secretType,
             Secret = secretOne,
             Resolution = SecretScanningAlert.ResolutionRevoked,
+            ResolutionComment = "This token was revoked during migration",
+            ResolverName = "actor"
         };
 
         var sourceSecretTwo = new GithubSecretScanningAlert()
@@ -384,6 +394,8 @@ public class SecretScanningAlertServiceTests
             SecretType = secretType,
             Secret = secretTwo,
             Resolution = SecretScanningAlert.ResolutionRevoked,
+            ResolutionComment = "This token was revoked during migration",
+            ResolverName = "actor"
         };
 
         var sourceSecretThree = new GithubSecretScanningAlert()
@@ -393,6 +405,8 @@ public class SecretScanningAlertServiceTests
             SecretType = secretType,
             Secret = secretThree,
             Resolution = SecretScanningAlert.ResolutionFalsePositive,
+            ResolutionComment = "This token was revoked during migration",
+            ResolverName = "actor"
         };
 
         var sourceLocation = new GithubSecretScanningAlertLocation()
@@ -443,7 +457,7 @@ public class SecretScanningAlertServiceTests
             100,
             SecretScanningAlert.AlertStateResolved,
             SecretScanningAlert.ResolutionRevoked,
-            null)
+            $"[@{sourceSecretOne.ResolverName}] {sourceSecretOne.ResolutionComment}")
         );
 
         _mockTargetGithubApi.Verify(m => m.UpdateSecretScanningAlert(
@@ -452,7 +466,7 @@ public class SecretScanningAlertServiceTests
             300,
             SecretScanningAlert.AlertStateResolved,
             SecretScanningAlert.ResolutionFalsePositive,
-            null)
+            $"[@{sourceSecretThree.ResolverName}] {sourceSecretThree.ResolutionComment}")
         );
     }
 
@@ -740,7 +754,7 @@ public class SecretScanningAlertServiceTests
             100,
             SecretScanningAlert.AlertStateResolved,
             SecretScanningAlert.ResolutionRevoked,
-            null)
+            "[@] ")
         );
     }
 
@@ -901,7 +915,7 @@ public class SecretScanningAlertServiceTests
             100,
             SecretScanningAlert.AlertStateResolved,
             SecretScanningAlert.ResolutionRevoked,
-            null)
+            "[@] ")
         );
     }
 
@@ -919,7 +933,8 @@ public class SecretScanningAlertServiceTests
             SecretType = secretType,
             Secret = secret,
             Resolution = SecretScanningAlert.ResolutionRevoked,
-            ResolutionComment = "This token was revoked during migration"
+            ResolutionComment = "This token was revoked during migration",
+            ResolverName = "actor"
         };
 
         var sourceLocation = new GithubSecretScanningAlertLocation
@@ -966,7 +981,7 @@ public class SecretScanningAlertServiceTests
             100,
             SecretScanningAlert.AlertStateResolved,
             SecretScanningAlert.ResolutionRevoked,
-            "This token was revoked during migration")
+            $"[@{sourceSecret.ResolverName}] {sourceSecret.ResolutionComment}")
         );
     }
 
@@ -1056,7 +1071,7 @@ public class SecretScanningAlertServiceTests
             100,
             SecretScanningAlert.AlertStateResolved,
             SecretScanningAlert.ResolutionRevoked,
-            null)
+            "[@] ")
         );
     }
 
@@ -1137,7 +1152,8 @@ public class SecretScanningAlertServiceTests
             SecretType = secretType,
             Secret = secret,
             Resolution = SecretScanningAlert.ResolutionFalsePositive,
-            ResolutionComment = "This is a test token"
+            ResolutionComment = "This is a test token",
+            ResolverName = "actor"
         };
 
         var sourceLocations = new[]
@@ -1214,7 +1230,46 @@ public class SecretScanningAlertServiceTests
             100,
             SecretScanningAlert.AlertStateResolved,
             SecretScanningAlert.ResolutionFalsePositive,
-            "This is a test token")
+            $"[@{sourceSecret.ResolverName}] {sourceSecret.ResolutionComment}")
+        );
+    }
+
+    [Fact]
+    public async Task Update_When_No_ResolutionComment_Still_Includes_ResolverName_Prefix()
+    {
+        // Arrange
+        var source = new GithubSecretScanningAlert {
+        Number = 1,
+        State  = SecretScanningAlert.AlertStateResolved,
+        SecretType        = "foo",
+        Secret            = "bar",
+        Resolution        = SecretScanningAlert.ResolutionRevoked,
+        ResolverName      = "actor",
+        ResolutionComment = null
+        };
+        var srcLoc = new GithubSecretScanningAlertLocation { LocationType = "commit", Path="f", StartLine=1,EndLine=1,StartColumn=1,EndColumn=1,BlobSha="x" };
+        _mockSourceGithubApi
+        .Setup(x => x.GetSecretScanningAlertsForRepository(SOURCE_ORG,SOURCE_REPO)).ReturnsAsync(new[]{source});
+        _mockSourceGithubApi
+        .Setup(x => x.GetSecretScanningAlertsLocations(SOURCE_ORG,SOURCE_REPO,1)).ReturnsAsync(new[]{srcLoc});
+
+        var tgt = new GithubSecretScanningAlert { Number=42, State=SecretScanningAlert.AlertStateOpen, SecretType="foo", Secret="bar" };
+        _mockTargetGithubApi
+        .Setup(x => x.GetSecretScanningAlertsForRepository(TARGET_ORG,TARGET_REPO)).ReturnsAsync(new[]{tgt});
+        _mockTargetGithubApi
+        .Setup(x => x.GetSecretScanningAlertsLocations(TARGET_ORG,TARGET_REPO,42)).ReturnsAsync(new[]{srcLoc});
+
+        // Act
+        await _service.MigrateSecretScanningAlerts(SOURCE_ORG,SOURCE_REPO,TARGET_ORG,TARGET_REPO,false);
+
+        // Assert
+        _mockTargetGithubApi.Verify(m => m.UpdateSecretScanningAlert(
+        TARGET_ORG,
+        TARGET_REPO,
+        42,
+        SecretScanningAlert.AlertStateResolved,
+        SecretScanningAlert.ResolutionRevoked,
+        "[@actor] ")  // even though comment was null
         );
     }
 }


### PR DESCRIPTION
This PR enhances the migration of Secret Scanning alerts (`gh gei migrate-secret-alerts` command) by adding support for the `ResolverName` property and migrates it in the comment of a possible matching target alert. With this we maintain the information of who originally resolved an alert.

Basically addresses #1334.

### Changes Made:

- Updated the `GithubSecretScanningAlert` model to include a new `ResolverName` field.
- Modified the `GithubApi` class to populate `ResolverName` from the GitHub API response.
- Enhanced the resolution comment format in `SecretScanningAlertService` to include the `ResolverName` in the targetResolutionComment.
- Added new test to cover edge-cases and update existing ones.

This improvement provides better visibility into the resolution history of Secret Scanning alerts by including the name of the resolver when applicable.

---

<!--  
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing  
-->

- [x] Did you write/update appropriate tests  
- [x] Release notes updated (if appropriate)  
- [x] Appropriate logging output  
- [x] Issue linked  
- [ ] ~~Docs updated (or issue created)~~  
- [ ] ~~New package licenses are added to `ThirdPartyNotices.txt` (if applicable)~~  

<!--  
For docs we should review the docs at:  
https://docs.github.com/en/migrations/using-github-enterprise-importer  
and the README.md in this repo  

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.  
-->
