### PR TITLE
Fix rewire-pipeline command to include target API URL and add unit test for sequential script rewire

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,0 +1,1 @@
+- Fixed a bug where `ado2gh generate-script` did not pass `--target-api-url` to the generated `rewire-pipeline` commands. When migrating to GitHub Enterprise Cloud with data residency (ghe.com), rewired Azure Pipelines were incorrectly pointed at github.com URLs instead of the data residency domain.

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
@@ -1365,6 +1365,38 @@ if ($Failed -ne 0) {
     }
 
     [Fact]
+    public async Task ParallelScript_Rewire_Pipeline_With_TargetApiUrl_Includes_TargetApiUrl()
+    {
+        // Arrange
+        var targetApiUrl = "https://api.tenant.ghe.com";
+
+        _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+        _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, new[] { ADO_TEAM_PROJECT })).ReturnsAsync(APP_ID);
+
+        _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+        _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+        _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+        _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+        _mockAdoInspector.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(ADO_PIPELINES);
+
+        var expectedRewireWithUrl = $"{{ gh ado2gh rewire-pipeline --target-api-url \"{targetApiUrl}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}";
+
+        // Act
+        var args = new GenerateScriptCommandArgs
+        {
+            GithubOrg = GITHUB_ORG,
+            AdoOrg = ADO_ORG,
+            Output = new FileInfo("unit-test-output"),
+            RewirePipelines = true,
+            TargetApiUrl = targetApiUrl
+        };
+        await _handler.Handle(args);
+
+        // Assert
+        _scriptOutput.Should().Contain(expectedRewireWithUrl);
+    }
+
+    [Fact]
     public async Task SequentialScript_CreateTeams_With_TargetApiUrl_Should_Include_TargetApiUrl_In_AddTeamToRepo_Commands()
     {
         // Arrange

--- a/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
+++ b/src/OctoshiftCLI.Tests/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandlerTests.cs
@@ -365,6 +365,39 @@ public class GenerateScriptCommandHandlerTests
     }
 
     [Fact]
+    public async Task SequentialScript_Rewire_Pipeline_With_TargetApiUrl_Includes_TargetApiUrl()
+    {
+        // Arrange
+        var targetApiUrl = "https://api.tenant.ghe.com";
+
+        _mockAdoApi.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+        _mockAdoApi.Setup(m => m.GetGithubAppId(ADO_ORG, GITHUB_ORG, ADO_TEAM_PROJECTS)).ReturnsAsync(APP_ID);
+
+        _mockAdoInspector.Setup(m => m.GetRepoCount()).ReturnsAsync(1);
+        _mockAdoInspector.Setup(m => m.GetOrgs()).ReturnsAsync(ADO_ORGS);
+        _mockAdoInspector.Setup(m => m.GetTeamProjects(ADO_ORG)).ReturnsAsync(ADO_TEAM_PROJECTS);
+        _mockAdoInspector.Setup(m => m.GetRepos(ADO_ORG, ADO_TEAM_PROJECT)).ReturnsAsync(ADO_REPOS);
+        _mockAdoInspector.Setup(m => m.GetPipelines(ADO_ORG, ADO_TEAM_PROJECT, FOO_REPO)).ReturnsAsync(ADO_PIPELINES);
+
+        var expectedRewire = $"Exec {{ gh ado2gh rewire-pipeline --target-api-url \"{targetApiUrl}\" --ado-org \"{ADO_ORG}\" --ado-team-project \"{ADO_TEAM_PROJECT}\" --ado-pipeline \"{FOO_PIPELINE}\" --github-org \"{GITHUB_ORG}\" --github-repo \"{ADO_TEAM_PROJECT}-{FOO_REPO}\" --service-connection-id \"{APP_ID}\" }}";
+
+        // Act
+        var args = new GenerateScriptCommandArgs
+        {
+            GithubOrg = GITHUB_ORG,
+            AdoOrg = ADO_ORG,
+            Sequential = true,
+            Output = new FileInfo("unit-test-output"),
+            RewirePipelines = true,
+            TargetApiUrl = targetApiUrl
+        };
+        await _handler.Handle(args);
+
+        // Assert
+        _scriptOutput.Should().Contain(expectedRewire);
+    }
+
+    [Fact]
     public async Task SequentialScript_Single_Repo_Two_Pipelines_No_Service_Connection_All_Options()
     {
         // Arrange

--- a/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
+++ b/src/ado2gh/Commands/GenerateScript/GenerateScriptCommandHandler.cs
@@ -172,7 +172,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
 
                     foreach (var adoPipeline in await _adoInspectorService.GetPipelines(adoOrg, adoTeamProject, adoRepo.Name))
                     {
-                        AppendLine(content, Exec(RewireAzurePipelineScript(adoOrg, adoTeamProject, adoPipeline, githubOrg, githubRepo, appId)));
+                        AppendLine(content, Exec(RewireAzurePipelineScript(adoOrg, adoTeamProject, adoPipeline, githubOrg, githubRepo, appId, targetApiUrl)));
                     }
                 }
             }
