### PR TITLE
fix: exclude errored code scanning analyses from migration

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-* **Bug Fix:** `migrate-code-scanning-alerts` now excludes code scanning analyses that have errors, preventing failed analyses from being migrated to the target repository.
+* **Bug Fix:** `migrate-code-scanning-alerts` now excludes code scanning analyses that had processing errors on initial uplaods, preventing the CLI from failing to continue when it encounters a failed SARIF retrieval because no SARIF exists.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-* **Bug Fix:** `migrate-code-scanning-alerts` now excludes code scanning analyses that had processing errors on initial uploads, preventing the CLI from failing to continue when it encounters a failed SARIF retrieval because no SARIF exists.
+* **Bug Fix:** `migrate-code-scanning-alerts` now excludes code scanning analyses that had processing errors on initial uploads, preventing the CLI from failing to continue when it encounters a failed SARIF retrieval because no SARIF exists. Skipped analyses are logged with their ID and error message.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,0 +1,1 @@
+* **Bug Fix:** `migrate-code-scanning-alerts` now excludes code scanning analyses that have errors, preventing failed analyses from being migrated to the target repository.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-* **Bug Fix:** `migrate-code-scanning-alerts` now excludes code scanning analyses that had processing errors on initial uplaods, preventing the CLI from failing to continue when it encounters a failed SARIF retrieval because no SARIF exists.
+* **Bug Fix:** `migrate-code-scanning-alerts` now excludes code scanning analyses that had processing errors on initial uploads, preventing the CLI from failing to continue when it encounters a failed SARIF retrieval because no SARIF exists.

--- a/src/Octoshift/Models/CodeScanningAnalysis.cs
+++ b/src/Octoshift/Models/CodeScanningAnalysis.cs
@@ -6,5 +6,6 @@ namespace Octoshift.Models
         public string CommitSha { get; set; }
         public string CreatedAt { get; set; }
         public int Id { get; set; }
+        public string Error { get; set; }
     }
 }

--- a/src/Octoshift/Services/CodeScanningAlertService.cs
+++ b/src/Octoshift/Services/CodeScanningAlertService.cs
@@ -65,6 +65,13 @@ public class CodeScanningAlertService
         {
             analysisNumber++;
 
+            if (!string.IsNullOrEmpty(analysis.Error))
+            {
+                _log.LogWarning($"Skipping analysis with Id {analysis.Id} which failed to process in the source repository: {analysis.Error}");
+                _log.LogWarning("	This error is non-fatal and will not affect your migrated code-scanning alerts.")
+                continue;
+            }
+
             string sarifReport;
             try
             {

--- a/src/Octoshift/Services/CodeScanningAlertService.cs
+++ b/src/Octoshift/Services/CodeScanningAlertService.cs
@@ -68,7 +68,7 @@ public class CodeScanningAlertService
             if (!string.IsNullOrEmpty(analysis.Error))
             {
                 _log.LogWarning($"Skipping analysis with Id {analysis.Id} which failed to process in the source repository: {analysis.Error}");
-                _log.LogWarning("	This error is non-fatal and will not affect your migrated code-scanning alerts.");
+                _log.LogWarning("    This error is non-fatal and will not affect your migrated code-scanning alerts.");
                 continue;
             }
 

--- a/src/Octoshift/Services/CodeScanningAlertService.cs
+++ b/src/Octoshift/Services/CodeScanningAlertService.cs
@@ -68,7 +68,7 @@ public class CodeScanningAlertService
             if (!string.IsNullOrEmpty(analysis.Error))
             {
                 _log.LogWarning($"Skipping analysis with Id {analysis.Id} which failed to process in the source repository: {analysis.Error}");
-                _log.LogWarning("	This error is non-fatal and will not affect your migrated code-scanning alerts.")
+                _log.LogWarning("	This error is non-fatal and will not affect your migrated code-scanning alerts.");
                 continue;
             }
 

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -957,6 +957,7 @@ public class GithubApi
         try
         {
             return await _client.GetAllAsync(url)
+                .Where(x => string.IsNullOrEmpty((string)x["error"]))
                 .Select(BuildCodeScanningAnalysis)
                 .ToListAsync();
         }

--- a/src/Octoshift/Services/GithubApi.cs
+++ b/src/Octoshift/Services/GithubApi.cs
@@ -957,7 +957,6 @@ public class GithubApi
         try
         {
             return await _client.GetAllAsync(url)
-                .Where(x => string.IsNullOrEmpty((string)x["error"]))
                 .Select(BuildCodeScanningAnalysis)
                 .ToListAsync();
         }
@@ -1238,6 +1237,7 @@ public class GithubApi
             CommitSha = (string)codescan["commit_sha"],
             Ref = (string)codescan["ref"],
             CreatedAt = (string)codescan["created_at"],
+            Error = (string)codescan["error"],
         };
 
     private static CodeScanningAlert BuildCodeScanningAlert(JToken scanningAlert) =>

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/CodeScanningAlertServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/CodeScanningAlertServiceTests.cs
@@ -347,7 +347,8 @@ public class CodeScanningAlertServiceTests
 
         await _alertService.MigrateAnalyses(SOURCE_ORG, SOURCE_REPO, TARGET_ORG, TARGET_REPO, "main", false);
 
-        _mockOctoLogger.Verify(log => log.LogWarning($"Skipping analysis {errorAnalysis.Id} due to error: something went wrong"));
+        _mockOctoLogger.Verify(log => log.LogWarning($"Skipping analysis with Id {errorAnalysis.Id} which failed to process in the source repository: something went wrong"));
+        _mockOctoLogger.Verify(log => log.LogWarning("	This error is non-fatal and will not affect your migrated code-scanning alerts."));
         _mockSourceGithubApi.Verify(x => x.GetSarifReport(SOURCE_ORG, SOURCE_REPO, errorAnalysis.Id), Times.Never);
         _mockTargetGithubApi.Verify(x => x.UploadSarifReport(TARGET_ORG, TARGET_REPO, "SARIF", validAnalysis.CommitSha, validAnalysis.Ref), Times.Once);
     }

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/CodeScanningAlertServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/CodeScanningAlertServiceTests.cs
@@ -316,6 +316,43 @@ public class CodeScanningAlertServiceTests
     }
 
     [Fact]
