### PR TITLE
Show --target-uploads-url and --use-github-storage in --help

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- The `--target-uploads-url` and `--use-github-storage` options are now visible in `--help` output for the `migrate-repo`, `migrate-org`, and `generate-script` commands (where applicable) in the gei, bbs2gh, and gl2gh extensions.

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScript/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScript/GenerateScriptCommandTests.cs
@@ -58,7 +58,7 @@ public class GenerateScriptCommandTests
         TestHelpers.VerifyCommandOption(_command.Options, "keep-archive", false);
         TestHelpers.VerifyCommandOption(_command.Options, "no-ssl-verify", false);
         TestHelpers.VerifyCommandOption(_command.Options, "target-api-url", false);
-        TestHelpers.VerifyCommandOption(_command.Options, "use-github-storage", false, true);
+        TestHelpers.VerifyCommandOption(_command.Options, "use-github-storage", false);
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScript/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/GenerateScript/GenerateScriptCommandTests.cs
@@ -36,7 +36,7 @@ public class GenerateScriptCommandTests
     {
         _command.Should().NotBeNull();
         _command.Name.Should().Be("generate-script");
-        _command.Options.Count.Should().Be(21);
+        _command.Options.Count.Should().Be(22);
 
         TestHelpers.VerifyCommandOption(_command.Options, "bbs-server-url", true);
         TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
@@ -58,6 +58,7 @@ public class GenerateScriptCommandTests
         TestHelpers.VerifyCommandOption(_command.Options, "keep-archive", false);
         TestHelpers.VerifyCommandOption(_command.Options, "no-ssl-verify", false);
         TestHelpers.VerifyCommandOption(_command.Options, "target-api-url", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "target-uploads-url", false);
         TestHelpers.VerifyCommandOption(_command.Options, "use-github-storage", false);
     }
 

--- a/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/bbs2gh/Commands/MigrateRepo/MigrateRepoCommandTests.cs
@@ -90,8 +90,8 @@ public class MigrateRepoCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "keep-archive", false);
         TestHelpers.VerifyCommandOption(command.Options, "no-ssl-verify", false);
         TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
-        TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false, true);
-        TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false, true);
+        TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false);
+        TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false);
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScript/GenerateScriptCommandTests.cs
@@ -56,8 +56,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.GenerateScript
             TestHelpers.VerifyCommandOption(command.Options, "aws-region", false);
             TestHelpers.VerifyCommandOption(command.Options, "keep-archive", false);
             TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
-            TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false, true);
-            TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false, true);
+            TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false);
+            TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateOrg/MigrateOrgCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateOrg/MigrateOrgCommandTests.cs
@@ -46,7 +46,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateOrg
             TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
             TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
-            TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false, true);
+            TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepo/MigrateRepoCommandTests.cs
@@ -20,7 +20,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             TestHelpers.VerifyCommandOption(command.Options, "github-target-org", true);
             TestHelpers.VerifyCommandOption(command.Options, "target-repo", false);
             TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
-            TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false, true);
+            TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false);
             TestHelpers.VerifyCommandOption(command.Options, "ghes-api-url", false);
             TestHelpers.VerifyCommandOption(command.Options, "azure-storage-connection-string", false);
             TestHelpers.VerifyCommandOption(command.Options, "aws-bucket-name", false);
@@ -40,7 +40,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands.MigrateRepo
             TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
             TestHelpers.VerifyCommandOption(command.Options, "keep-archive", false);
-            TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false, true);
+            TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false);
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/gl2gh/Commands/GenerateScript/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gl2gh/Commands/GenerateScript/GenerateScriptCommandTests.cs
@@ -42,7 +42,7 @@ public class GenerateScriptCommandTests
         TestHelpers.VerifyCommandOption(_command.Options, "gitlab-server-url", true);
         TestHelpers.VerifyCommandOption(_command.Options, "github-org", true);
         TestHelpers.VerifyCommandOption(_command.Options, "target-api-url", false);
-        TestHelpers.VerifyCommandOption(_command.Options, "target-uploads-url", false, true);
+        TestHelpers.VerifyCommandOption(_command.Options, "target-uploads-url", false);
         TestHelpers.VerifyCommandOption(_command.Options, "gitlab-pat", false);
         TestHelpers.VerifyCommandOption(_command.Options, "gitlab-group", false);
         TestHelpers.VerifyCommandOption(_command.Options, "gitlab-project", false);
@@ -52,7 +52,7 @@ public class GenerateScriptCommandTests
         TestHelpers.VerifyCommandOption(_command.Options, "aws-region", false);
         TestHelpers.VerifyCommandOption(_command.Options, "keep-archive", false);
         TestHelpers.VerifyCommandOption(_command.Options, "no-ssl-verify", false);
