### PR TITLE
Fix broken build / linter errors

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.404",
+    "version": "8.0.410",
     "rollForward": "minor"
   }
 }

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/AdoApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/AdoApiTests.cs
@@ -455,7 +455,7 @@ public class AdoApiTests
             }
         };
 
-        await sut.AddRepoToBoardsGithubConnection(ADO_ORG, ADO_TEAM_PROJECT, connectionId, connectionName, endpointId, new List<string>() { ADO_REPO, repo2 });
+        await sut.AddRepoToBoardsGithubConnection(ADO_ORG, ADO_TEAM_PROJECT, connectionId, connectionName, endpointId, [ADO_REPO, repo2]);
 
         _mockAdoClient.Verify(m => m.PostAsync(endpoint, It.Is<object>(y => y.ToJson() == payload.ToJson())).Result);
     }

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/CodeScanningAlertServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/CodeScanningAlertServiceTests.cs
@@ -135,7 +135,7 @@ public class CodeScanningAlertServiceTests
         var processingStatus = new SarifProcessingStatus
         {
             Status = SarifProcessingStatus.Complete,
-            Errors = new Collection<string>()
+            Errors = []
         };
 
         _mockSourceGithubApi.Setup(x => x.GetCodeScanningAnalysisForRepository(SOURCE_ORG, SOURCE_REPO, "main")).ReturnsAsync(new[] { analysis1, analysis2 });
@@ -219,7 +219,7 @@ public class CodeScanningAlertServiceTests
         const string sarifResponse2 = "SARIF_RESPONSE_2";
         const string sarifResponse3 = "SARIF_RESPONSE_3";
         var processingStatus =
-            new SarifProcessingStatus { Status = SarifProcessingStatus.Complete, Errors = new Collection<string>() };
+            new SarifProcessingStatus { Status = SarifProcessingStatus.Complete, Errors = [] };
 
         _mockSourceGithubApi.Setup(x => x.GetCodeScanningAnalysisForRepository(SOURCE_ORG, SOURCE_REPO, "main")).ReturnsAsync(new[] { analysis1, analysis2, analysis3 });
         _mockTargetGithubApi.Setup(x => x.GetCodeScanningAnalysisForRepository(TARGET_ORG, TARGET_REPO, "main")).ReturnsAsync(new[] { analysis1 });
@@ -898,7 +898,7 @@ public class CodeScanningAlertServiceTests
         var processingStatus = new SarifProcessingStatus
         {
             Status = SarifProcessingStatus.Complete,
-            Errors = new Collection<string>()
+            Errors = []
         };
 
         _mockSourceGithubApi.Setup(x => x.GetCodeScanningAnalysisForRepository(SOURCE_ORG, SOURCE_REPO, "main")).ReturnsAsync(new[] { analysis1, analysis2 });

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -2842,17 +2842,6 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
         location.Path.Should().Be((string)expectedData["details"]["path"]);
     }
 
