### PR TITLE
Refresh GitHub git archive URLs if they have expired

### DIFF
--- a/src/Octoshift/Commands/CreateTeam/CreateTeamCommandHandler.cs
+++ b/src/Octoshift/Commands/CreateTeam/CreateTeamCommandHandler.cs
@@ -44,32 +44,15 @@ public class CreateTeamCommandHandler : ICommandHandler<CreateTeamCommandArgs>
         }
         else
         {
-            _log.LogInformation($"Attempting to link team '{args.TeamName}' to IDP group '{args.IdpGroup}'");
-
             var members = await _githubApi.GetTeamMembers(args.GithubOrg, teamSlug);
-            _log.LogInformation($"Found {members.Count()} existing team members to remove before linking to IDP group");
 
             foreach (var member in members)
             {
-                _log.LogInformation($"Removing team member '{member}' from team '{teamSlug}'");
                 await _githubApi.RemoveTeamMember(args.GithubOrg, teamSlug, member);
             }
 
-            _log.LogInformation($"Searching for IDP group '{args.IdpGroup}' in organization '{args.GithubOrg}'");
+            var idpGroupId = await _githubApi.GetIdpGroupId(args.GithubOrg, args.IdpGroup);
 
-            int idpGroupId;
-            try
-            {
-                idpGroupId = await _githubApi.GetIdpGroupId(args.GithubOrg, args.IdpGroup);
-                _log.LogInformation($"Found IDP group '{args.IdpGroup}' with ID: {idpGroupId}");
-            }
-            catch (OctoshiftCliException ex)
-            {
-                _log.LogError($"Failed to find IDP group: {ex.Message}");
-                throw;
-            }
-
-            _log.LogInformation($"Adding IDP group '{args.IdpGroup}' (ID: {idpGroupId}) to team '{teamSlug}'");
             await _githubApi.AddEmuGroupToTeam(args.GithubOrg, teamSlug, idpGroupId);
 
             _log.LogSuccess("Successfully linked team to Idp group");

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -390,7 +390,7 @@ public class GithubApi
                     $lockSource: Boolean)";
         var gql = @"
                 startRepositoryMigration(
-                    input: {
+                    input: { 
                         sourceId: $sourceId,
                         ownerId: $ownerId,
                         sourceRepositoryUrl: $sourceRepositoryUrl,
@@ -456,7 +456,7 @@ public class GithubApi
                         $targetEnterpriseId: ID!,
                         $sourceAccessToken: String!)";
         var gql = @"
-                startOrganizationMigration(
+                startOrganizationMigration( 
                     input: {
                         sourceOrgUrl: $sourceOrgUrl,
                         targetOrgName: $targetOrgName,
@@ -620,15 +620,8 @@ public class GithubApi
     {
         var url = $"{_apiUrl}/orgs/{org.EscapeDataString()}/external-groups";
 
-        var allGroups = await _client.GetAllAsync(url, data => (JArray)data["groups"]).ToListAsync();
-
-        var group = allGroups.SingleOrDefault(x => string.Equals((string)x["group_name"], groupName, StringComparison.OrdinalIgnoreCase));
-
-        if (group == null)
-        {
-            var availableGroups = string.Join(", ", allGroups.Select(g => $"'{g["group_name"]}'"));
-            throw new OctoshiftCliException($"IDP group '{groupName}' not found in organization '{org}'. Available groups: {availableGroups}");
-        }
+        var group = await _client.GetAllAsync(url, data => (JArray)data["groups"])
+            .SingleAsync(x => string.Equals((string)x["group_name"], groupName, StringComparison.OrdinalIgnoreCase));
 
         return (int)group["group_id"];
     }
@@ -1084,7 +1077,7 @@ public class GithubApi
                 )";
         var gql = @"
                 abortRepositoryMigration(
-                    input: {
+                    input: { 
                         migrationId: $migrationId
                     })
                    { success }";

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -272,7 +272,7 @@ public class GithubApiTests
                     ""id"": 1
                 }},
                 {{
-                    ""login"": ""{teamMember2}"",
+                    ""login"": ""{teamMember2}"", 
                     ""id"": 2
                 }}
             ]";
@@ -286,7 +286,7 @@ public class GithubApiTests
                     ""id"": 3
                 }},
                 {{
-                    ""login"": ""{teamMember4}"",
+                    ""login"": ""{teamMember4}"", 
                     ""id"": 4
                 }}
             ]";
@@ -555,7 +555,7 @@ public class GithubApiTests
         var role = "admin";
         var response = $@"
             {{
-                ""role"": ""{role}""
+                ""role"": ""{role}"" 
             }}";
 
         _githubClientMock
@@ -638,15 +638,15 @@ public class GithubApiTests
             $"{{\"query\":\"query($login: String!) {{organization(login: $login) {{ login, id, name }} }}\",\"variables\":{{\"login\":\"{GITHUB_ORG}\"}}}}";
         var response = JObject.Parse($@"
             {{
-                ""data"":
+                ""data"": 
                     {{
-                        ""organization"":
+                        ""organization"": 
                             {{
                                 ""login"": ""{GITHUB_ORG}"",
                                 ""id"": ""{orgId}"",
-                                ""name"": ""github""
-                            }}
-                    }}
+                                ""name"": ""github"" 
+                            }} 
+                    }} 
             }}");
 
         _githubClientMock
