### PR TITLE
Use BBS_ARCHIVE_URL in CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -253,6 +253,7 @@ jobs:
           ADO_SERVER_PAT: ${{ secrets.ADO_SERVER_PAT }}
           BBS_USERNAME: ${{ secrets.BBS_USERNAME }}
           BBS_PASSWORD: ${{ secrets.BBS_PASSWORD }}
+          BBS_ARCHIVE_URL: ${{ secrets.BBS_ARCHIVE_URL }}
           SSH_KEY_BBS: ${{ secrets.SSH_KEY_BBS }}
           SSH_PORT_BBS: ${{ secrets.SSH_PORT_BBS }}
           SMB_PASSWORD: ${{ secrets.SMB_PASSWORD }}


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

`BBS_ARCHIVE_URL` was added to `integration-tests.yml` but missed in `CI.yml`, causing BBS e2e tests to fail. This adds the same env var to keep both workflows in sync.

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->