### PR TITLE
Terminology fixes for migrator role commands

### DIFF
--- a/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/GrantMigratorRole/GrantMigratorRoleCommandBase.cs
@@ -10,7 +10,7 @@ public class GrantMigratorRoleCommandBase : CommandBase<GrantMigratorRoleCommand
 {
     public GrantMigratorRoleCommandBase() : base(
         name: "grant-migrator-role",
-        description: "Allows an organization admin to grant a USER or TEAM the migrator role for a single GitHub organization. The migrator role allows the role assignee to perform migrations into the target organization.")
+        description: "Allows an organization owner to grant a USER or TEAM the migrator role for a single GitHub organization. The migrator role allows the role assignee to perform migrations into the target organization.")
     {
     }
 

--- a/src/Octoshift/Commands/RevokeMigratorRole/RevokeMigratorRoleCommandBase.cs
+++ b/src/Octoshift/Commands/RevokeMigratorRole/RevokeMigratorRoleCommandBase.cs
@@ -10,7 +10,7 @@ public class RevokeMigratorRoleCommandBase : CommandBase<RevokeMigratorRoleComma
 {
     public RevokeMigratorRoleCommandBase() : base(
         name: "revoke-migrator-role",
-        description: "Allows an organization admin to revoke the migrator role for a USER or TEAM for a single GitHub organization. This will remove their ability to run a migration into the target organization.")
+        description: "Allows an organization owner to revoke the migrator role for a USER or TEAM for a single GitHub organization. This will remove their ability to run a migration into the target organization.")
     {
     }
 


### PR DESCRIPTION
Update terminology from "admin" to "owner" in descriptions for grant and revoke migrator role commands to ensure consistency and clarity with regular GitHub parlance.