### PR TITLE
Fix for code scanning alert no. 932: Missed opportunity to use Where

### DIFF
--- a/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -109,12 +109,10 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
         {
             foreach (var teamProject in await _adoInspectorService.GetTeamProjects(org))
             {
-                foreach (var repo in await _adoInspectorService.GetRepos(org, teamProject))
+                foreach (var repo in (await _adoInspectorService.GetRepos(org, teamProject))
+                    .Where(repo => !seen.Add(GetGithubRepoName(teamProject, repo.Name))))
                 {
-                    if (!seen.Add(GetGithubRepoName(teamProject, repo.Name)))
-                    {
-                        _log.LogWarning($"DUPLICATE REPO NAME: {GetGithubRepoName(teamProject, repo.Name)}");
-                    }
+                    _log.LogWarning($"DUPLICATE REPO NAME: {GetGithubRepoName(teamProject, repo.Name)}");
                 }
             }
         }


### PR DESCRIPTION
Fix for [https://github.com/github/gh-gei/security/code-scanning/932](https://github.com/github/gh-gei/security/code-scanning/932)

CodeQL suggests this improvement and it's listed as 1 of 3 current security findings for this repo (I'm trying to get that list down to 0). It's a minor change, but it is arguably the better way to write that chunk of code, so I'm inclined to make the change rather than dismiss the finding.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