-        TestHelpers.VerifyCommandOption(_command.Options, "use-github-storage", false, true);
+        TestHelpers.VerifyCommandOption(_command.Options, "use-github-storage", false);
     }
 
     [Fact]

--- a/src/OctoshiftCLI.Tests/gl2gh/Commands/MigrateRepo/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gl2gh/Commands/MigrateRepo/MigrateRepoCommandTests.cs
@@ -76,8 +76,8 @@ public class MigrateRepoCommandTests
         TestHelpers.VerifyCommandOption(command.Options, "keep-archive", false);
         TestHelpers.VerifyCommandOption(command.Options, "no-ssl-verify", false);
         TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
-        TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false, true);
-        TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false, true);
+        TestHelpers.VerifyCommandOption(command.Options, "target-uploads-url", false);
+        TestHelpers.VerifyCommandOption(command.Options, "use-github-storage", false);
     }
 
     [Fact]

--- a/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommand.cs
@@ -127,7 +127,6 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
 
     public Option<bool> UseGithubStorage { get; } = new("--use-github-storage")
     {
-        IsHidden = true,
         Description = "Enables multipart uploads to a GitHub owned storage for use during migration. " +
                       "Configure chunk size with the GITHUB_OWNED_STORAGE_MULTIPART_MEBIBYTES environment variable (default: 100 MiB, minimum: 5 MiB).",
     };

--- a/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommand.cs
+++ b/src/bbs2gh/Commands/GenerateScript/GenerateScriptCommand.cs
@@ -18,6 +18,7 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
         AddOption(BbsServerUrl);
         AddOption(GithubOrg);
         AddOption(TargetApiUrl);
+        AddOption(TargetUploadsUrl);
         AddOption(BbsUsername);
         AddOption(BbsPassword);
         AddOption(BbsProject);
@@ -124,6 +125,10 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
     {
         Description = "The URL of the target API, if not migrating to github.com. Defaults to https://api.github.com"
     };
