### PR TITLE
External PR 1471: Add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -159,9 +159,6 @@ jobs:
       checks: write
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'github'
     needs: [build-for-e2e-test]
-    permissions:
-      checks: write
-      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

This PR adds explicit permissions to the CI workflow following security best practices and the principle of least privilege.

## Context

This is based on external PR #1471 by @yugannkt. This fixes the 403 errors we've been seeing in CI when publishing test results and ensures all jobs have only the permissions they need.

## Changes

- **Workflow-level**: Set default `contents: read` as baseline
- **build job**: `contents: read`, `actions: write`, `security-events: write` (for checkout, artifacts, CodeQL)
- **upload-event-file job**: `contents: read`, `actions: write` (for uploading event file)
- **build-for-e2e-test job**: `contents: read`, `actions: write` (for building and uploading binaries)
- **e2e-test job**: `contents: read`, `actions: write`, `checks: write` (for downloading artifacts, uploading logs, publishing test results)
- **publish job**: `contents: write` (for creating releases and committing release notes)

This follows the principle of least privilege by giving each job only the permissions it actually needs.

Fixes #1457