@@ -282,7 +282,7 @@ public class GenerateScriptCommandHandler : ICommandHandler<GenerateScriptComman
                         appIds.TryGetValue(adoOrg, out var appId);
                         foreach (var adoPipeline in await _adoInspectorService.GetPipelines(adoOrg, adoTeamProject, adoRepo.Name))
                         {
-                            AppendLine(content, "        " + Wrap(RewireAzurePipelineScript(adoOrg, adoTeamProject, adoPipeline, githubOrg, githubRepo, appId)));
+                            AppendLine(content, "        " + Wrap(RewireAzurePipelineScript(adoOrg, adoTeamProject, adoPipeline, githubOrg, githubRepo, appId, targetApiUrl)));
                         }
 
                         AppendLine(content, "    )");
@@ -370,9 +370,9 @@ if ($Failed -ne 0) {
             ? $"gh ado2gh add-team-to-repo{(targetApiUrl.HasValue() ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --github-org \"{githubOrg}\" --github-repo \"{githubRepo}\" --team \"{adoTeamProject.ReplaceInvalidCharactersWithDash()}-Admins\" --role \"admin\"{(_log.Verbose ? " --verbose" : string.Empty)}"
             : null;
 
-    private string RewireAzurePipelineScript(string adoOrg, string adoTeamProject, string adoPipeline, string githubOrg, string githubRepo, string appId) =>
+    private string RewireAzurePipelineScript(string adoOrg, string adoTeamProject, string adoPipeline, string githubOrg, string githubRepo, string appId, string targetApiUrl) =>
         _generateScriptOptions.RewirePipelines && appId.HasValue()
-            ? $"gh ado2gh rewire-pipeline --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-pipeline \"{adoPipeline}\" --github-org \"{githubOrg}\" --github-repo \"{githubRepo}\" --service-connection-id \"{appId}\"{(_log.Verbose ? " --verbose" : string.Empty)}"
+            ? $"gh ado2gh rewire-pipeline{(targetApiUrl.HasValue() ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --ado-org \"{adoOrg}\" --ado-team-project \"{adoTeamProject}\" --ado-pipeline \"{adoPipeline}\" --github-org \"{githubOrg}\" --github-repo \"{githubRepo}\" --service-connection-id \"{appId}\"{(_log.Verbose ? " --verbose" : string.Empty)}"
             : null;
 
     private string WaitForMigrationScript(string repoMigrationKey, string targetApiUrl) => $"gh ado2gh wait-for-migration{(targetApiUrl.HasValue() ? $" --target-api-url \"{targetApiUrl}\"" : string.Empty)} --migration-id $RepoMigrations[\"{repoMigrationKey}\"]";


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [x] Did you write/update appropriate tests
- [x] Release notes updated (if appropriate)
- [x] Appropriate logging output
- [x] Issue linked
- [x] Docs updated (or issue created)
- [x] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->

This pull request addresses an important bug in the Azure DevOps to GitHub migration tooling, ensuring that the `--target-api-url` parameter is properly passed to generated `rewire-pipeline` commands. This is especially critical for migrations to GitHub Enterprise Cloud instances with data residency requirements. The changes also include updates to the test suite to validate this behavior.

**Bug fix and feature correctness:**

* Fixed a bug where `ado2gh generate-script` did not pass `--target-api-url` to generated `rewire-pipeline` commands, preventing incorrect pipeline rewiring when migrating to GitHub Enterprise Cloud with data residency.

**Implementation updates:**

* Updated the `RewireAzurePipelineScript` method in `GenerateScriptCommandHandler.cs` to include the `targetApiUrl` parameter, ensuring the generated script contains the correct API URL for rewired pipelines.
* Modified both sequential and parallel script generation paths to pass `targetApiUrl` to the `RewireAzurePipelineScript` method, ensuring consistency for all migration modes. [[1]](diffhunk://#diff-0c259697d58a17114450ade240223c61a46c4afd989119fc74f343f1e10c78eaL175-R175) [[2]](diffhunk://#diff-0c259697d58a17114450ade240223c61a46c4afd989119fc74f343f1e10c78eaL285-R285)

**Testing improvements:**

* Added a new test case `SequentialScript_Rewire_Pipeline_With_TargetApiUrl_Includes_TargetApiUrl` in `GenerateScriptCommandHandlerTests.cs` to verify that the generated script includes the `--target-api-url` parameter for rewired pipelines.

Fixes: #1590 