@@ -672,15 +672,15 @@ public class GithubApiTests
 
         var response = JObject.Parse($@"
             {{
-                ""data"":
+                ""data"": 
                     {{
-                        ""organization"":
+                        ""organization"": 
                             {{
                                 ""login"": ""{GITHUB_ORG}"",
                                 ""id"": ""{orgId}"",
-                                ""name"": ""github""
-                            }}
-                    }}
+                                ""name"": ""github"" 
+                            }} 
+                    }} 
             }}");
 
         _githubClientMock
@@ -739,15 +739,15 @@ public class GithubApiTests
 
         var response = JObject.Parse($@"
            {{
-                ""data"":
+                ""data"": 
                     {{
-                        ""organization"":
+                        ""organization"": 
                             {{
                                 ""login"": ""{GITHUB_ORG}"",
                                 ""databaseId"": ""{databaseId}"",
-                                ""name"": ""github""
-                            }}
-                    }}
+                                ""name"": ""github"" 
+                            }} 
+                    }} 
             }}");
 
         _githubClientMock
@@ -775,14 +775,14 @@ public class GithubApiTests
             $"{{\"query\":\"query($slug: String!) {{enterprise (slug: $slug) {{ slug, id }} }}\",\"variables\":{{\"slug\":\"{GITHUB_ENTERPRISE}\"}}}}";
         var response = JObject.Parse($@"
             {{
-                ""data"":
+                ""data"": 
                     {{
-                        ""enterprise"":
+                        ""enterprise"": 
                             {{
                                 ""slug"": ""{GITHUB_ENTERPRISE}"",
                                 ""id"": ""{enterpriseId}""
-                            }}
-                    }}
+                            }} 
+                    }} 
             }}");
 
         _githubClientMock
@@ -808,14 +808,14 @@ public class GithubApiTests
 
         var response = JObject.Parse($@"
             {{
-                ""data"":
+                ""data"": 
                     {{
-                        ""enterprise"":
+                        ""enterprise"": 
                             {{
                                 ""slug"": ""{GITHUB_ENTERPRISE}"",
                                 ""id"": ""{enterpriseId}""
-                            }}
-                    }}
+                            }} 
+                    }} 
             }}");
 
         _githubClientMock
