### PR TITLE
Return response body in user facing logs when encountering 5xx responses

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,0 +1,1 @@
+- BBS2GH: When a Bitbucket Server API request fails with a 5xx response, the response body is now included in the standard log output (alongside the generic error message) to make troubleshooting easier without needing to inspect the verbose log.

--- a/src/Octoshift/Services/BbsClient.cs
+++ b/src/Octoshift/Services/BbsClient.cs
@@ -97,6 +97,16 @@ public class BbsClient
         var content = await response.Content.ReadAsStringAsync();
         _log.LogVerbose($"RESPONSE ({response.StatusCode}): {content}");
 
+        if (!response.IsSuccessStatusCode && (int)response.StatusCode >= 500)
+        {
+            var serverErrorException = new HttpRequestException(
+                $"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}).",
+                null,
+                response.StatusCode);
+            serverErrorException.Data["ResponseBody"] = content;
+            throw serverErrorException;
+        }
+
         response.EnsureSuccessStatusCode();
 
         return content;

--- a/src/Octoshift/Services/BbsClient.cs
+++ b/src/Octoshift/Services/BbsClient.cs
@@ -85,7 +85,7 @@ public class BbsClient
         }
 
         using var payload = body?.ToJson().ToStringContent();
-        var response = httpMethod.ToString() switch
+        using var response = httpMethod.ToString() switch
         {
             "GET" => await _httpClient.GetAsync(url),
             "DELETE" => await _httpClient.DeleteAsync(url),

--- a/src/Octoshift/Services/OctoLogger.cs
+++ b/src/Octoshift/Services/OctoLogger.cs
@@ -146,7 +146,18 @@ public class OctoLogger
         lock (_mutex)
         {
             var verboseMessage = ex is HttpRequestException httpEx ? $"[HTTP ERROR {(int?)httpEx.StatusCode}] {ex}" : ex.ToString();
-            var logMessage = Verbose ? verboseMessage : ex is OctoshiftCliException ? ex.Message : GENERIC_ERROR_MESSAGE;
+            var responseBody = ex.Data["ResponseBody"] as string;
+            if (responseBody is not null)
+            {
+                verboseMessage = $"{verboseMessage}{Environment.NewLine}Response: {responseBody}";
+            }
+            var logMessage = Verbose
+                ? verboseMessage
+                : ex is OctoshiftCliException
+                    ? ex.Message
+                    : responseBody is not null
+                        ? $"{GENERIC_ERROR_MESSAGE}{Environment.NewLine}Response: {responseBody}"
+                        : GENERIC_ERROR_MESSAGE;
 
             var output = Redact(FormatMessage(logMessage, LogLevel.ERROR));
 

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/BbsClientTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/BbsClientTests.cs
@@ -467,6 +467,34 @@ public sealed class BbsClientTests : IDisposable
     }
 
     [Fact]
+    public async Task SendAsync_Includes_Response_Body_In_Exception_Data_On_5xx()
+    {
+        // Arrange
+        const string url = "http://example.com/resource";
+        const string responseBody = "{\"errors\":[{\"message\":\"Could not start migration job\"}]}";
+
+        using var response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+        {
+            Content = new StringContent(responseBody)
+        };
+
+        var handlerMock = MockHttpHandler(req => req.Method == HttpMethod.Post, response);
+
+        using var httpClient = new HttpClient(handlerMock.Object);
+        var bbsClient = new BbsClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy);
+
+        // Act
+        var thrown = await bbsClient
+            .Invoking(async x => await x.PostAsync(url, _rawRequestBody))
+            .Should()
+            .ThrowExactlyAsync<HttpRequestException>();
+
+        // Assert
+        thrown.Which.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        thrown.Which.Data["ResponseBody"].Should().Be(responseBody);
+    }
+
+    [Fact]
     public async Task GetAllAsync_Overrides_Pagination_Query_Params_In_Request_Url()
     {
         // Arrange

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/BbsClientTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/BbsClientTests.cs
@@ -442,19 +442,28 @@ public sealed class BbsClientTests : IDisposable
         const string url = "http://example.com/resource";
 
         var firstResponseContent = new { isLastPage = false, nextPageStart = 2, values = Array.Empty<object>() }.ToJson();
-        using var firstResponse = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(firstResponseContent) };
-
-        using var secondResponse = new HttpResponseMessage(HttpStatusCode.InternalServerError);
 
         var handlerMock = new Mock<HttpMessageHandler>();
 
         // first request
         const string firstRequestUrl = $"{url}?start=0&limit=100";
-        MockHttpHandler(req => req.Method == HttpMethod.Get && req.RequestUri!.ToString() == firstRequestUrl, firstResponse, handlerMock);
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get && req.RequestUri!.ToString() == firstRequestUrl),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(firstResponseContent) });
 
-        // second request
+        // second request - return a fresh response each time so retries don't reuse a disposed instance
         const string secondRequestUrl = $"{url}?start=2&limit=100";
-        MockHttpHandler(req => req.Method == HttpMethod.Get && req.RequestUri!.ToString() == secondRequestUrl, secondResponse, handlerMock);
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get && req.RequestUri!.ToString() == secondRequestUrl),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.InternalServerError));
 
         using var httpClient = new HttpClient(handlerMock.Object);
         var bbsClient = new BbsClient(_mockOctoLogger.Object, httpClient, null, _retryPolicy);

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/OctoLoggerTests.cs
@@ -241,6 +241,30 @@ public class OctoLoggerTests
     }
 
     [Fact]
+    public void LogError_For_Exception_With_ResponseBody_Should_Include_Response_Body_In_Non_Verbose_Mode()
+    {
+        // Arrange
+        const string genericErrorMessage = "An unexpected error happened. Please see the logs for details.";
+        const string responseBody = "{\"errors\":[{\"message\":\"Could not start migration job\"}]}";
+        var httpException = new HttpRequestException("Response status code does not indicate success: 503 (Service Unavailable).", null, HttpStatusCode.ServiceUnavailable);
+        httpException.Data["ResponseBody"] = responseBody;
+
+        // Act
+        _octoLogger.LogError(httpException);
+
+        // Assert
+        _consoleOutput.Should().BeNull();
+
+        _consoleError.Should().Contain(genericErrorMessage);
+        _consoleError.Should().Contain($"Response: {responseBody}");
+
+        _logOutput.Should().Contain(genericErrorMessage);
+        _logOutput.Should().Contain($"Response: {responseBody}");
+
+        _verboseLogOutput.Should().Contain(responseBody);
+    }
+
+    [Fact]
     public void LogInformation_Should_Write_To_Console_Out()
     {
         // Act


### PR DESCRIPTION
This pull request improves the logging and troubleshooting experience for Bitbucket Server (BBS) API failures by ensuring that the response body from 5xx errors is included in both the exception data and standard log output. This makes it easier to diagnose issues without needing to enable verbose logs. The changes also include comprehensive tests to verify this new behavior.

Closes https://github.com/github/gh-gei/issues/1556

<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->