### PR TITLE
Add native macOS ARM64 (Apple Silicon) builds for all CLIs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -347,11 +347,13 @@ jobs:
             ./dist/ado2gh.*.linux-x64.tar.gz
             ./dist/ado2gh.*.linux-arm64.tar.gz
             ./dist/ado2gh.*.osx-x64.tar.gz
+            ./dist/ado2gh.*.osx-arm64.tar.gz
             ./dist/win-x64/gei-windows-amd64.exe
             ./dist/win-x86/gei-windows-386.exe
             ./dist/linux-x64/gei-linux-amd64
             ./dist/linux-arm64/gei-linux-arm64
             ./dist/osx-x64/gei-darwin-amd64
+            ./dist/osx-arm64/gei-darwin-arm64
 
       - name: Create gh-ado2gh Release
         # a06a81a03ee405af7f2048a818ed3f03bbf83c7b is tag v2, pinned to avoid supply chain attacks
@@ -366,6 +368,7 @@ jobs:
             ./dist/linux-x64/ado2gh-linux-amd64
             ./dist/linux-arm64/ado2gh-linux-arm64
             ./dist/osx-x64/ado2gh-darwin-amd64
+            ./dist/osx-arm64/ado2gh-darwin-arm64
 
       - name: Create gh-bbs2gh Release
         # a06a81a03ee405af7f2048a818ed3f03bbf83c7b is tag v2, pinned to avoid supply chain attacks
@@ -380,6 +383,7 @@ jobs:
             ./dist/linux-x64/bbs2gh-linux-amd64
             ./dist/linux-arm64/bbs2gh-linux-arm64
             ./dist/osx-x64/bbs2gh-darwin-amd64
+            ./dist/osx-arm64/bbs2gh-darwin-arm64
 
       - name: Archive Release Notes
         shell: pwsh

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,4 @@
 - Fixed `ado2gh generate-script --download-migration-logs` to generate valid commands using `--target-api-url` that work with the `ado2gh download-logs` command
 - Added `--target-api-url` support to `ado2gh download-logs` and `bbs2gh download-logs` commands for GHEC data residency scenarios
 - Maintained backward compatibility: `--github-api-url` continues to work as an alias for `--target-api-url` in `ado2gh` and `bbs2gh` CLIs
+- Added native macOS ARM64 (Apple Silicon) builds for all CLIs

--- a/publish.ps1
+++ b/publish.ps1
@@ -93,6 +93,21 @@ else {
     }
 
     Copy-Item ./dist/osx-x64/ado2gh ./dist/osx-x64/ado2gh-darwin-amd64
+
+    # osx-arm64 build
+    dotnet publish src/ado2gh/ado2gh.csproj -c Release -o dist/osx-arm64/ -r osx-arm64 -p:PublishSingleFile=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    tar -cvzf ./dist/ado2gh.$AssemblyVersion.osx-arm64.tar.gz -C ./dist/osx-arm64 ado2gh
+
+    if (Test-Path -Path ./dist/osx-arm64/ado2gh-darwin-arm64) {
+        Remove-Item ./dist/osx-arm64/ado2gh-darwin-arm64
+    }
+
+    Copy-Item ./dist/osx-arm64/ado2gh ./dist/osx-arm64/ado2gh-darwin-arm64
 }  
 
 
@@ -171,6 +186,19 @@ else {
     }
 
     Rename-Item ./dist/osx-x64/gei gei-darwin-amd64
+
+    # osx-arm64 build
+    dotnet publish src/gei/gei.csproj -c Release -o dist/osx-arm64/ -r osx-arm64 -p:PublishSingleFile=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    if (Test-Path -Path ./dist/osx-arm64/gei-darwin-arm64) {
+        Remove-Item ./dist/osx-arm64/gei-darwin-arm64
+    }
+
+    Rename-Item ./dist/osx-arm64/gei gei-darwin-arm64
 }
 
 ### bbs2gh ###
@@ -248,4 +276,17 @@ else {
     }
 
     Rename-Item ./dist/osx-x64/bbs2gh bbs2gh-darwin-amd64
+
+    # osx-arm64 build
+    dotnet publish src/bbs2gh/bbs2gh.csproj -c Release -o dist/osx-arm64/ -r osx-arm64 -p:PublishSingleFile=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true /p:DebugType=None /p:IncludeNativeLibrariesForSelfExtract=true /p:VersionPrefix=$AssemblyVersion
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    if (Test-Path -Path ./dist/osx-arm64/bbs2gh-darwin-arm64) {
+        Remove-Item ./dist/osx-arm64/bbs2gh-darwin-arm64
+    }
+
+    Rename-Item ./dist/osx-arm64/bbs2gh bbs2gh-darwin-arm64
 }


### PR DESCRIPTION
## Summary

Add `osx-arm64` (darwin-arm64) build targets for all three CLIs (ado2gh, gei, bbs2gh), enabling native Apple Silicon binaries. This follows the same pattern established when `linux-arm64` support was added in b65ed95.

Currently macOS ARM users rely on Rosetta 2 to run the x64 binaries. With this change, native ARM64 binaries are produced and published alongside the existing platform targets.

## Changes

### `publish.ps1`
- Added `osx-arm64` `dotnet publish` steps for **ado2gh**, **gei**, and **bbs2gh** inside the existing macOS build blocks (controlled by `SKIP_MACOS`)
- **ado2gh**: produces `dist/osx-arm64/ado2gh-darwin-arm64` and `dist/ado2gh.*.osx-arm64.tar.gz` (using `Copy-Item`, matching existing ado2gh pattern)
- **gei**: produces `dist/osx-arm64/gei-darwin-arm64` (using `Rename-Item`, matching existing gei pattern)
- **bbs2gh**: produces `dist/osx-arm64/bbs2gh-darwin-arm64` (using `Rename-Item`, matching existing bbs2gh pattern)

### `.github/workflows/CI.yml`
- Added `osx-arm64` release assets to all three GitHub Release steps (gh-gei, gh-ado2gh, gh-bbs2gh)

### `RELEASENOTES.md`
- Added release note for the new darwin-arm64 builds

## Notes
- No changes to `.csproj` files needed — RIDs are passed via `-r` at publish time
- No changes to `justfile` needed — `publish-macos` delegates to `publish.ps1` which now includes osx-arm64
- No changes to e2e test workflows — arm64 binaries are not used for e2e testing (consistent with linux-arm64 approach, since GitHub Actions runners are x64-only)


## Testing

I just migrated a few repositories from github.com to GH DR in the EU successfully.