### PR TITLE
Refactor the inconsistent access token resolution between ENV and CLI args 

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
 
+- Fixed issue where CLI commands required GH_PAT environment variable even when GitHub tokens were provided via command-line arguments (--github-source-pat, --github-target-pat). All migration commands now work correctly with CLI-only token authentication.

--- a/src/Octoshift/Factories/GithubApiFactory.cs
+++ b/src/Octoshift/Factories/GithubApiFactory.cs
@@ -30,7 +30,7 @@ public sealed class GithubApiFactory : ISourceGithubApiFactory, ITargetGithubApi
     {
         apiUrl ??= DEFAULT_API_URL;
         uploadsUrl ??= DEFAULT_UPLOADS_URL;
-        sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
+        sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken(throwIfNotFound: false);
         var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), _versionProvider, _retryPolicy, _dateTimeProvider, sourcePersonalAccessToken);
         var multipartUploader = new ArchiveUploader(githubClient, uploadsUrl, _octoLogger, _retryPolicy);
         return new GithubApi(githubClient, apiUrl, _retryPolicy, multipartUploader);
@@ -40,7 +40,7 @@ public sealed class GithubApiFactory : ISourceGithubApiFactory, ITargetGithubApi
     {
         apiUrl ??= DEFAULT_API_URL;
         uploadsUrl ??= DEFAULT_UPLOADS_URL;
-        sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
+        sourcePersonalAccessToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken(throwIfNotFound: false);
         var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("NoSSL"), _versionProvider, _retryPolicy, _dateTimeProvider, sourcePersonalAccessToken);
         var multipartUploader = new ArchiveUploader(githubClient, uploadsUrl, _octoLogger, _retryPolicy);
         return new GithubApi(githubClient, apiUrl, _retryPolicy, multipartUploader);
@@ -50,7 +50,7 @@ public sealed class GithubApiFactory : ISourceGithubApiFactory, ITargetGithubApi
     {
         apiUrl ??= DEFAULT_API_URL;
         uploadsUrl ??= DEFAULT_UPLOADS_URL;
-        targetPersonalAccessToken ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
+        targetPersonalAccessToken ??= _environmentVariableProvider.TargetGithubPersonalAccessToken(throwIfNotFound: false);
         var githubClient = new GithubClient(_octoLogger, _clientFactory.CreateClient("Default"), _versionProvider, _retryPolicy, _dateTimeProvider, targetPersonalAccessToken);
         var multipartUploader = new ArchiveUploader(githubClient, uploadsUrl, _octoLogger, _retryPolicy);
         return new GithubApi(githubClient, apiUrl, _retryPolicy, multipartUploader);

--- a/src/ado2gh/Commands/IntegrateBoards/IntegrateBoardsCommandHandler.cs
+++ b/src/ado2gh/Commands/IntegrateBoards/IntegrateBoardsCommandHandler.cs
@@ -29,7 +29,7 @@ public class IntegrateBoardsCommandHandler : ICommandHandler<IntegrateBoardsComm
 
         _log.LogInformation("Integrating Azure Boards...");
 
-        args.GithubPat ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
+        args.GithubPat ??= _environmentVariableProvider.TargetGithubPersonalAccessToken(throwIfNotFound: false);
 
         var adoTeamProjectId = await _adoApi.GetTeamProjectId(args.AdoOrg, args.AdoTeamProject);
         var githubHandle = await _adoApi.GetGithubHandle(args.AdoOrg, args.AdoTeamProject, args.GithubPat);

--- a/src/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/ado2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -30,7 +30,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         _log.LogInformation("Migrating Repo...");
 
-        args.GithubPat ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
+        args.GithubPat ??= _environmentVariableProvider.TargetGithubPersonalAccessToken(throwIfNotFound: false);
 
         var adoRepoUrl = GetAdoRepoUrl(args.AdoOrg, args.AdoTeamProject, args.AdoRepo, args.AdoServerUrl);
 

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -227,7 +227,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
     {
         _log.LogInformation("Creating Migration Source...");
 
-        args.GithubPat ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
+        args.GithubPat ??= _environmentVariableProvider.TargetGithubPersonalAccessToken(throwIfNotFound: false);
         var githubOrgId = await _githubApi.GetOrganizationId(args.GithubOrg);
 
         try
@@ -250,7 +250,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         var bbsRepoUrl = GetBbsRepoUrl(args);
 
-        args.GithubPat ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
+        args.GithubPat ??= _environmentVariableProvider.TargetGithubPersonalAccessToken(throwIfNotFound: false);
         var githubOrgId = await _githubApi.GetOrganizationId(args.GithubOrg);
 
         string migrationId;

--- a/src/gei/Commands/MigrateCodeScanningAlerts/MigrateCodeScanningAlertsCommand.cs
+++ b/src/gei/Commands/MigrateCodeScanningAlerts/MigrateCodeScanningAlertsCommand.cs
@@ -78,10 +78,7 @@ public class MigrateCodeScanningAlertsCommand : CommandBase<MigrateCodeScanningA
             throw new ArgumentNullException(nameof(sp));
         }
 
-        var environmentVariableProvider = sp.GetRequiredService<EnvironmentVariableProvider>();
-        args.GithubSourcePat ??= environmentVariableProvider.SourceGithubPersonalAccessToken(false);
-        args.GithubTargetPat ??= environmentVariableProvider.TargetGithubPersonalAccessToken();
-
+        // The factory handles environment variable resolution
         if (args.GithubSourcePat.IsNullOrWhiteSpace())
         {
             args.GithubSourcePat = args.GithubTargetPat;

--- a/src/gei/Commands/MigrateOrg/MigrateOrgCommandHandler.cs
+++ b/src/gei/Commands/MigrateOrg/MigrateOrgCommandHandler.cs
@@ -72,7 +72,7 @@ public class MigrateOrgCommandHandler : ICommandHandler<MigrateOrgCommandArgs>
     }
 
     private string GetSourceToken(MigrateOrgCommandArgs args) =>
-        args.GithubSourcePat ?? _environmentVariableProvider.SourceGithubPersonalAccessToken();
+        args.GithubSourcePat ?? _environmentVariableProvider.SourceGithubPersonalAccessToken(throwIfNotFound: false);
 
     private string GetGithubOrgUrl(string org, string baseUrl) => $"{baseUrl ?? DEFAULT_GITHUB_BASE_URL}/{org.EscapeDataString()}";
 }

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommandHandler.cs
@@ -151,7 +151,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
 
         var sourceRepoUrl = GetSourceRepoUrl(args);
         var sourceToken = GetSourceToken(args);
