### PR TITLE
Fix unnecessary retries on repository existence checks

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,3 @@
 - Added validation to detect and return clear error messages when a URL is provided instead of a name for organization, repository, or enterprise arguments (e.g., `--github-org`, `--github-target-org`, `--source-repo`, `--github-target-enterprise`)
+- Fixed an issue where repository existence checks would incorrectly retry on expected responses (200/404/301), causing unnecessary delays during migrations. The check now only retries on transient server errors (5xx status codes) while responding immediately to deterministic states.
 - Added `--target-api-url` as an optional arg to the `add-team-to-repo` command

--- a/src/Octoshift/Services/GithubClient.cs
+++ b/src/Octoshift/Services/GithubClient.cs
@@ -45,7 +45,13 @@ public class GithubClient
         }
     }
 
-    public virtual async Task<string> GetNonSuccessAsync(string url, HttpStatusCode status) => (await GetWithRetry(url, expectedStatus: status)).Content;
+    public virtual async Task<string> GetNonSuccessAsync(string url, HttpStatusCode status)
+    {
+        return (await _retryPolicy.HttpRetry(
+            async () => await SendAsync(HttpMethod.Get, url, expectedStatus: status),
+            ex => ex.StatusCode.HasValue && (int)ex.StatusCode.Value >= 500
+        )).Content;
+    }
 
     public virtual async Task<string> GetAsync(string url, Dictionary<string, string> customHeaders = null) => (await GetWithRetry(url, customHeaders)).Content;
 

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubClientTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubClientTests.cs
@@ -1063,7 +1063,65 @@ public sealed class GithubClientTests
     }
 
     [Fact]
-    public async Task GetNonSuccessAsync_Retries_On_Non_Success()
+    public async Task GetNonSuccessAsync_Does_Not_Retry_On_Expected_Status()
+    {
+        // Arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(CreateHttpResponseFactory(statusCode: HttpStatusCode.NotFound, content: "Not Found"));
+
+        using var httpClient = new HttpClient(handlerMock.Object);
+        var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
+
+        // Act
+        var result = await githubClient.GetNonSuccessAsync(URL, HttpStatusCode.NotFound);
+
+        // Assert
+        result.Should().Be("Not Found");
+        handlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetNonSuccessAsync_Does_Not_Retry_On_Unexpected_Success_Status()
+    {
+        // Arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(CreateHttpResponseFactory(statusCode: HttpStatusCode.OK, content: "Success"));
+
+        using var httpClient = new HttpClient(handlerMock.Object);
+        var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
+
+        // Act & Assert - should throw immediately without retry
+        await FluentActions
+            .Invoking(async () => await githubClient.GetNonSuccessAsync(URL, HttpStatusCode.NotFound))
+            .Should()
+            .ThrowExactlyAsync<HttpRequestException>()
+            .WithMessage("*OK*");
+
+        handlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetNonSuccessAsync_Retries_On_Server_Error()
     {
         // Arrange
         var handlerMock = new Mock<HttpMessageHandler>();
@@ -1073,17 +1131,82 @@ public sealed class GithubClientTests
                 "SendAsync",
                 ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
                 ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(CreateHttpResponseFactory(statusCode: HttpStatusCode.InternalServerError))
-            .ReturnsAsync(CreateHttpResponseFactory(statusCode: HttpStatusCode.Found, content: EXPECTED_RESPONSE_CONTENT));
+            .ReturnsAsync(CreateHttpResponseFactory(statusCode: HttpStatusCode.InternalServerError, content: "Server Error"))
+            .ReturnsAsync(CreateHttpResponseFactory(statusCode: HttpStatusCode.NotFound, content: "Not Found"));
 
         using var httpClient = new HttpClient(handlerMock.Object);
         var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
 
-        // Act
-        var result = await githubClient.GetNonSuccessAsync(URL, HttpStatusCode.Found);
+        // Act - should retry on 5xx and eventually succeed
+        var result = await githubClient.GetNonSuccessAsync(URL, HttpStatusCode.NotFound);
 
         // Assert
-        result.Should().Be(EXPECTED_RESPONSE_CONTENT);
+        result.Should().Be("Not Found");
+        handlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(2),
+            ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetNonSuccessAsync_Does_Not_Retry_On_Client_Error()
+    {
+        // Arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(CreateHttpResponseFactory(statusCode: HttpStatusCode.BadRequest, content: "Bad Request"));
+
+        using var httpClient = new HttpClient(handlerMock.Object);
+        var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
+
+        // Act & Assert - should throw immediately without retry on 4xx
+        await FluentActions
+            .Invoking(async () => await githubClient.GetNonSuccessAsync(URL, HttpStatusCode.NotFound))
+            .Should()
+            .ThrowExactlyAsync<HttpRequestException>()
+            .WithMessage("*BadRequest*");
+
+        handlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetNonSuccessAsync_Does_Not_Retry_On_Redirect_Status()
+    {
+        // Arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(CreateHttpResponseFactory(statusCode: HttpStatusCode.MovedPermanently, content: "Moved"));
+
+        using var httpClient = new HttpClient(handlerMock.Object);
+        var githubClient = new GithubClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy, _dateTimeProvider.Object, PERSONAL_ACCESS_TOKEN);
+
+        // Act & Assert - should throw immediately without retry on redirect
+        await FluentActions
+            .Invoking(async () => await githubClient.GetNonSuccessAsync(URL, HttpStatusCode.NotFound))
+            .Should()
+            .ThrowExactlyAsync<HttpRequestException>()
+            .WithMessage("*MovedPermanently*");
+
+        handlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+            ItExpr.IsAny<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
This PR merges external PR #1478 from @AakashSuresh2003 which fixes issue #1447.

## Summary
Modified `GetNonSuccessAsync` to only retry on transient 5xx server errors, eliminating unnecessary retries on deterministic responses (200/404/301/4xx) during repository existence checks.

## Problem
Previously, `GetNonSuccessAsync` used `GetWithRetry` which retried on all non-success responses, causing unnecessary delays during migrations when checking repository existence.

## Solution
Changed to use `HttpRetry` with a custom predicate that only retries on 5xx errors:
```csharp
ex => ex.StatusCode.HasValue && (int)ex.StatusCode.Value >= 500
```

## Impact
- `DoesRepoExist()`: Expects 404 → now returns immediately instead of retrying
- `GetArchiveMigrationUrl()`: Expects 302 → now returns immediately instead of retrying
- Both still retry on transient 5xx server errors

## Testing
- All 1023 tests passing
- 5 new comprehensive test cases covering:
  - Expected status (404) returns immediately
  - Unexpected success (200) throws immediately
  - Server errors (5xx) retry as expected
  - Client errors (4xx) throw immediately
  - Redirects (301) throw immediately

Closes #1447
Merges #1478

cc: @AakashSuresh2003