### PR TITLE
Poll migration status every 60s in bbs2gh, ado2gh, and GEI organization migrations

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-- Poll migration status every 60 seconds with wait-for-migration.
+- Poll migration status every 60 seconds when waiting for migrations to complete.

--- a/src/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -77,8 +77,8 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         while (RepositoryMigrationStatus.IsPending(migrationState))
         {
-            _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. Waiting 10 seconds...");
-            await Task.Delay(10000);
+            _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. Waiting 60 seconds...");
+            await Task.Delay(60000);
             (migrationState, _, warningsCount, failureReason, migrationLogUrl) = await _githubApi.GetMigration(migrationId);
         }
 

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -19,7 +19,8 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
     private readonly IBbsArchiveDownloader _bbsArchiveDownloader;
     private readonly FileSystemProvider _fileSystemProvider;
     private readonly WarningsCountLogger _warningsCountLogger;
-    private const int CHECK_STATUS_DELAY_IN_MILLISECONDS = 10000;
+    private const int CHECK_EXPORT_STATUS_DELAY_IN_MILLISECONDS = 10000;
+    private const int CHECK_MIGRATION_STATUS_DELAY_IN_MILLISECONDS = 60000;
 
     public MigrateRepoCommandHandler(
         OctoLogger log,
@@ -170,7 +171,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         while (ExportState.IsInProgress(exportState))
         {
             _log.LogInformation($"Export status: {exportState}; {exportProgress}% complete");
-            await Task.Delay(CHECK_STATUS_DELAY_IN_MILLISECONDS);
+            await Task.Delay(CHECK_EXPORT_STATUS_DELAY_IN_MILLISECONDS);
             (exportState, exportMessage, exportProgress) = await _bbsApi.GetExport(exportId);
         }
 
@@ -274,8 +275,8 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         while (RepositoryMigrationStatus.IsPending(migrationState))
         {
-            _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. Waiting 10 seconds...");
-            await Task.Delay(CHECK_STATUS_DELAY_IN_MILLISECONDS);
+            _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. Waiting 60 seconds...");
+            await Task.Delay(CHECK_MIGRATION_STATUS_DELAY_IN_MILLISECONDS);
             (migrationState, _, warningsCount, failureReason, migrationLogUrl) = await _githubApi.GetMigration(migrationId);
         }
 

--- a/src/gei/Commands/MigrateOrg/MigrateOrgCommandHandler.cs
+++ b/src/gei/Commands/MigrateOrg/MigrateOrgCommandHandler.cs
@@ -52,13 +52,13 @@ public class MigrateOrgCommandHandler : ICommandHandler<MigrateOrgCommandArgs>
             if (OrganizationMigrationStatus.IsRepoMigration(migrationState))
             {
                 var migratedRepositoriesCount = (int)totalRepositoriesCount - (int)remainingRepositoriesCount;
-                _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. {migratedRepositoriesCount}/{totalRepositoriesCount} repo(s) migrated. Waiting 10 seconds...");
+                _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. {migratedRepositoriesCount}/{totalRepositoriesCount} repo(s) migrated. Waiting 60 seconds...");
             }
             else
             {
-                _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. Waiting 10 seconds...");
+                _log.LogInformation($"Migration in progress (ID: {migrationId}). State: {migrationState}. Waiting 60 seconds...");
             }
-            await Task.Delay(10000);
+            await Task.Delay(60000);
             (migrationState, _, _, failureReason, remainingRepositoriesCount, totalRepositoriesCount) = await _githubApi.GetOrganizationMigration(migrationId);
         }
 


### PR DESCRIPTION
Follow-up to https://github.com/github/gh-gei/pull/1392!

This PR ensures that a 60 second polling time is used for all adapters, including in bbs2gh, ado2gh, and GEI organization migrations.  This matches the new behavior in the `wait-for-migration` command where it polls every 60 seconds.

Here's some output from our integration tests that proves this functionality:

### ADO

```
[2025-07-24 05:18:36] [INFO] Migration <migration ID> for gei-e2e-2-gei-e2e-2 is QUEUED
[2025-07-24 05:18:36] [INFO] Waiting 60 seconds...
[2025-07-24 05:19:37] [INFO] Migration <migration ID> for gei-e2e-2-gei-e2e-2 is QUEUED
[2025-07-24 05:19:37] [INFO] Waiting 60 seconds...
[2025-07-24 05:20:38] [INFO] Migration <migration ID> for gei-e2e-2-gei-e2e-2 is QUEUED
[2025-07-24 05:20:38] [INFO] Waiting 60 seconds...
[2025-07-24 05:21:39] [INFO] Migration <migration ID> for gei-e2e-2-gei-e2e-2 is IN_PROGRESS
```

### BBS

```
[2025-07-24 05:16:38] [INFO] Migration in progress (ID: <migration ID>). State: PENDING_VALIDATION. Waiting 60 seconds...
[2025-07-24 05:17:39] [INFO] Migration in progress (ID: <migration ID>). State: IN_PROGRESS. Waiting 60 seconds...
[2025-07-24 05:18:39] [INFO] Migration in progress (ID: <migration ID>). State: IN_PROGRESS. Waiting 60 seconds...
[2025-07-24 05:19:39] [INFO] Migration in progress (ID: <migration ID>). State: IN_PROGRESS. Waiting 60 seconds...
[2025-07-24 05:20:40] [INFO] Migration completed (ID: <migration ID>)! State: SUCCEEDED
```

### GitHub

```
[OUTPUT] [2025-07-24 05:16:35] [INFO] Migration <migration ID> for repo-1 is QUEUED
[OUTPUT] [2025-07-24 05:16:35] [INFO] Waiting 60 seconds...
[OUTPUT] [2025-07-24 05:17:35] [INFO] Migration <migration ID> for repo-1 is IN_PROGRESS
[OUTPUT] [2025-07-24 05:17:35] [INFO] Waiting 60 seconds...
[OUTPUT] [2025-07-24 05:18:36] [INFO] Migration <migration ID> for repo-1 is IN_PROGRESS
[OUTPUT] [2025-07-24 05:18:36] [INFO] Waiting 60 seconds...
[OUTPUT] [2025-07-24 05:19:36] [INFO] Migration <migration ID> for repo-1 is IN_PROGRESS
[OUTPUT] [2025-07-24 05:19:36] [INFO] Waiting 60 seconds...
[OUTPUT] [2025-07-24 05:20:36] [INFO] Migration <migration ID> succeeded for repo-1
```

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->