+    public async Task MigrateAnalyses_Skips_Analyses_With_Error_And_Logs_Warning()
+    {
+        var validAnalysis = new CodeScanningAnalysis
+        {
+            Id = 111,
+            CreatedAt = "2022-03-30T00:00:00Z",
+            CommitSha = "valid_sha",
+            Ref = "refs/heads/main"
+        };
+        var errorAnalysis = new CodeScanningAnalysis
+        {
+            Id = 222,
+            CreatedAt = "2022-03-29T00:00:00Z",
+            CommitSha = "error_sha",
+            Ref = "refs/heads/main",
+            Error = "something went wrong"
+        };
+        var processingStatus = new SarifProcessingStatus
+        {
+            Status = SarifProcessingStatus.Complete,
+            Errors = Enumerable.Empty<string>()
+        };
+
+        _mockSourceGithubApi.Setup(x => x.GetCodeScanningAnalysisForRepository(SOURCE_ORG, SOURCE_REPO, "main")).ReturnsAsync(new[] { errorAnalysis, validAnalysis });
+        _mockTargetGithubApi.Setup(x => x.GetCodeScanningAnalysisForRepository(TARGET_ORG, TARGET_REPO, "main")).ReturnsAsync(Enumerable.Empty<CodeScanningAnalysis>());
+        _mockSourceGithubApi.Setup(x => x.GetSarifReport(SOURCE_ORG, SOURCE_REPO, validAnalysis.Id)).ReturnsAsync("SARIF");
+        _mockTargetGithubApi.Setup(x => x.UploadSarifReport(TARGET_ORG, TARGET_REPO, "SARIF", validAnalysis.CommitSha, validAnalysis.Ref)).ReturnsAsync("sarif-id");
+        _mockTargetGithubApi.Setup(x => x.GetSarifProcessingStatus(TARGET_ORG, TARGET_REPO, "sarif-id")).ReturnsAsync(processingStatus);
+
+        await _alertService.MigrateAnalyses(SOURCE_ORG, SOURCE_REPO, TARGET_ORG, TARGET_REPO, "main", false);
+
+        _mockOctoLogger.Verify(log => log.LogWarning($"Skipping analysis {errorAnalysis.Id} due to error: something went wrong"));
+        _mockSourceGithubApi.Verify(x => x.GetSarifReport(SOURCE_ORG, SOURCE_REPO, errorAnalysis.Id), Times.Never);
+        _mockTargetGithubApi.Verify(x => x.UploadSarifReport(TARGET_ORG, TARGET_REPO, "SARIF", validAnalysis.CommitSha, validAnalysis.Ref), Times.Once);
+    }
+
+    [Fact]
     public async Task MigrateAlerts_Matches_Dismissed_Alert_By_Last_Instance_And_Updates_Target()
     {
         var CommitSha = "SHA_1";

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/CodeScanningAlertServiceTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/CodeScanningAlertServiceTests.cs
@@ -348,7 +348,7 @@ public class CodeScanningAlertServiceTests
         await _alertService.MigrateAnalyses(SOURCE_ORG, SOURCE_REPO, TARGET_ORG, TARGET_REPO, "main", false);
 
         _mockOctoLogger.Verify(log => log.LogWarning($"Skipping analysis with Id {errorAnalysis.Id} which failed to process in the source repository: something went wrong"));
-        _mockOctoLogger.Verify(log => log.LogWarning("	This error is non-fatal and will not affect your migrated code-scanning alerts."));
+        _mockOctoLogger.Verify(log => log.LogWarning("    This error is non-fatal and will not affect your migrated code-scanning alerts."));
         _mockSourceGithubApi.Verify(x => x.GetSarifReport(SOURCE_ORG, SOURCE_REPO, errorAnalysis.Id), Times.Never);
         _mockTargetGithubApi.Verify(x => x.UploadSarifReport(TARGET_ORG, TARGET_REPO, "SARIF", validAnalysis.CommitSha, validAnalysis.Ref), Times.Once);
     }

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -3069,7 +3069,7 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
     }
 
     [Fact]
