### PR TITLE
Bump release to 1.15.1

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+Adjusting the release version so we can go to 1.15.1


### PR DESCRIPTION
The last release was set to to https://github.com/github/gh-gei/releases/tag/v1.9.1
and it should have been set to 1.15.1