### PR TITLE
Add workflow permissions and a SHA argument to Integration Test Build

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,6 +6,14 @@ on:
       pr_number:
         type: number
         required: true
+      sha:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 
 jobs:
   build-for-e2e-test:
@@ -19,6 +27,18 @@ jobs:
       with:
         ref: 'refs/pull/${{ github.event.inputs.pr_number }}/merge'
         fetch-depth: 0
+
+    - name: Check SHA
+      run: |
+        prsha=`git rev-parse origin/pull/${{ github.event.inputs.pr_number }}/head | awk '{ print $1 }'`
+
+        Write-Output "PR SHA: $prsha"
+        Write-Output "expected SHA: ${{ github.event.inputs.SHA }}"
+
+        if ($prsha -ne ${{ github.event.inputs.SHA }}) {
+          Write-Error "SHA must match"
+          exit 1
+        }
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v2


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

To improve the security of the `Integration Tests` build I added explicit workflow permissions, and I required the person who queues it to specify the SHA of the PR in addition to the PR number.

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->