-        var targetToken = args.GithubTargetPat ?? _environmentVariableProvider.TargetGithubPersonalAccessToken();
+        var targetToken = args.GithubTargetPat ?? _environmentVariableProvider.TargetGithubPersonalAccessToken(throwIfNotFound: false);
 
         string migrationId;
 
@@ -212,7 +212,7 @@ public class MigrateRepoCommandHandler : ICommandHandler<MigrateRepoCommandArgs>
         _log.LogInformation($"Migration log available at {migrationLogUrl} or by running `gh {CliContext.RootCommand} download-logs --github-target-org {args.GithubTargetOrg} --target-repo {args.TargetRepo}`");
     }
 
-    private string GetSourceToken(MigrateRepoCommandArgs args) => args.GithubSourcePat ?? _environmentVariableProvider.SourceGithubPersonalAccessToken();
+    private string GetSourceToken(MigrateRepoCommandArgs args) => args.GithubSourcePat ?? _environmentVariableProvider.SourceGithubPersonalAccessToken(throwIfNotFound: false);
 
     private string GetSourceRepoUrl(MigrateRepoCommandArgs args) => GetGithubRepoUrl(args.GithubSourceOrg, args.SourceRepo, args.GhesApiUrl.HasValue() ? ExtractGhesBaseUrl(args.GhesApiUrl) : null);
 

--- a/src/gei/Commands/MigrateSecretAlerts/MigrateSecretAlertsCommand.cs
+++ b/src/gei/Commands/MigrateSecretAlerts/MigrateSecretAlertsCommand.cs
@@ -78,10 +78,7 @@ public class MigrateSecretAlertsCommand : CommandBase<MigrateSecretAlertsCommand
             throw new ArgumentNullException(nameof(sp));
         }
 