-    private void AssertSecretScanningData(GithubSecretScanningAlert actual, JToken expectedData)
-    {
-        actual.Number.Should().Be((int)expectedData["number"]);
-        actual.State.Should().Be((string)expectedData["state"]);
-        actual.SecretType.Should().Be((string)expectedData["secret_type"]);
-        actual.Resolution.Should().Be((string)expectedData["resolution"]);
-        actual.Secret.Should().Be((string)expectedData["secret"]);
-        actual.ResolutionComment.Should().Be((string)expectedData["resolution_comment"]);
-        actual.ResolverName.Should().Be((string)expectedData["resolved_by"]["login"]);
-    }
-
     [Fact]
     public async Task UpdateSecretScanningAlert_Calls_The_Right_Endpoint_With_Payload_For_Resolved_State()
     {

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
@@ -28,11 +28,11 @@ public class GenerateScriptCommandHandlerTests
     private const string GITHUB_ORG = "GITHUB_ORG";
     private const string ADO_SERVER_URL = "http://ado.contoso.com";
 
-    private readonly IEnumerable<string> ADO_ORGS = new List<string>() { ADO_ORG };
-    private readonly IEnumerable<string> ADO_TEAM_PROJECTS = new List<string>() { ADO_TEAM_PROJECT };
-    private IEnumerable<AdoRepository> ADO_REPOS = new List<AdoRepository> { new() { Name = FOO_REPO } };
-    private IEnumerable<string> ADO_PIPELINES = new List<string>() { FOO_PIPELINE };
-    private readonly IEnumerable<string> EMPTY_PIPELINES = new List<string>();
+    private readonly IEnumerable<string> ADO_ORGS = [ADO_ORG];
+    private readonly IEnumerable<string> ADO_TEAM_PROJECTS = [ADO_TEAM_PROJECT];
+    private IEnumerable<AdoRepository> ADO_REPOS = [new() { Name = FOO_REPO }];
+    private IEnumerable<string> ADO_PIPELINES = [FOO_PIPELINE];
+    private readonly IEnumerable<string> EMPTY_PIPELINES = [];
 
     private readonly Mock<AdoApi> _mockAdoApi = TestHelpers.CreateMock<AdoApi>();
     private readonly Mock<AdoInspectorService> _mockAdoInspector = TestHelpers.CreateMock<AdoInspectorService>();
@@ -326,7 +326,7 @@ public class GenerateScriptCommandHandlerTests
     public async Task SequentialScript_Single_Repo_Two_Pipelines_All_Options()
     {
         // Arrange
-        ADO_PIPELINES = new List<string> { FOO_PIPELINE, BAR_PIPELINE };
+        ADO_PIPELINES = [FOO_PIPELINE, BAR_PIPELINE];
 
         _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
         _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, ADO_TEAM_PROJECTS)).ReturnsAsync(APP_ID);