+
+    public Option<string> TargetUploadsUrl { get; } = new(
+        name: "--target-uploads-url",
+        description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com");
 
     public Option<bool> UseGithubStorage { get; } = new("--use-github-storage")
     {

--- a/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -193,8 +193,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
     };
     public Option<string> TargetUploadsUrl { get; } = new(
         name: "--target-uploads-url",
-        description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com")
-    { IsHidden = true };
+        description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com");
     public Option<bool> NoSslVerify { get; } = new(
         name: "--no-ssl-verify",
         description: "Disables SSL verification when communicating with your Bitbucket Server/Data Center instance. All other migration steps will continue to verify SSL. " +
@@ -202,8 +201,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
     public Option<bool> UseGithubStorage { get; } = new(
         name: "--use-github-storage",
         description: "Enables multipart uploads to a GitHub owned storage for use during migration. " +
-                     "Configure chunk size with the GITHUB_OWNED_STORAGE_MULTIPART_MEBIBYTES environment variable (default: 100 MiB, minimum: 5 MiB).")
-    { IsHidden = true };
+                     "Configure chunk size with the GITHUB_OWNED_STORAGE_MULTIPART_MEBIBYTES environment variable (default: 100 MiB, minimum: 5 MiB).");
 
     public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, IServiceProvider sp)
     {

--- a/src/gei/Commands/GenerateScript/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScript/GenerateScriptCommand.cs
@@ -103,11 +103,9 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.GenerateScript
         };
         public Option<string> TargetUploadsUrl { get; } = new(
             name: "--target-uploads-url",
-            description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com")
-        { IsHidden = true };
+            description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com");
         public Option<bool> UseGithubStorage { get; } = new("--use-github-storage")
         {
-            IsHidden = true,
             Description = "Enables multipart uploads to a GitHub owned storage for use during migration. " +
                           "Configure chunk size with the GITHUB_OWNED_STORAGE_MULTIPART_MEBIBYTES environment variable (default: 100 MiB, minimum: 5 MiB).",
         };

--- a/src/gei/Commands/MigrateOrg/MigrateOrgCommand.cs
+++ b/src/gei/Commands/MigrateOrg/MigrateOrgCommand.cs
@@ -48,8 +48,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateOrg
         };
         public Option<string> TargetUploadsUrl { get; } = new(
             name: "--target-uploads-url",
-            description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com")
-        { IsHidden = true };
+            description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com");
         public Option<bool> QueueOnly { get; } = new("--queue-only")
         {
             Description = "Only queues the migration, does not wait for it to finish. Use the wait-for-migration command to subsequently wait for it to finish and view the status."

--- a/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -69,8 +69,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
         };
         public Option<string> TargetUploadsUrl { get; } = new(
             name: "--target-uploads-url",
-            description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com")
-        { IsHidden = true };
+            description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com");
 
         // GHES migration path
         public Option<string> GhesApiUrl { get; } = new("--ghes-api-url")
@@ -108,7 +107,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands.MigrateRepo
         };
         public Option<bool> UseGithubStorage { get; } = new("--use-github-storage")
         {
-            IsHidden = true,
             Description = "Enables multipart uploads to a GitHub owned storage for use during migration. " +
                           "Configure chunk size with the GITHUB_OWNED_STORAGE_MULTIPART_MEBIBYTES environment variable (default: 100 MiB, minimum: 5 MiB).",
         };

--- a/src/gl2gh/Commands/GenerateScript/GenerateScriptCommand.cs
+++ b/src/gl2gh/Commands/GenerateScript/GenerateScriptCommand.cs
@@ -79,8 +79,7 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
 
     public Option<string> TargetUploadsUrl { get; } = new(
         name: "--target-uploads-url",
-        description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com")
-    { IsHidden = true };
+        description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com");
 
     public Option<bool> NoSslVerify { get; } = new(
         name: "--no-ssl-verify",
@@ -89,7 +88,6 @@ public class GenerateScriptCommand : CommandBase<GenerateScriptCommandArgs, Gene
 
     public Option<bool> UseGithubStorage { get; } = new("--use-github-storage")
     {
-        IsHidden = true,
         Description = "Enables multipart uploads to a GitHub owned storage for use during migration. " +
                       "Configure chunk size with the GITHUB_OWNED_STORAGE_MULTIPART_MEBIBYTES environment variable (default: 100 MiB, minimum: 5 MiB).",
     };

--- a/src/gl2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
+++ b/src/gl2gh/Commands/MigrateRepo/MigrateRepoCommand.cs
@@ -120,8 +120,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
     };
     public Option<string> TargetUploadsUrl { get; } = new(
         name: "--target-uploads-url",
-        description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com")
-    { IsHidden = true };
+        description: "The URL of the target uploads API, if not migrating to github.com. Defaults to https://uploads.github.com");
     public Option<bool> NoSslVerify { get; } = new(
         name: "--no-ssl-verify",
         description: "Disables SSL verification when communicating with your GitLab instance. All other migration steps will continue to verify SSL. " +
@@ -129,8 +128,7 @@ public class MigrateRepoCommand : CommandBase<MigrateRepoCommandArgs, MigrateRep
     public Option<bool> UseGithubStorage { get; } = new(
         name: "--use-github-storage",
         description: "Enables multipart uploads to a GitHub owned storage for use during migration. " +
-                     "Configure chunk size with the GITHUB_OWNED_STORAGE_MULTIPART_MEBIBYTES environment variable (default: 100 MiB, minimum: 5 MiB).")
-    { IsHidden = true };
+                     "Configure chunk size with the GITHUB_OWNED_STORAGE_MULTIPART_MEBIBYTES environment variable (default: 100 MiB, minimum: 5 MiB).");
 
     public override MigrateRepoCommandHandler BuildHandler(MigrateRepoCommandArgs args, IServiceProvider sp)
     {


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

## Summary

Unhides the `--target-uploads-url` and `--use-github-storage` options in `--help` output for the `migrate-repo`, `migrate-org`, and `generate-script` commands (where applicable) across the `gei`, `bbs2gh`, and `gl2gh` extensions.

Closes #1517. Supersedes #1518 (thanks @akordowski for the original attempt).

## Motivation

Customers using non-github.com targets or GitHub-owned storage need to discover these options without reading source code. They've been hidden by default, which caused repeated confusion in support conversations.

## Changes

Removed `IsHidden = true` from the option definitions in:

- `src/gei/Commands/MigrateRepo/MigrateRepoCommand.cs`
- `src/gei/Commands/MigrateOrg/MigrateOrgCommand.cs`
- `src/gei/Commands/GenerateScript/GenerateScriptCommand.cs`
- `src/bbs2gh/Commands/MigrateRepo/MigrateRepoCommand.cs`
- `src/bbs2gh/Commands/GenerateScript/GenerateScriptCommand.cs`
- `src/gl2gh/Commands/MigrateRepo/MigrateRepoCommand.cs`
- `src/gl2gh/Commands/GenerateScript/GenerateScriptCommand.cs`

Updated the corresponding `VerifyCommandOption` assertions to expect the options to be visible.

Added a release note bullet to `RELEASENOTES.md`.

`ado2gh` is unaffected since it is a non archive path.



## Verification

- `dotnet format src/OctoshiftCLI.sln` — clean
- `dotnet build src/OctoshiftCLI.sln /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- `dotnet test src/OctoshiftCLI.Tests/OctoshiftCLI.Tests.csproj` — 1113 passed, 0 failed


- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->