### PR TITLE
Skip BBS source data setup in integration tests

### DIFF
--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -95,12 +95,13 @@ public sealed class BbsToGithub : IDisposable
         await retryPolicy.Retry(async () =>
         {
             await _targetHelper.ResetBlobContainers();
-            await sourceHelper.ResetBbsTestEnvironment(bbsProjectKey);
+            // TODO: Re-enable source data setup once BBS environment is updated
+            // await sourceHelper.ResetBbsTestEnvironment(bbsProjectKey);
             await _targetHelper.ResetGithubTestEnvironment(githubTargetOrg);
 
-            await sourceHelper.CreateBbsProject(bbsProjectKey);
-            await sourceHelper.CreateBbsRepo(bbsProjectKey, repo1);
-            await sourceHelper.InitializeBbsRepo(bbsProjectKey, repo1);
+            // await sourceHelper.CreateBbsProject(bbsProjectKey);
+            // await sourceHelper.CreateBbsRepo(bbsProjectKey, repo1);
+            // await sourceHelper.InitializeBbsRepo(bbsProjectKey, repo1);
         });
 
         var sshPort = Environment.GetEnvironmentVariable("SSH_PORT_BBS");


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

The BBS integration tests currently destroy and recreate source data on every run. Since the test data already exists in the BBS environment, we can skip the recreation step. This simplifies the test setup and allows for faster, more concurrent test runs.

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->