### PR TITLE
Update BBS integration tests to use prebuilt archive URL

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -186,6 +186,7 @@ jobs:
         ADO_SERVER_PAT: ${{ secrets.ADO_SERVER_PAT }}
         BBS_USERNAME: ${{ secrets.BBS_USERNAME }}
         BBS_PASSWORD: ${{ secrets.BBS_PASSWORD }}
+        BBS_ARCHIVE_URL: ${{ secrets.BBS_ARCHIVE_URL }}
         SSH_KEY_BBS: ${{ secrets.SSH_KEY_BBS }}
         SSH_PORT_BBS: ${{ secrets.SSH_PORT_BBS }}
         SMB_PASSWORD: ${{ secrets.SMB_PASSWORD }}

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -76,65 +76,78 @@ public sealed class BbsToGithub : IDisposable
         _targetHelper = new TestHelper(_output, _targetGithubApi, _targetGithubClient, _blobServiceClient);
     }
 
-    [Theory]
-    [InlineData("https://e2e-bbs-linux-1.westus2.cloudapp.azure.com", true, ArchiveUploadOption.AzureStorage)]
-    [InlineData("https://e2e-bbs-linux-1.westus2.cloudapp.azure.com", true, ArchiveUploadOption.AwsS3)]
-    [InlineData("https://e2e-bbs-linux-1.westus2.cloudapp.azure.com", true, ArchiveUploadOption.GithubStorage)]
-    public async Task Basic(string bbsServer, bool useSshForArchiveDownload, ArchiveUploadOption uploadOption)
+    // TODO: Re-enable full basic BBS integration test matrix once BBS environment is updated.
+    // [Theory]
+    // [InlineData("https://e2e-bbs-linux-1.westus2.cloudapp.azure.com", true, ArchiveUploadOption.AzureStorage)]
+    // [InlineData("https://e2e-bbs-linux-1.westus2.cloudapp.azure.com", true, ArchiveUploadOption.AwsS3)]
+    // [InlineData("https://e2e-bbs-linux-1.westus2.cloudapp.azure.com", true, ArchiveUploadOption.GithubStorage)]
+    [Fact]
+    public async Task Basic()
     {
         var bbsProjectKey = $"E2E-{TestHelper.GetOsName().ToUpper()}";
         var githubTargetOrg = $"octoshift-e2e-bbs-{TestHelper.GetOsName()}";
-        var repo1 = $"{bbsProjectKey}-repo-1";
+        // TODO: Re-enable source data setup once BBS environment is updated
+        // var repo1 = $"{bbsProjectKey}-repo-1";
         var targetRepo1 = $"{bbsProjectKey}-e2e-{TestHelper.GetOsName().ToLower()}-repo-1";
 
-        var sourceBbsApi = new BbsApi(_sourceBbsClient, bbsServer, _logger);
-        var sourceHelper = new TestHelper(_output, sourceBbsApi, _sourceBbsClient, bbsServer);
+        // TODO: Re-enable source data setup once BBS environment is updated
+        // var sourceBbsApi = new BbsApi(_sourceBbsClient, bbsServer, _logger);
+        // var sourceHelper = new TestHelper(_output, sourceBbsApi, _sourceBbsClient, bbsServer);
 
         var retryPolicy = new RetryPolicy(null);
 
         await retryPolicy.Retry(async () =>
         {
             await _targetHelper.ResetBlobContainers();
-            await sourceHelper.ResetBbsTestEnvironment(bbsProjectKey);
+            // TODO: Re-enable source data setup once BBS environment is updated
+            // await sourceHelper.ResetBbsTestEnvironment(bbsProjectKey);
             await _targetHelper.ResetGithubTestEnvironment(githubTargetOrg);
 
-            await sourceHelper.CreateBbsProject(bbsProjectKey);
-            await sourceHelper.CreateBbsRepo(bbsProjectKey, repo1);
-            await sourceHelper.InitializeBbsRepo(bbsProjectKey, repo1);
+            // await sourceHelper.CreateBbsProject(bbsProjectKey);
+            // await sourceHelper.CreateBbsRepo(bbsProjectKey, repo1);
+            // await sourceHelper.InitializeBbsRepo(bbsProjectKey, repo1);
         });
 
-        var sshPort = Environment.GetEnvironmentVariable("SSH_PORT_BBS");
-        var archiveDownloadOptions = $" --ssh-user octoshift --ssh-private-key {SSH_KEY_FILE} --ssh-port {sshPort}";
-        if (useSshForArchiveDownload)
-        {
-            var sshKey = Environment.GetEnvironmentVariable("SSH_KEY_BBS");
-            await File.WriteAllTextAsync(Path.Join(TestHelper.GetOsDistPath(), SSH_KEY_FILE), sshKey);
-        }
-        else
-        {
-            archiveDownloadOptions = " --smb-user octoshift";
-            _tokens.Add("SMB_PASSWORD", Environment.GetEnvironmentVariable("SMB_PASSWORD"));
-        }
+        // TODO: Re-enable full BBS export and archive download flow once BBS environment is updated
+        // var sshPort = Environment.GetEnvironmentVariable("SSH_PORT_BBS");
+        // var archiveDownloadOptions = $" --ssh-user octoshift --ssh-private-key {SSH_KEY_FILE} --ssh-port {sshPort}";
+        // if (useSshForArchiveDownload)
+        // {
+        //     var sshKey = Environment.GetEnvironmentVariable("SSH_KEY_BBS");
+        //     await File.WriteAllTextAsync(Path.Join(TestHelper.GetOsDistPath(), SSH_KEY_FILE), sshKey);
+        // }
+        // else
+        // {
+        //     archiveDownloadOptions = " --smb-user octoshift";
+        //     _tokens.Add("SMB_PASSWORD", Environment.GetEnvironmentVariable("SMB_PASSWORD"));
+        // }
 
-        var archiveUploadOptions = "";
-        if (uploadOption == ArchiveUploadOption.AzureStorage)
-        {
-            _tokens.Add("AZURE_STORAGE_CONNECTION_STRING", _azureStorageConnectionString);
-        }
-        else if (uploadOption == ArchiveUploadOption.AwsS3)
-        {
-            _tokens.Add("AWS_ACCESS_KEY_ID", Environment.GetEnvironmentVariable("AWS_ACCESS_KEY_ID"));
-            _tokens.Add("AWS_SECRET_ACCESS_KEY", Environment.GetEnvironmentVariable("AWS_SECRET_ACCESS_KEY"));
-            var awsBucketName = Environment.GetEnvironmentVariable("AWS_BUCKET_NAME");
-            archiveUploadOptions = $" --aws-bucket-name {awsBucketName} --aws-region {AWS_REGION}";
-        }
-        else if (uploadOption == ArchiveUploadOption.GithubStorage)
-        {
-            archiveUploadOptions = " --use-github-storage";
-        }
+        // var archiveUploadOptions = "";
+        // if (uploadOption == ArchiveUploadOption.AzureStorage)
+        // {
+        //     _tokens.Add("AZURE_STORAGE_CONNECTION_STRING", _azureStorageConnectionString);
+        // }
+        // else if (uploadOption == ArchiveUploadOption.AwsS3)
+        // {
+        //     _tokens.Add("AWS_ACCESS_KEY_ID", Environment.GetEnvironmentVariable("AWS_ACCESS_KEY_ID"));
+        //     _tokens.Add("AWS_SECRET_ACCESS_KEY", Environment.GetEnvironmentVariable("AWS_SECRET_ACCESS_KEY"));
+        //     var awsBucketName = Environment.GetEnvironmentVariable("AWS_BUCKET_NAME");
+        //     archiveUploadOptions = $" --aws-bucket-name {awsBucketName} --aws-region {AWS_REGION}";
+        // }
+        // else if (uploadOption == ArchiveUploadOption.GithubStorage)
+        // {
+        //     archiveUploadOptions = " --use-github-storage";
+        // }
 
-        await _targetHelper.RunBbsCliMigration(
-            $"generate-script --github-org {githubTargetOrg} --bbs-server-url {bbsServer} --bbs-project {bbsProjectKey}{archiveDownloadOptions}{archiveUploadOptions}", _tokens);
+        // await _targetHelper.RunBbsCliMigration(
+        //     $"generate-script --github-org {githubTargetOrg} --bbs-server-url {bbsServer} --bbs-project {bbsProjectKey}{archiveDownloadOptions}{archiveUploadOptions}", _tokens);
+
+        var archiveUrl = Environment.GetEnvironmentVariable("BBS_ARCHIVE_URL");
+
+        await _targetHelper.RunCliCommand(
+            $"bbs2gh migrate-repo --archive-url {archiveUrl} --github-org {githubTargetOrg} --github-repo {targetRepo1} --target-repo-visibility private",
+            "gh",
+            _tokens);
 
         _targetHelper.AssertNoErrorInLogs(_startTime);
 
@@ -144,7 +157,7 @@ public sealed class BbsToGithub : IDisposable
         // TODO: Assert migration logs are downloaded
     }
 
