### PR TITLE
Add ADO team project option to inventory report command

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,0 +1,1 @@
+- **ado2gh**: Add ADO team project filter option to inventory report command

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,2 +1,2 @@
 - Added new `gl2gh` CLI (not yet generally available) for migrating GitLab repositories (GitLab.com and self-hosted) to GitHub. Includes `migrate-repo`, `generate-script`, and `inventory-report` along with the standard supporting commands (e.g. `download-logs`, `wait-for-migration`, `abort-migration`, `grant-migrator-role`, `revoke-migrator-role`, `create-team`, `generate-mannequin-csv`, `reclaim-mannequin`). Archives can be uploaded via Azure Blob Storage, AWS S3, or GitHub-owned storage.
-- **ado2gh**: Add ADO team project filter option to inventory report command
+- **ado2gh**: Add `--ado-team-project` filter option to inventory report command.

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReport/InventoryReportCommandArgsTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReport/InventoryReportCommandArgsTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Moq;
+using OctoshiftCLI.AdoToGithub.Commands.InventoryReport;
+using OctoshiftCLI.Services;
+using Xunit;
+
+namespace OctoshiftCLI.Tests.AdoToGithub.Commands.InventoryReport;
+
+public class InventoryReportCommandArgsTests
+{
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+
+    private const string ADO_ORG = "ado-org";
+    private const string ADO_TEAM_PROJECT = "ado-project";
+
+    [Fact]
+    public void Validate_Throws_When_AdoTeamProject_Is_Specified_Without_AdoOrg()
+    {
+        var args = new InventoryReportCommandArgs
+        {
+            AdoTeamProject = ADO_TEAM_PROJECT
+        };
+
+        FluentActions.Invoking(() => args.Validate(_mockOctoLogger.Object))
+            .Should()
+            .ThrowExactly<OctoshiftCliException>()
+            .WithMessage("The --ado-team-project option requires the --ado-org option to also be provided.");
+    }
+
+    [Fact]
+    public void Validate_Succeeds_With_Valid_Names()
+    {
+        var args = new InventoryReportCommandArgs
+        {
+            AdoOrg = ADO_ORG,
+            AdoTeamProject = ADO_TEAM_PROJECT,
+        };
+
+        args.Validate(_mockOctoLogger.Object);
+
+        args.AdoOrg.Should().Be(ADO_ORG);
+        args.AdoTeamProject.Should().Be(ADO_TEAM_PROJECT);
+    }
+}

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReport/InventoryReportCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReport/InventoryReportCommandHandlerTests.cs
@@ -11,6 +11,7 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands.InventoryReport;
 public class InventoryReportCommandHandlerTests
 {
     private const string ADO_ORG = "foo-org";
+    private const string ADO_TEAM_PROJECT = "foo-team-project";
     private readonly Mock<AdoInspectorService> _mockAdoInspectorService = TestHelpers.CreateMock<AdoInspectorService>();
     private readonly Mock<OrgsCsvGeneratorService> _mockOrgsCsvGenerator = TestHelpers.CreateMock<OrgsCsvGeneratorService>();
     private readonly Mock<TeamProjectsCsvGeneratorService> _mockTeamProjectsCsvGenerator = TestHelpers.CreateMock<TeamProjectsCsvGeneratorService>();
@@ -108,6 +109,36 @@ public class InventoryReportCommandHandlerTests
         _pipelinesCsvOutput.Should().Be(expectedPipelinesCsv);
 
         _mockAdoInspectorService.Object.OrgFilter.Should().Be(ADO_ORG);
+        _mockAdoInspectorService.Object.TeamProjectFilter.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Scoped_To_Single_Org_And_Single_Team_Project()
+    {
+        var expectedOrgsCsv = "csv stuff";
+        var expectedTeamProjectsCsv = "more csv stuff";
+        var expectedReposCsv = "repo csv stuff";
+        var expectedPipelinesCsv = "pipelines csv stuff";
+
+        _mockOrgsCsvGenerator.Setup(m => m.Generate(null, false)).ReturnsAsync(expectedOrgsCsv);
+        _mockTeamProjectsCsvGenerator.Setup(m => m.Generate(null, false)).ReturnsAsync(expectedTeamProjectsCsv);
+        _mockReposCsvGenerator.Setup(m => m.Generate(null, false)).ReturnsAsync(expectedReposCsv);
+        _mockPipelinesCsvGenerator.Setup(m => m.Generate(null)).ReturnsAsync(expectedPipelinesCsv);
+
+        var args = new InventoryReportCommandArgs
+        {
+            AdoOrg = ADO_ORG,
+            AdoTeamProject = ADO_TEAM_PROJECT,
+        };
+        await _handler.Handle(args);
+
+        _orgsCsvOutput.Should().Be(expectedOrgsCsv);
+        _teamProjectsCsvOutput.Should().Be(expectedTeamProjectsCsv);
+        _reposCsvOutput.Should().Be(expectedReposCsv);
+        _pipelinesCsvOutput.Should().Be(expectedPipelinesCsv);
+
+        _mockAdoInspectorService.Object.OrgFilter.Should().Be(ADO_ORG);
+        _mockAdoInspectorService.Object.TeamProjectFilter.Should().Be(ADO_TEAM_PROJECT);
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReport/InventoryReportCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/InventoryReport/InventoryReportCommandTests.cs
@@ -41,9 +41,10 @@ namespace OctoshiftCLI.Tests.AdoToGithub.Commands.InventoryReport
         {
             Assert.NotNull(_command);
             Assert.Equal("inventory-report", _command.Name);
-            Assert.Equal(4, _command.Options.Count);
+            Assert.Equal(5, _command.Options.Count);
 
             TestHelpers.VerifyCommandOption(_command.Options, "ado-org", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "ado-team-project", false);
             TestHelpers.VerifyCommandOption(_command.Options, "ado-pat", false);
             TestHelpers.VerifyCommandOption(_command.Options, "minimal", false);
             TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);

--- a/src/ado2gh/Commands/InventoryReport/InventoryReportCommand.cs
+++ b/src/ado2gh/Commands/InventoryReport/InventoryReportCommand.cs
@@ -16,6 +16,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands.InventoryReport
                              "Note: Expects ADO_PAT env variable or --ado-pat option to be set.")
         {
             AddOption(AdoOrg);
+            AddOption(AdoTeamProject);
             AddOption(AdoPat);
             AddOption(Minimal);
             AddOption(Verbose);
@@ -24,6 +25,10 @@ namespace OctoshiftCLI.AdoToGithub.Commands.InventoryReport
         public Option<string> AdoOrg { get; } = new("--ado-org")
         {
             Description = "If not provided will iterate over all orgs that ADO_PAT has access to."
+        };
+        public Option<string> AdoTeamProject { get; } = new("--ado-team-project")
+        {
+            Description = "If provided, will only generate CSV files for the specified team project. Requires --ado-org to also be provided."
         };
         public Option<string> AdoPat { get; } = new("--ado-pat");
         public Option<bool> Minimal { get; } = new("--minimal")

--- a/src/ado2gh/Commands/InventoryReport/InventoryReportCommandArgs.cs
+++ b/src/ado2gh/Commands/InventoryReport/InventoryReportCommandArgs.cs
@@ -5,6 +5,7 @@ namespace OctoshiftCLI.AdoToGithub.Commands.InventoryReport
     public class InventoryReportCommandArgs : CommandArgs
     {
         public string AdoOrg { get; set; }
+        public string AdoTeamProject { get; set; }
         [Secret]
         public string AdoPat { get; set; }
         public bool Minimal { get; set; }

--- a/src/ado2gh/Commands/InventoryReport/InventoryReportCommandArgs.cs
+++ b/src/ado2gh/Commands/InventoryReport/InventoryReportCommandArgs.cs
@@ -1,4 +1,5 @@
 ﻿using OctoshiftCLI.Commands;
+using OctoshiftCLI.Services;
 
 namespace OctoshiftCLI.AdoToGithub.Commands.InventoryReport
 {
@@ -9,5 +10,13 @@ namespace OctoshiftCLI.AdoToGithub.Commands.InventoryReport
         [Secret]
         public string AdoPat { get; set; }
         public bool Minimal { get; set; }
+
+        public override void Validate(OctoLogger log)
+        {
+            if (string.IsNullOrEmpty(AdoOrg) && !string.IsNullOrEmpty(AdoTeamProject))
+            {
+                throw new OctoshiftCliException("The --ado-team-project option requires the --ado-org option to also be provided.");
+            }
+        }
     }
 }

--- a/src/ado2gh/Commands/InventoryReport/InventoryReportCommandHandler.cs
+++ b/src/ado2gh/Commands/InventoryReport/InventoryReportCommandHandler.cs
@@ -44,6 +44,7 @@ public class InventoryReportCommandHandler : ICommandHandler<InventoryReportComm
         _log.LogInformation("Creating inventory report...");
 
         _adoInspectorService.OrgFilter = args.AdoOrg;
+        _adoInspectorService.TeamProjectFilter = args.AdoTeamProject;
 
         _log.LogInformation("Finding Orgs...");
         var orgs = await _adoInspectorService.GetOrgs();


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->

Resolves issue: #1545 - New Feature : Add Team Project Filtering to Inventory Report Command