### PR TITLE
Make the `--target-uploads-url` option visible to the help output

### DIFF
--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandTests.cs
@@ -90,7 +90,7 @@ public class MigrateRepoCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "keep-archive", false);
         TestHelpers.VerifyCommandOption(command.Options, "no-ssl-verify", false);
         TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
-        TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false, true);
+        TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false);
         TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false, true);
     }
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandTests.cs
@@ -56,7 +56,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.GenerateScript
             TestHelpers.VerifyCommandOption(command.Options, "aws-region", false);
             TestHelpers.VerifyCommandOption(command.Options, "keep-archive", false);
             TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
-            TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false, true);
+            TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false);
             TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false, true);
         }
 

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateOrg/MigrateOrgCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateOrg/MigrateOrgCommandTests.cs
@@ -46,7 +46,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateOrg
             TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
             TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
-            TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false, true);
+            TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandTests.cs
@@ -20,7 +20,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             TestHelpers.VerifyCommandOption(command.Options, "github-target-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "target-repo", false);
             TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
-            TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false, true);
+            TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false);
             TestHelpers.VerifyCommandOption(command.Options, "ghes-api-url", false);
             TestHelpers.VerifyCommandOption(command.Options, "azure-storage-connection-string", false);
             TestHelpers.VerifyCommandOption(command.Options, "aws-bucket-name", false);

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -193,8 +193,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
     };
     public Option<string> TargetUploadsUrl { get; } = new(
         name: "--target-uploads-url",
-        description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com")
-    { IsHidden = true };
+        description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com");
     public Option<bool> NoSslVerify { get; } = new(
         name: "--no-ssl-verify",
         description: "Disables SSL verification when communicating with your Bitbucket Server/Data Center instance. All other migration steps will continue to verify SSL. " +

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommand.cs
@@ -103,8 +103,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
         };
         public Option<string> TargetUploadsUrl { get; } = new(
             name: "--target-uploads-url",
-            description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com")
-        { IsHidden = true };
+            description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com");
         public Option<bool> UseGithubStorage { get; } = new("--use-github-storage")
         {
             IsHidden = true,

--- a/src/gei/Commands/MigrateOrg/MigrateOrgCommand.cs
+++ b/src/gei/Commands/MigrateOrg/MigrateOrgCommand.cs
@@ -48,8 +48,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateOrg
         };
         public Option<string> TargetUploadsUrl { get; } = new(
             name: "--target-uploads-url",
-            description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com")
-        { IsHidden = true };
+            description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com");
         public Option<bool> QueueOnly { get; } = new("--queue-only")
         {
             Description = "Only queues the migration, does not wait for it to finish. Use the wait-for-migration command to subsequently wait for it to finish and view the status."

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -69,8 +69,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
         };
         public Option<string> TargetUploadsUrl { get; } = new(
             name: "--target-uploads-url",
-            description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com")
-        { IsHidden = true };
+            description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com");
 
         // GHES migration path
         public Option<string> GhesApiUrl { get; } = new("--ghes-api-url")


### PR DESCRIPTION
- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

This PR addresses the issue #1517 and makes the  `--target-uploads-url` option visible to the help output.