-    [Fact]
+    [Fact(Skip = "Re-enable multipart upload test once BBS environment is updated")]
     public async Task MigrateRepo_MultipartUpload()
     {
         var githubTargetOrg = $"octoshift-e2e-bbs-{TestHelper.GetOsName()}";

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -85,12 +85,14 @@ public sealed class BbsToGithub : IDisposable
     [Fact]
     public async Task Basic()
     {
-        var bbsProjectKey = $"E2E-{TestHelper.GetOsName().ToUpper()}";
+        // TODO: Re-enable source data setup once BBS environment is updated
+        // var bbsProjectKey = $"E2E-{TestHelper.GetOsName().ToUpper()}";
+        var bbsProjectKey = "OCTOTEST";
         var githubTargetOrg = $"octoshift-e2e-bbs-{TestHelper.GetOsName()}";
-        var repo1 = $"{bbsProjectKey}-repo-1";
+        // var repo1 = $"{bbsProjectKey}-repo-1";
+        var bbsRepo = "bbs-test-repo";
         var targetRepo1 = $"{bbsProjectKey}-e2e-{TestHelper.GetOsName().ToLower()}-repo-1";
 
-        // TODO: Re-enable source data setup once BBS environment is updated
         // var sourceBbsApi = new BbsApi(_sourceBbsClient, bbsServer, _logger);
         // var sourceHelper = new TestHelper(_output, sourceBbsApi, _sourceBbsClient, bbsServer);
 
@@ -144,10 +146,10 @@ public sealed class BbsToGithub : IDisposable
 
         var archiveUrl = Environment.GetEnvironmentVariable("BBS_ARCHIVE_URL");
 
-        var bbsServer = "https://e2e-bbs-linux-1.westus2.cloudapp.azure.com";
+        var bbsServer = "https://test-bbs-o.githubapp.com";
 
         await _targetHelper.RunCliCommand(
-            $"bbs2gh migrate-repo --archive-url {archiveUrl} --bbs-server-url {bbsServer} --bbs-project {bbsProjectKey} --bbs-repo {repo1} --github-org {githubTargetOrg} --github-repo {targetRepo1} --target-repo-visibility private",
+            $"bbs2gh migrate-repo --archive-url {archiveUrl} --bbs-server-url {bbsServer} --bbs-project {bbsProjectKey} --bbs-repo {bbsRepo} --github-org {githubTargetOrg} --github-repo {targetRepo1} --target-repo-visibility private",
             "gh",
             _tokens);
 

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -87,8 +87,7 @@ public sealed class BbsToGithub : IDisposable
     {
         var bbsProjectKey = $"E2E-{TestHelper.GetOsName().ToUpper()}";
         var githubTargetOrg = $"octoshift-e2e-bbs-{TestHelper.GetOsName()}";
-        // TODO: Re-enable source data setup once BBS environment is updated
-        // var repo1 = $"{bbsProjectKey}-repo-1";
+        var repo1 = $"{bbsProjectKey}-repo-1";
         var targetRepo1 = $"{bbsProjectKey}-e2e-{TestHelper.GetOsName().ToLower()}-repo-1";
 
         // TODO: Re-enable source data setup once BBS environment is updated
@@ -145,8 +144,10 @@ public sealed class BbsToGithub : IDisposable
 
         var archiveUrl = Environment.GetEnvironmentVariable("BBS_ARCHIVE_URL");
 
+        var bbsServer = "https://e2e-bbs-linux-1.westus2.cloudapp.azure.com";
+
         await _targetHelper.RunCliCommand(
-            $"bbs2gh migrate-repo --archive-url {archiveUrl} --github-org {githubTargetOrg} --github-repo {targetRepo1} --target-repo-visibility private",
+            $"bbs2gh migrate-repo --archive-url {archiveUrl} --bbs-server-url {bbsServer} --bbs-project {bbsProjectKey} --bbs-repo {repo1} --github-org {githubTargetOrg} --github-repo {targetRepo1} --target-repo-visibility private",
             "gh",
             _tokens);
 

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -14,7 +14,7 @@ namespace OctoshiftCLI.IntegrationTests;
 public sealed class BbsToGithub : IDisposable
 {
     private const string SSH_KEY_FILE = "ssh_key.pem";
-    // TODO: Re-enable AWS upload option once BBS environment is updated
+    // TODO: Revert when BBS source environment is updated — see PR #1547.
     // private const string AWS_REGION = "us-east-1";
     private const string UPLOADS_URL = "https://uploads.github.com";
 
@@ -77,7 +77,7 @@ public sealed class BbsToGithub : IDisposable
         _targetHelper = new TestHelper(_output, _targetGithubApi, _targetGithubClient, _blobServiceClient);
     }
 
-    // TODO: Re-enable full basic BBS integration test matrix once BBS environment is updated.
+    // TODO: Revert when BBS source environment is updated — see PR #1547.
     // [Theory]
     // [InlineData("https://e2e-bbs-linux-1.westus2.cloudapp.azure.com", true, ArchiveUploadOption.AzureStorage)]
     // [InlineData("https://e2e-bbs-linux-1.westus2.cloudapp.azure.com", true, ArchiveUploadOption.AwsS3)]
@@ -85,12 +85,14 @@ public sealed class BbsToGithub : IDisposable
     [Fact]
     public async Task Basic()
     {
-        // TODO: Re-enable source data setup once BBS environment is updated
         // var bbsProjectKey = $"E2E-{TestHelper.GetOsName().ToUpper()}";
-        var bbsProjectKey = "OCTOTEST";
-        var githubTargetOrg = $"octoshift-e2e-bbs-{TestHelper.GetOsName()}";
         // var repo1 = $"{bbsProjectKey}-repo-1";
+        var bbsProjectKey = "OCTOTEST";
         var bbsRepo = "bbs-test-repo";
+        var bbsServer = "https://test-bbs-o.githubapp.com";
+        var archiveUrl = Environment.GetEnvironmentVariable("BBS_ARCHIVE_URL");
+
+        var githubTargetOrg = $"octoshift-e2e-bbs-{TestHelper.GetOsName()}";
         var targetRepo1 = $"{bbsProjectKey}-e2e-{TestHelper.GetOsName().ToLower()}-repo-1";
 
         // var sourceBbsApi = new BbsApi(_sourceBbsClient, bbsServer, _logger);
@@ -101,7 +103,6 @@ public sealed class BbsToGithub : IDisposable
         await retryPolicy.Retry(async () =>
         {
             await _targetHelper.ResetBlobContainers();
-            // TODO: Re-enable source data setup once BBS environment is updated
             // await sourceHelper.ResetBbsTestEnvironment(bbsProjectKey);
             await _targetHelper.ResetGithubTestEnvironment(githubTargetOrg);
 
@@ -110,7 +111,7 @@ public sealed class BbsToGithub : IDisposable
             // await sourceHelper.InitializeBbsRepo(bbsProjectKey, repo1);
         });
 
-        // TODO: Re-enable full BBS export and archive download flow once BBS environment is updated
+        // TODO: Revert when BBS source environment is updated.
         // var sshPort = Environment.GetEnvironmentVariable("SSH_PORT_BBS");
         // var archiveDownloadOptions = $" --ssh-user octoshift --ssh-private-key {SSH_KEY_FILE} --ssh-port {sshPort}";
         // if (useSshForArchiveDownload)
@@ -144,10 +145,6 @@ public sealed class BbsToGithub : IDisposable
         // await _targetHelper.RunBbsCliMigration(
         //     $"generate-script --github-org {githubTargetOrg} --bbs-server-url {bbsServer} --bbs-project {bbsProjectKey}{archiveDownloadOptions}{archiveUploadOptions}", _tokens);
 
-        var archiveUrl = Environment.GetEnvironmentVariable("BBS_ARCHIVE_URL");
-
-        var bbsServer = "https://test-bbs-o.githubapp.com";
-
         await _targetHelper.RunCliCommand(
             $"bbs2gh migrate-repo --archive-url {archiveUrl} --bbs-server-url {bbsServer} --bbs-project {bbsProjectKey} --bbs-repo {bbsRepo} --github-org {githubTargetOrg} --github-repo {targetRepo1} --target-repo-visibility private",
             "gh",
@@ -161,7 +158,8 @@ public sealed class BbsToGithub : IDisposable
         // TODO: Assert migration logs are downloaded
     }
 
-    [Fact(Skip = "Re-enable multipart upload test once BBS environment is updated")]
+    // TODO: Revert when BBS source environment is updated — see PR #1547.
+    [Fact(Skip = "Skipped while BBS source environment is being updated.")]
     public async Task MigrateRepo_MultipartUpload()
     {
         var githubTargetOrg = $"octoshift-e2e-bbs-{TestHelper.GetOsName()}";

--- a/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/BbsToGithub.cs
@@ -14,7 +14,8 @@ namespace OctoshiftCLI.IntegrationTests;
 public sealed class BbsToGithub : IDisposable
 {
     private const string SSH_KEY_FILE = "ssh_key.pem";
-    private const string AWS_REGION = "us-east-1";
+    // TODO: Re-enable AWS upload option once BBS environment is updated
+    // private const string AWS_REGION = "us-east-1";
     private const string UPLOADS_URL = "https://uploads.github.com";
 
     private readonly ITestOutputHelper _output;


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->
This PR updates the BBS integration tests to migrate from a prebuilt archive URL as the BBS source environment used by the integration tests needs to be updated.

### Test results
The BBS integration tests fail on the PR check because the required env var isn't available there, but they pass when run from my branch with it configured: https://github.com/github/gh-gei/actions/runs/25008527467

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->