### PR TITLE
Fix for code scanning alert no. 984: Call to System.IO.Path.Combine

### DIFF
--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -158,7 +158,7 @@ namespace OctoshiftCLI.IntegrationTests
 
         public async Task InitializeBbsRepo(string bbsProjectKey, string repoName)
         {
-            var repoPath = Path.Combine(Path.GetTempPath(), $"{repoName}-{Guid.NewGuid()}");
+            var repoPath = Path.Join(Path.GetTempPath(), $"{repoName}-{Guid.NewGuid()}");
 
             Directory.CreateDirectory(repoPath);
 

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -82,7 +82,7 @@ namespace OctoshiftCLI.AdoToGithub
 
         private static void WarnIfNotUsingExtension()
         {
-            if (!Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory).EndsWith(Path.Join("extensions", "gh-ado2gh").ToString()))
+            if (!Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory).EndsWith(Path.Join("extensions", "gh-ado2gh")))
             {
                 Logger.LogWarning("You are not running the ado2gh CLI as a gh extension. This is not recommended, please run: gh extension install github/gh-ado2gh");
             }

--- a/src/ado2gh/Program.cs
+++ b/src/ado2gh/Program.cs
@@ -82,7 +82,7 @@ namespace OctoshiftCLI.AdoToGithub
 
         private static void WarnIfNotUsingExtension()
         {
-            if (!Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory).EndsWith(Path.Combine("extensions", "gh-ado2gh").ToString()))
+            if (!Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory).EndsWith(Path.Join("extensions", "gh-ado2gh").ToString()))
             {
                 Logger.LogWarning("You are not running the ado2gh CLI as a gh extension. This is not recommended, please run: gh extension install github/gh-ado2gh");
             }


### PR DESCRIPTION
Fix for [https://github.com/github/gh-gei/security/code-scanning/984](https://github.com/github/gh-gei/security/code-scanning/984) and [https://github.com/github/gh-gei/security/code-scanning/983](https://github.com/github/gh-gei/security/code-scanning/983)

`Path.Combine` and `Path.Join` do effectively the same thing, but `Path.Combine` is susceptible to a potential security vulnerability whereas `Path.Join` is not. So the best practice is to always use `Path.Join`.

This should resolve the last 2 outstanding security isseus flagged in this repo.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
