### PR TITLE
Pin 3rd-party GitHub Actions to commit hashes to avoid supply chain attacks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: extractions/setup-just@v3
+      # e33e0265a09d6d736e2ee1e0eb685ef1de4669ff is tag v3, pinned to avoid supply chain attacks
+      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff
       - name: Initialize CodeQL
         if: matrix.runner-os == 'ubuntu-latest'
         uses: github/codeql-action/init@v4
@@ -63,7 +64,8 @@ jobs:
         run: cp coverage/**/coverage.cobertura.xml coverage/coverage.cobertura.xml
 
       - name: Code Coverage Summary Report
-        uses: irongut/CodeCoverageSummary@v1.3.0
+        # 51cc3a756ddcd398d447c044c02cb6aa83fdae95 is tag v1.3.0, pinned to avoid supply chain attacks
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95
         if: always() && matrix.runner-os == 'ubuntu-latest' && matrix.language == 'csharp'
         with:
           filename: coverage/coverage.cobertura.xml
@@ -118,7 +120,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: extractions/setup-just@v3
+      # e33e0265a09d6d736e2ee1e0eb685ef1de4669ff is tag v3, pinned to avoid supply chain attacks
+      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -266,7 +269,8 @@ jobs:
         run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --filter "${{ matrix.source-vcs }}ToGithub" --logger:"junit;LogFilePath=integration-tests.xml" --logger "console;verbosity=normal" /p:VersionPrefix=9.9
 
       - name: Publish Integration Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        # 6e8f8c55b476f977d1c58cfbd7e337cbf86d917f is tag v2, pinned to avoid supply chain attacks
+        uses: EnricoMi/publish-unit-test-result-action@6e8f8c55b476f977d1c58cfbd7e337cbf86d917f
         if: always() && matrix.runner-os == 'ubuntu-latest' && github.actor != 'dependabot[bot]'
         with:
           files: "**/*-tests.xml"
@@ -333,7 +337,8 @@ jobs:
           CLI_VERSION: ${{ github.ref }}
 
       - name: Create gh-gei Release
-        uses: softprops/action-gh-release@v2
+        # a06a81a03ee405af7f2048a818ed3f03bbf83c7b is tag v2, pinned to avoid supply chain attacks
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
           body_path: ./RELEASENOTES.md
           files: |
@@ -349,7 +354,8 @@ jobs:
             ./dist/osx-x64/gei-darwin-amd64
 
       - name: Create gh-ado2gh Release
-        uses: softprops/action-gh-release@v2
+        # a06a81a03ee405af7f2048a818ed3f03bbf83c7b is tag v2, pinned to avoid supply chain attacks
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
           body_path: ./RELEASENOTES.md
           repository: github/gh-ado2gh
@@ -362,7 +368,8 @@ jobs:
             ./dist/osx-x64/ado2gh-darwin-amd64
 
       - name: Create gh-bbs2gh Release
-        uses: softprops/action-gh-release@v2
+        # a06a81a03ee405af7f2048a818ed3f03bbf83c7b is tag v2, pinned to avoid supply chain attacks
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
           body_path: ./RELEASENOTES.md
           repository: github/gh-bbs2gh

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -203,7 +203,8 @@ jobs:
       run: dotnet test src/OctoshiftCLI.IntegrationTests/OctoshiftCLI.IntegrationTests.csproj --filter "${{ matrix.source-vcs }}ToGithub" --logger:"junit;LogFilePath=integration-tests.xml" --logger "console;verbosity=normal" /p:VersionPrefix=9.9
 
     - name: Publish Integration Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2
+      # 6e8f8c55b476f977d1c58cfbd7e337cbf86d917f is tag v2, pinned to avoid supply chain attacks
+      uses: EnricoMi/publish-unit-test-result-action@6e8f8c55b476f977d1c58cfbd7e337cbf86d917f
       if: always() && matrix.runner-os == 'ubuntu-latest'
       with:
         files: "**/*-tests.xml"

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -39,7 +39,8 @@ jobs:
           sanitized_prnumber=$(grep -E '^[0-9]+$' <<< "$prnumber")
           echo "PR_NUMBER=$sanitized_prnumber" >> "$GITHUB_ENV"
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        # 6e8f8c55b476f977d1c58cfbd7e337cbf86d917f is tag v2, pinned to avoid supply chain attacks
+        uses: EnricoMi/publish-unit-test-result-action@6e8f8c55b476f977d1c58cfbd7e337cbf86d917f
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json
@@ -48,7 +49,8 @@ jobs:
           check_name: "Unit Test Results"
 
       - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        # 773744901bac0e8cbb5a0dc842800d45e9b2b405 is tag v2, pinned to avoid supply chain attacks
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405
         with:
           recreate: true
           path: artifacts/Code Coverage Report/code-coverage-results.md


### PR DESCRIPTION
Addresses the following code-scanning alerts:
- https://github.com/github/gh-gei/security/code-scanning/1036
- https://github.com/github/gh-gei/security/code-scanning/1037
- https://github.com/github/gh-gei/security/code-scanning/1038
- https://github.com/github/gh-gei/security/code-scanning/1041
- https://github.com/github/gh-gei/security/code-scanning/1042
- https://github.com/github/gh-gei/security/code-scanning/1043
- https://github.com/github/gh-gei/security/code-scanning/1044
- https://github.com/github/gh-gei/security/code-scanning/1045

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->