-        var environmentVariableProvider = sp.GetRequiredService<EnvironmentVariableProvider>();
-        args.GithubSourcePat ??= environmentVariableProvider.SourceGithubPersonalAccessToken(false);
-        args.GithubTargetPat ??= environmentVariableProvider.TargetGithubPersonalAccessToken();
-
+        // The factory handles environment variable resolution
         if (args.GithubSourcePat.IsNullOrWhiteSpace())
         {
             args.GithubSourcePat = args.GithubTargetPat;

--- a/src/gei/Factories/CodeScanningAlertServiceFactory.cs
+++ b/src/gei/Factories/CodeScanningAlertServiceFactory.cs
@@ -25,13 +25,27 @@ public class CodeScanningAlertServiceFactory
     public virtual CodeScanningAlertService
         Create(string sourceApi, string sourceToken, string targetApi, string targetToken, bool sourceApiNoSsl = false)
     {
-        sourceToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
-        targetToken ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
+        // Only resolve from environment if tokens are explicitly null
+        // Use consistent throwIfNotFound=false to prevent exceptions when CLI args are preferred
+        sourceToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken(false);
+
+        targetToken ??= _environmentVariableProvider.TargetGithubPersonalAccessToken(false);
+
+        // Validate that we have tokens after all resolution attempts
+        if (string.IsNullOrWhiteSpace(sourceToken))
+        {
+            throw new OctoshiftCliException("Source GitHub Personal Access Token is required. Provide it via --github-source-pat argument or GH_SOURCE_PAT/GH_PAT environment variable.");
+        }
+
+        if (string.IsNullOrWhiteSpace(targetToken))
+        {
+            throw new OctoshiftCliException("Target GitHub Personal Access Token is required. Provide it via --github-target-pat argument or GH_PAT environment variable.");
+        }
 
         var sourceGithubApi = sourceApiNoSsl
-            ? _sourceGithubApiFactory.CreateClientNoSsl(sourceApi, sourceToken)
-            : _sourceGithubApiFactory.Create(sourceApi, sourceToken);
+            ? _sourceGithubApiFactory.CreateClientNoSsl(sourceApi, null, sourceToken)
+            : _sourceGithubApiFactory.Create(sourceApi, null, sourceToken);
 
-        return new(sourceGithubApi, _targetGithubApiFactory.Create(targetApi, targetToken), _octoLogger);
+        return new(sourceGithubApi, _targetGithubApiFactory.Create(targetApi, null, targetToken), _octoLogger);
     }
 }

--- a/src/gei/Factories/SecretScanningAlertServiceFactory.cs
+++ b/src/gei/Factories/SecretScanningAlertServiceFactory.cs
@@ -25,13 +25,27 @@ public class SecretScanningAlertServiceFactory
     public virtual SecretScanningAlertService
         Create(string sourceApi, string sourceToken, string targetApi, string targetToken, bool sourceApiNoSsl = false)
     {
-        sourceToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken();
-        targetToken ??= _environmentVariableProvider.TargetGithubPersonalAccessToken();
+        // Only resolve from environment if tokens are explicitly null
+        // Use consistent throwIfNotFound=false to prevent exceptions when CLI args are preferred
+        sourceToken ??= _environmentVariableProvider.SourceGithubPersonalAccessToken(false);
+
+        targetToken ??= _environmentVariableProvider.TargetGithubPersonalAccessToken(false);
+
+        // Validate that we have tokens after all resolution attempts
+        if (string.IsNullOrWhiteSpace(sourceToken))
+        {
+            throw new OctoshiftCliException("Source GitHub Personal Access Token is required. Provide it via --github-source-pat argument or GH_SOURCE_PAT/GH_PAT environment variable.");
+        }
+
+        if (string.IsNullOrWhiteSpace(targetToken))
+        {
+            throw new OctoshiftCliException("Target GitHub Personal Access Token is required. Provide it via --github-target-pat argument or GH_PAT environment variable.");
+        }
 
         var sourceGithubApi = sourceApiNoSsl
-            ? _sourceGithubApiFactory.CreateClientNoSsl(sourceApi, sourceToken)
-            : _sourceGithubApiFactory.Create(sourceApi, sourceToken);
+            ? _sourceGithubApiFactory.CreateClientNoSsl(sourceApi, null, sourceToken)
+            : _sourceGithubApiFactory.Create(sourceApi, null, sourceToken);
 
-        return new(sourceGithubApi, _targetGithubApiFactory.Create(targetApi, targetToken), _octoLogger);
+        return new(sourceGithubApi, _targetGithubApiFactory.Create(targetApi, null, targetToken), _octoLogger);
     }
 }


### PR DESCRIPTION
This pull request improves how GitHub Personal Access Tokens (PATs) are resolved throughout the codebase. 

The issue was identified in the #1409. After investigating it turned out there were inconsistencies on how we resolve PATs CLI provided and ENV provided ones. 

The following issues were identified:
- Redundant token resolution: Both command handlers and factories attempt to resolve tokens from environment variables
- Inconsistent error handling: Different throwIfNotFound parameters across the codebase
- Tight coupling: Factories are tightly coupled to EnvironmentVariableProvider even when not needed
- Pattern inconsistency: Different factory classes may have different token resolution behaviors

This PR tries to consolidate to one solution and uses the same pattern everywhere. The order is as follows:

1. CLI args first: --github-source-pat, --github-target-pat, etc.
2. ENV variables second: GH_SOURCE_PAT, GH_PAT, etc.
3. Gracefull fallback: No exceptions thrown if env vars missing
4. Clear error messages: Mode descriptitive errors only when no token is found at all

Improvements from user perspective:
- CLI arguments work reliably without requiring environment variables
- Consistent behavior across all migration commands

Code perspective:
- Clean separation of concerns between commands and factories
- Consistent error handling
- Single source of truth for token resolution logic
- Easier to add new commands with token requirements

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->