### PR TITLE
Mark `gl2gh` GA (in anticipation of GA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 
 The [GitHub Enterprise Importer](https://docs.github.com/en/migrations/using-github-enterprise-importer) (GEI, formerly Octoshift) is a highly customizable API-first migration offering designed to help you move your enterprise to GitHub Enterprise Cloud. The GEI-CLI wraps the GEI APIs as a cross-platform console application to simplify customizing your migration experience.
 
-> GEI is generally available for repository migrations originating from Azure DevOps or GitHub that target GitHub Enterprise Cloud. It is in public beta for repository migrations from BitBucket Server and Data Center to GitHub Enterprise Cloud.
+> GEI is generally available for repository migrations originating from Azure DevOps, GitHub, or GitLab that target GitHub Enterprise Cloud. It is in public beta for repository migrations from BitBucket Server and Data Center to GitHub Enterprise Cloud.
 
 ## Using the GEI CLI
 There are 4 separate CLIs that we ship as extensions for the official [GitHub CLI](https://github.com/cli/cli#installation):
 - `gh gei` - Run migrations between GitHub products
 - `gh ado2gh` - Run migrations from Azure DevOps to GitHub
 - `gh bbs2gh` - Run migrations from BitBucket Server or Data Center to GitHub
-- `gh gl2gh` - Run migrations from GitLab to GitHub _(not yet generally available)_
+- `gh gl2gh` - Run migrations from GitLab to GitHub
 
 To use `gh gei` first install the latest [GitHub CLI](https://github.com/cli/cli#installation), then run the command
 >`gh extension install github/gh-gei`
@@ -25,8 +25,6 @@ To use `gh bbs2gh` first install the latest [GitHub CLI](https://github.com/cli/
 
 To use `gh gl2gh` first install the latest [GitHub CLI](https://github.com/cli/cli#installation), then run the command
 >`gh extension install github/gh-gl2gh`
-
-> **Note:** `gh gl2gh` is not yet generally available. The extension repo and releases may not be published yet.
 
 We update the extensions frequently, so make sure you update them on a regular basis:
 >`gh extension upgrade github/gh-gei`

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+- The `gl2gh` extension is now generally available for repository migrations from GitLab (GitLab.com and self-hosted) to GitHub Enterprise Cloud or GitHub Enterprise Cloud with data residency.


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->



---



The `gl2gh` extension will GA soon. In anticipation, this PR removes the "not yet generally available" language from the README and adds the GA announcement to the release notes. Once we do GA will create a release to actually publish this. 

## Changes

- **README.md**
  - Updated the top-level GEI availability summary to include GitLab alongside Azure DevOps and GitHub as GA to GitHub Enterprise Cloud.
  - Removed the `_(not yet generally available)_` qualifier from the `gh gl2gh` bullet under "Using the GEI CLI".
  - Removed the standalone `> **Note:** gh gl2gh is not yet generally available...` blockquote under the install instructions.
- **RELEASENOTES.md**
  - Added a bullet announcing GitLab (GitLab.com and self-hosted) → GitHub Enterprise Cloud / GitHub Enterprise Cloud with data residency GA.

## Not changed
- Historical release notes under `releasenotes/` (v1.30.0, v1.30.1) still describe the extension as "not yet generally available" — leaving them as point-in-time records.
- No runtime code or CLI help text changes were needed; there were no preview/beta warnings emitted from `src/gl2gh/`.

## Follow-up
- Cut the tag and publish the release when ready.


- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)
- [ ] New package licenses are added to `ThirdPartyNotices.txt` (if applicable)

<!--
For docs we should review the docs at:
https://docs.github.com/en/migrations/using-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.
-->