-    public async Task GetCodeScanningAnalysisForRepository_Excludes_Analyses_With_Error()
+    public async Task GetCodeScanningAnalysisForRepository_Includes_Analyses_With_Error()
     {
         // Arrange
         const string url = $"https://api.github.com/repos/{GITHUB_ORG}/{GITHUB_REPO}/code-scanning/analyses?per_page=100&sort=created&direction=asc";
@@ -3104,8 +3104,11 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
         var scanResults = await _githubApi.GetCodeScanningAnalysisForRepository(GITHUB_ORG, GITHUB_REPO);
 
         // Assert
-        scanResults.Count().Should().Be(1);
+        scanResults.Count().Should().Be(2);
         scanResults.First().Id.Should().Be(38200197);
+        scanResults.First().Error.Should().BeEmpty();
+        scanResults.Last().Id.Should().Be(38026365);
+        scanResults.Last().Error.Should().Be("something went wrong");
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/GithubApiTests.cs
@@ -3069,6 +3069,46 @@ $",\"variables\":{{\"id\":\"{orgId}\",\"login\":\"{login}\"}}}}";
     }
 
     [Fact]
+    public async Task GetCodeScanningAnalysisForRepository_Excludes_Analyses_With_Error()
+    {
+        // Arrange
+        const string url = $"https://api.github.com/repos/{GITHUB_ORG}/{GITHUB_REPO}/code-scanning/analyses?per_page=100&sort=created&direction=asc";
+
+        var validAnalysis = $@"
+                {{
+                    ""ref"": ""refs/heads/main"",
+                    ""commit_sha"": ""25cb837876685f98756d0c934ffe6cd09da570f8"",
+                    ""created_at"": ""2022-08-08T19:00:18Z"",
+                    ""id"": 38200197,
+                    ""error"": """"
+                }}
+            ";
+
+        var errorAnalysis = $@"
+                {{
+                    ""ref"": ""refs/heads/main"",
+                    ""commit_sha"": ""67f8626e1f3ca40e9678e1dcfc4f840009ffc260"",
+                    ""created_at"": ""2022-08-06T19:40:39Z"",
+                    ""id"": 38026365,
+                    ""error"": ""something went wrong""
+                }}
+            ";
+
+        var analyses = new List<JToken> { JToken.Parse(validAnalysis), JToken.Parse(errorAnalysis) };
+
+        _githubClientMock
+            .Setup(m => m.GetAllAsync(url, null))
+            .Returns(analyses.ToAsyncEnumerable());
+
+        // Act
+        var scanResults = await _githubApi.GetCodeScanningAnalysisForRepository(GITHUB_ORG, GITHUB_REPO);
+
+        // Assert
+        scanResults.Count().Should().Be(1);
+        scanResults.First().Id.Should().Be(38200197);
+    }
+
+    [Fact]
     public async Task GetCodeScanningAnalysisForRepository_Passes_Filtered_Branch_As_QueryString()
     {
         const string url = $"https://api.github.com/repos/{GITHUB_ORG}/{GITHUB_REPO}/code-scanning/analyses?per_page=100&sort=created&direction=asc&ref=main";


### PR DESCRIPTION
Filter out code scanning analyses with non-empty error fields when listing analyses from the source repository, preventing failed analyses from being migrated to the target repository.

When the `migrate-code-scanning-alerts` is invoked, it used the `ListAnalyses` API. The results objects in the returned array have an `error` field. If on the initial upload the SARIF failed to process, the error field is populated. When we try to `GetAnalysis` to retrieve the SARIF content, we get a `422 Unprocessable Entity` because the results retrieval system can't process the SARIF. The GEI CLI fails at that point, instead of skipping that particular result.

We've also built and tested this locally against a production migration and confirmed this works as intended.

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->