### PR TITLE
Fix environment variable injection vulnerability in publish-test-results workflow

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           eventjson=`cat 'artifacts/Event File/event.json'`
           prnumber=`echo $(jq -r '.pull_request.number' <<< "$eventjson")`
-          echo "PR_NUMBER=$(echo $prnumber | tr -cd '[0-9]')" >> $GITHUB_ENV
+          echo "PR_NUMBER=$(echo $prnumber | tr -cd '0-9')" >> $GITHUB_ENV
       
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
Resolves code scanning alert #1035 - Environment variable injection in `publish-test-results.yml` workflow by correcting the tr command to properly sanitize PR_NUMBER. Changed from `tr -cd '[0-9]'` to `tr -cd '0-9'` to ensure only digits are allowed, preventing potential injection attacks from user-controlled workflow_run events.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [x] Issue linked (https://github.com/github/gh-gei/security/code-scanning/1035)
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)


<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->