### PR TITLE
Poll migration status every 60 seconds

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- Poll migration status every 60 seconds with wait-for-migration.

--- a/src/Octoshift/Commands/WaitForMigration/WaitForMigrationCommandHandler.cs
+++ b/src/Octoshift/Commands/WaitForMigration/WaitForMigrationCommandHandler.cs
@@ -9,7 +9,7 @@ namespace OctoshiftCLI.Commands.WaitForMigration;
 
 public class WaitForMigrationCommandHandler : ICommandHandler<WaitForMigrationCommandArgs>
 {
-    internal int WaitIntervalInSeconds = 10;
+    internal int WaitIntervalInSeconds = 60;
 
     private readonly OctoLogger _log;
     private readonly GithubApi _githubApi;


### PR DESCRIPTION
In practice, polling a migration every 10 seconds while performing a lot of migrations can sometimes mean that the API rate limits are hit, which can be disruptive to migrations.  This PR increases the polling time in the wait-for-migration from 10 seconds to 60 seconds to alleviate this issue.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->