@@ -1005,7 +1005,7 @@ public class GithubApiTests
                     $lockSource: Boolean)";
         const string gql = @"
                 startRepositoryMigration(
-                    input: {
+                    input: { 
                         sourceId: $sourceId,
                         ownerId: $ownerId,
                         sourceRepositoryUrl: $sourceRepositoryUrl,
@@ -1115,7 +1115,7 @@ public class GithubApiTests
                     $lockSource: Boolean)";
         const string gql = @"
                 startRepositoryMigration(
-                    input: {
+                    input: { 
                         sourceId: $sourceId,
                         ownerId: $ownerId,
                         sourceRepositoryUrl: $sourceRepositoryUrl,
@@ -1201,7 +1201,7 @@ public class GithubApiTests
         // Arrange
         var response = JObject.Parse(@"
             {
-                ""data"": {
+                ""data"": { 
                     ""startRepositoryMigration"": {
                         ""repositoryMigration"": {
                             ""id"": ""RM_kgC4NjFhNmE2NGU2ZWE1YTQwMDA5ODliZjhi""
@@ -1799,43 +1799,6 @@ public class GithubApiTests
     }
 
     [Fact]
-    public async Task GetIdpGroupId_Throws_OctoshiftCliException_When_Group_Not_Found()
-    {
-        // Arrange
-        const string groupName = "NONEXISTENT_GROUP";
-
-        var url = $"https://api.github.com/orgs/{GITHUB_ORG}/external-groups";
-
-        var group1 = new
-        {
-            group_id = 123,
-            group_name = "existing-group-1",
-            updated_at = DateTime.Parse("2021-01-24T11:31:04-06:00")
-        };
-        var group2 = new
-        {
-            group_id = 456,
-            group_name = "existing-group-2",
-            updated_at = DateTime.Parse("2021-03-24T11:31:04-06:00")
-        };
-
-        _githubClientMock
-            .Setup(m => m.GetAllAsync(url, It.IsAny<Func<JToken, JArray>>(), null))
-            .Returns(new[]
-            {
-                JToken.FromObject(group1),
-                JToken.FromObject(group2)
-            }.ToAsyncEnumerable());
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<OctoshiftCliException>(
-            () => _githubApi.GetIdpGroupId(GITHUB_ORG, groupName));
-
-        exception.Message.Should().Contain($"IDP group '{groupName}' not found in organization '{GITHUB_ORG}'");
-        exception.Message.Should().Contain("Available groups: 'existing-group-1', 'existing-group-2'");
-    }
-
-    [Fact]
     public async Task GetTeamSlug_Returns_The_Team_Slug()
     {
         // Arrange
@@ -2055,14 +2018,14 @@ public class GithubApiTests
 
         var response = JObject.Parse($@"
             {{
-                ""data"":
+                ""data"": 
                     {{
-                        ""user"":
+                        ""user"": 
                             {{
                                 ""id"": ""{userId}"",
-                                ""name"": ""{login}""
-                            }}
-                    }}
+                                ""name"": ""{login}"" 
+                            }} 
+                    }} 
             }}");
 
         _githubClientMock
@@ -2162,7 +2125,7 @@ public class GithubApiTests
         var url = $"https://api.github.com/graphql";
 
         var payload =
-@"{""query"":""query($id: ID!, $first: Int, $after: String) {
+@"{""query"":""query($id: ID!, $first: Int, $after: String) { 
                 node(id: $id) {
                     ... on Organization {
                         mannequins(first: $first, after: $after) {
@@ -2213,7 +2176,7 @@ $",\"variables\":{{\"id\":\"{orgId}\"}}}}";
         var url = $"https://api.github.com/graphql";
 
         var payload =
-@"{""query"":""query($id: ID!, $first: Int, $after: String) {
+@"{""query"":""query($id: ID!, $first: Int, $after: String) { 
                 node(id: $id) {
                     ... on Organization {
                         mannequins(first: $first, after: $after) {
@@ -2296,7 +2259,7 @@ $",\"variables\":{{\"id\":\"{orgId}\"}}}}";
         var url = $"https://api.github.com/graphql";
 
         var payload =
-@"{""query"":""query($id: ID!, $first: Int, $after: String) {
+@"{""query"":""query($id: ID!, $first: Int, $after: String) { 
                 node(id: $id) {
                     ... on Organization {
                         mannequins(first: $first, after: $after) {
@@ -2380,7 +2343,7 @@ $",\"variables\":{{\"id\":\"{orgId}\"}}}}";
         var url = $"https://api.github.com/graphql";
 
         var payload =
-@"{""query"":""query($id: ID!, $first: Int, $after: String, $login: String) {
+@"{""query"":""query($id: ID!, $first: Int, $after: String, $login: String) { 
                 node(id: $id) {
                     ... on Organization {
                         mannequins(first: $first, after: $after, login: $login) {
@@ -2430,7 +2393,7 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
         var url = $"https://api.github.com/graphql";
 
         var payload =
-@"{""query"":""query($id: ID!, $first: Int, $after: String, $login: String) {
+@"{""query"":""query($id: ID!, $first: Int, $after: String, $login: String) { 
                 node(id: $id) {
                     ... on Organization {
                         mannequins(first: $first, after: $after, login: $login) {
@@ -3022,7 +2985,7 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
 
         var response = $@"
             {{
-                ""default_branch"": ""main""
+                ""default_branch"": ""main"" 
             }}";
 
         _githubClientMock
@@ -3405,7 +3368,7 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
         var response = $@"
                 {{
                     ""id"": ""sarif-id"",
-                }}
+                }}  
             ";
         _githubClientMock
             .Setup(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == expectedPayload.ToJson()), null))
@@ -3438,7 +3401,7 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
         var response = $@"
                 {{
                     ""id"": ""sarif-id"",
-                }}
+                }}  
             ";
         _githubClientMock
             .SetupSequence(m => m.PostAsync(url, It.Is<object>(x => x.ToJson() == expectedPayload.ToJson()), null))
@@ -3463,7 +3426,7 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
                 {{
                     ""analyses_url"": ""https://api.,github.com/repos/{GITHUB_ORG}/{GITHUB_REPO}/code-scanning/sarifs/sarif-id"",
                     ""processing_status"": ""pending""
-                }}
+                }}  
             ";
         _githubClientMock
             .Setup(m => m.GetAsync(url, null))
@@ -3490,7 +3453,7 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
                         ""error1"",
                         ""error2""
                     ]
-                }}
+                }}  
             ";
         _githubClientMock
             .Setup(m => m.GetAsync(url, null))
@@ -3569,7 +3532,7 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
                 )";
         const string gql = @"
                 abortRepositoryMigration(
-                    input: {
+                    input: { 
                         migrationId: $migrationId
                     })
                    { success }";
@@ -3587,9 +3550,9 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
         const bool actualBooleanResponse = true;
         var response = JObject.Parse($@"
             {{
-                ""data"":
+                ""data"": 
                     {{
-                        ""abortRepositoryMigration"":
+                        ""abortRepositoryMigration"": 
                             {{
                                 ""success"": ""{actualBooleanResponse}""
                             }}
@@ -3628,7 +3591,7 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
     [Fact]
     public async Task UploadArchiveToGithubStorage_Should_Upload_The_Content()
     {
-        //Arange
+        //Arange 
         const string orgDatabaseId = "1234";
         const string archiveName = "archiveName";
 


### PR DESCRIPTION
This PR fixes an issue when sometimes for GitHub migrations the metadata export takes a long time and it causes the gitArchiveUrl that was generated right before starting with the metadata export to expire. What we now do is check to see if the git archive URL expires (by catching 403 errors for migrations backed by Azure/S3 or 404 errors when backed by GHES local storage) and if so, re-fresh the download URL to allow the download to continue.


- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->