@@ -374,7 +374,7 @@ public class GenerateScriptCommandHandlerTests
     public async Task SequentialScript_Single_Repo_Two_Pipelines_No_Service_Connection_All_Options()
     {
         // Arrange
-        ADO_PIPELINES = new List<string> { FOO_PIPELINE, BAR_PIPELINE };
+        ADO_PIPELINES = [FOO_PIPELINE, BAR_PIPELINE];
 
         _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
         _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
@@ -874,7 +874,7 @@ if ($Failed -ne 0) {
     public async Task ParallelScript_Two_Repos_Two_Pipelines_All_Options()
     {
         // Arrange
-        ADO_REPOS = new List<AdoRepository> { new() { Name = FOO_REPO }, new() { Name = BAR_REPO } };
+        ADO_REPOS = [new() { Name = FOO_REPO }, new() { Name = BAR_REPO }];
 
         _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
         _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, ADO_TEAM_PROJECTS)).ReturnsAsync(APP_ID);
@@ -1031,7 +1031,7 @@ if ($Failed -ne 0) {
     public async Task ParallelScript_Single_Repo_No_Service_Connection_All_Options()
     {
         // Arrange
-        ADO_PIPELINES = new List<string> { FOO_PIPELINE, BAR_PIPELINE };
+        ADO_PIPELINES = [FOO_PIPELINE, BAR_PIPELINE];
 
         _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandlerTests.cs
@@ -251,7 +251,7 @@ public class MigrateRepoCommandHandlerTests
     [Fact]
     public async Task It_Falls_Back_To_Ado_And_Github_Pats_From_Environment_When_Not_Provided()
     {
-        _mockGithubApi.Setup(x => x.GetRepos(GITHUB_ORG).Result).Returns(new List<(string Name, string Visibility)>());
+        _mockGithubApi.Setup(x => x.GetRepos(GITHUB_ORG).Result).Returns([]);
         _mockGithubApi.Setup(x => x.GetMigration(It.IsAny<string>()).Result).Returns((State: RepositoryMigrationStatus.Succeeded, GITHUB_REPO, 0, null, null));
 
         _mockEnvironmentVariableProvider

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/OrgsCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/OrgsCsvGeneratorServiceTests.cs
@@ -21,7 +21,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
         private const string ADO_ORG = "foo-org";
-        private readonly IEnumerable<string> _adoOrgs = new List<string>() { ADO_ORG };
+        private readonly IEnumerable<string> _adoOrgs = [ADO_ORG];
 
         private readonly OrgsCsvGeneratorService _service;
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/PipelinesCsvGeneratorServiceTests.cs
@@ -20,13 +20,13 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
         private const string ADO_ORG = "foo-org";
-        private readonly IEnumerable<string> _adoOrgs = new List<string>() { ADO_ORG };
+        private readonly IEnumerable<string> _adoOrgs = [ADO_ORG];
         private const string ADO_TEAM_PROJECT = "foo-tp";
-        private readonly IEnumerable<string> _adoTeamProjects = new List<string>() { ADO_TEAM_PROJECT };
+        private readonly IEnumerable<string> _adoTeamProjects = [ADO_TEAM_PROJECT];
         private const string ADO_REPO = "foo-repo";
-        private readonly IEnumerable<AdoRepository> _adoRepos = new List<AdoRepository> { new() { Name = ADO_REPO } };
+        private readonly IEnumerable<AdoRepository> _adoRepos = [new() { Name = ADO_REPO }];
         private const string ADO_PIPELINE = "foo-pipeline";
-        private readonly IEnumerable<string> _adoPipelines = new List<string>() { ADO_PIPELINE };
+        private readonly IEnumerable<string> _adoPipelines = [ADO_PIPELINE];
 
         private readonly PipelinesCsvGeneratorService _service;
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/ReposCsvGeneratorServiceTests.cs
@@ -22,11 +22,11 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
         private const string ADO_ORG = "foo-org";
-        private readonly IEnumerable<string> _adoOrgs = new List<string>() { ADO_ORG };
+        private readonly IEnumerable<string> _adoOrgs = [ADO_ORG];
         private const string ADO_TEAM_PROJECT = "foo-tp";
-        private readonly IEnumerable<string> _adoTeamProjects = new List<string>() { ADO_TEAM_PROJECT };
+        private readonly IEnumerable<string> _adoTeamProjects = [ADO_TEAM_PROJECT];
         private const string ADO_REPO = "foo-repo";
-        private readonly IEnumerable<AdoRepository> _adoRepos = new List<AdoRepository> { new() { Name = ADO_REPO, Size = 12345 } };
+        private readonly IEnumerable<AdoRepository> _adoRepos = [new() { Name = ADO_REPO, Size = 12345 }];
 
         private readonly ReposCsvGeneratorService _service;
 

--- a/src/OctoshiftCLI.Tests/ado2gh/Services/TeamProjectsCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Services/TeamProjectsCsvGeneratorServiceTests.cs
@@ -21,9 +21,9 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands
         private readonly Mock<AdoInspectorServiceFactory> _mockAdoInspectorServiceFactory = TestHelpers.CreateMock<AdoInspectorServiceFactory>();
 
         private const string ADO_ORG = "foo-org";
-        private readonly IEnumerable<string> _adoOrgs = new List<string>() { ADO_ORG };
+        private readonly IEnumerable<string> _adoOrgs = [ADO_ORG];
         private const string ADO_TEAM_PROJECT = "foo-tp";
-        private readonly IEnumerable<string> _adoTeamProjects = new List<string>() { ADO_TEAM_PROJECT };
+        private readonly IEnumerable<string> _adoTeamProjects = [ADO_TEAM_PROJECT];
 
         private readonly TeamProjectsCsvGeneratorService _service;
 

--- a/src/OctoshiftCLI.Tests/bbs2gh/Services/BbsInspectorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Services/BbsInspectorServiceTests.cs
@@ -37,7 +37,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands
             var result = await _service.GetProjects();
 
             // Assert
-            result.Should().BeEquivalentTo(new List<(string, string)>() { (BBS_FOO_PROJECT_KEY, project1), (BBS_BAR_PROJECT_KEY, project2) });
+            result.Should().BeEquivalentTo([(BBS_FOO_PROJECT_KEY, project1), (BBS_BAR_PROJECT_KEY, project2)]);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/bbs2gh/Services/ProjectsCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Services/ProjectsCsvGeneratorServiceTests.cs
@@ -29,7 +29,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands
         private const string BBS_PASSWORD = "bbs-password";
         private const bool NO_SSL_VERIFY = true;
         private readonly (string, string) _bbsProject = (BBS_FOO_PROJECT_KEY, BBS_FOO_PROJECT);
-        private readonly IEnumerable<(string, string)> _bbsProjects = new List<(string, string)>() { (BBS_FOO_PROJECT_KEY, BBS_FOO_PROJECT), (BBS_BAR_PROJECT_KEY, BBS_BAR_PROJECT) };
+        private readonly IEnumerable<(string, string)> _bbsProjects = [(BBS_FOO_PROJECT_KEY, BBS_FOO_PROJECT), (BBS_BAR_PROJECT_KEY, BBS_BAR_PROJECT)];
 
         private readonly ProjectsCsvGeneratorService _service;
 

--- a/src/OctoshiftCLI.Tests/bbs2gh/Services/ReposCsvGeneratorServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Services/ReposCsvGeneratorServiceTests.cs
@@ -33,7 +33,7 @@ namespace OctoshiftCLI.Tests.BbsToGithub.Commands
         private const bool ARCHIVED = false;
         private const ulong REPO_SIZE = 10000UL;
         private const ulong ATTACHMENTS_SIZE = 10000UL;
-        private readonly IEnumerable<BbsRepository> _bbsRepos = new List<BbsRepository> { new() { Name = BBS_REPO, Slug = BBS_REPO_SLUG } };
+        private readonly IEnumerable<BbsRepository> _bbsRepos = [new() { Name = BBS_REPO, Slug = BBS_REPO_SLUG }];
 
         private readonly ReposCsvGeneratorService _service;
 

--- a/src/ado2gh/Services/AdoInspectorService.cs
+++ b/src/ado2gh/Services/AdoInspectorService.cs
@@ -35,7 +35,7 @@ namespace OctoshiftCLI.AdoToGithub
 
         public virtual void LoadReposCsv(string csvPath)
         {
-            _orgs = new List<string>();
+            _orgs = [];
 
             using var csvStream = OpenFileStream(csvPath);
             using var csvParser = new TextFieldParser(csvStream);
@@ -57,7 +57,7 @@ namespace OctoshiftCLI.AdoToGithub
 
                 if (!_teamProjects.ContainsKey(org))
                 {
-                    _teamProjects.Add(org, new List<string>());
+                    _teamProjects.Add(org, []);
                 }
 
                 if (!_repos.ContainsKey(org))
@@ -72,7 +72,7 @@ namespace OctoshiftCLI.AdoToGithub
 
                 if (!_repos[org].ContainsKey(teamProject))
                 {
-                    _repos[org].Add(teamProject, new List<AdoRepository>());
+                    _repos[org].Add(teamProject, []);
                 }
 
                 if (!_repos[org][teamProject].Any(x => x.Name == repo))
@@ -88,7 +88,7 @@ namespace OctoshiftCLI.AdoToGithub
             {
                 if (OrgFilter.HasValue())
                 {
-                    _orgs = new List<string>() { OrgFilter };
+                    _orgs = [OrgFilter];
                 }
                 else
                 {

--- a/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -81,7 +81,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         }
 
         var projects = args.BbsProject.HasValue()
-            ? new List<string>() { args.BbsProject }
+            ? [args.BbsProject]
             : (await _bbsApi.GetProjects()).Select(x => x.Key);
 
         foreach (var projectKey in projects)


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

The builds started failing with a bunch of linter errors. Not sure what changed because the linter WAS passing and no code has changed (maybe the build server has a newer version of dotnet that is smarter). But the linter errors it's showing are legit problems with the code so I went and fixed them all up in the codebase. 

The build still won't be fully green, because of the problems with the ADO integration tests. But I want to fix one problem per PR, so lets get this one merged to fix the linter errors then I'll push up other PR's to deal with the other problems.

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->